### PR TITLE
Fixed selecting multiple include types for Catalog Entry

### DIFF
--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Code/QSDirectoryParser.m
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Code/QSDirectoryParser.m
@@ -86,12 +86,17 @@
 		if (aliasFile || (![enumerator isInvisible] && ![[file lastPathComponent] hasPrefix:@"."] && ![file isEqualToString:@"/mach.sym"]) ) {
             type = [manager UTIOfFile:file];
 			// if we are an alias or the file has no reason to be included
-			BOOL include = YES;
-            for (NSString *requiredType in types) {
-                if (!UTTypeConformsTo((CFStringRef)type, (CFStringRef)requiredType)) {
-                    include = NO;
-                }
-            }
+			BOOL include = NO;
+			if (![types count]) {
+				include = YES;
+			} else {
+				for(NSString * requiredType in types) {
+					if (UTTypeConformsTo((CFStringRef)type, (CFStringRef)requiredType)) {
+						include = YES;
+						break;
+					}
+				}
+			}
             for (NSString *excludedType in excludedTypes) {
                 if (UTTypeConformsTo((CFStringRef)type, (CFStringRef)excludedType)) {
                     include = NO;


### PR DESCRIPTION
Multiple include types for Catalog Entry had been working before "Exclude Filetypes" was implemented, but then broken. Because it checked each of the include types and excluded the file if it did not conform. If there was multiple include types, the file definitely could not conform all the types so that it would always be excluded. Now it can be fixed from my fork.
