### PR TITLE
this adds the Most Recent Download proxy object

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSDownloads.h
+++ b/Quicksilver/Code-QuickStepCore/QSDownloads.h
@@ -1,0 +1,13 @@
+//
+//  QSDownloads.h
+//  Quicksilver
+//
+//  Created by Rob McBroom on 4/8/11.
+//
+
+#import "QSObject.h"
+
+@interface QSDownloads : NSObject {
+}
+- (id)resolveProxyObject:(id)proxy;
+@end

--- a/Quicksilver/Code-QuickStepCore/QSDownloads.m
+++ b/Quicksilver/Code-QuickStepCore/QSDownloads.m
@@ -1,0 +1,30 @@
+//
+//  QSDownloads.m
+//  Quicksilver
+//
+//  Created by Rob McBroom on 4/8/11.
+//
+
+#import "QSDownloads.h"
+
+@implementation QSDownloads
+- (id)resolveProxyObject:(id)proxy {
+    NSString *downloads = [@"~/Downloads" stringByStandardizingPath];
+    NSFileManager *manager = [NSFileManager defaultManager];
+    NSArray *contents = [manager contentsOfDirectoryAtPath:downloads error:nil];
+    NSString *mrdpath;
+    NSDate *mostRecent = [NSDate distantPast];
+    for (NSString *downloadedFile in contents) {
+        if ([downloadedFile isEqualToString:@".DS_Store"]) continue;
+        if ([downloadedFile isEqualToString:@".localized"]) continue;
+        NSString *downloadPath = [downloads stringByAppendingPathComponent:downloadedFile];
+        NSDate *modified = [[manager attributesOfItemAtPath:downloadPath error:nil] fileModificationDate];
+        if ([mostRecent compare:modified] == NSOrderedAscending) {
+            mostRecent = modified;
+            mrdpath = downloadPath;
+        }
+    }    
+    QSObject *mrd = [QSObject objectWithString:mrdpath];
+    return mrd;
+}
+@end

--- a/Quicksilver/PropertyLists/QSRegistration.plist
+++ b/Quicksilver/PropertyLists/QSRegistration.plist
@@ -427,6 +427,19 @@
 				<string>qs.process</string>
 			</array>
 		</dict>
+		<key>QSMostRecentDownloadProxy</key>
+		<dict>
+			<key>icon</key>
+			<string>ProxyIcon</string>
+			<key>name</key>
+			<string>Most Recent Download</string>
+			<key>providerClass</key>
+			<string>QSDownloads</string>
+			<key>types</key>
+			<array>
+				<string>NSFilenamesPboardType</string>
+			</array>
+		</dict>
 	</dict>
 	<key>QSRegistryHeaders</key>
 	<dict>

--- a/Quicksilver/Quicksilver.xcodeproj/project.pbxproj
+++ b/Quicksilver/Quicksilver.xcodeproj/project.pbxproj
@@ -302,6 +302,8 @@
 		92E9461A0D04CCEF0013377F /* QSModifierKeyEvents.m in Sources */ = {isa = PBXBuildFile; fileRef = 92E946180D04CCEF0013377F /* QSModifierKeyEvents.m */; };
 		CDCC201010A4C14B009C4EED /* QSMDPredicate.h in Headers */ = {isa = PBXBuildFile; fileRef = CDCC200E10A4C14B009C4EED /* QSMDPredicate.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CDCC201110A4C14B009C4EED /* QSMDPredicate.m in Sources */ = {isa = PBXBuildFile; fileRef = CDCC200F10A4C14B009C4EED /* QSMDPredicate.m */; };
+		D493990D1350078E00B908C6 /* QSDownloads.h in Headers */ = {isa = PBXBuildFile; fileRef = D49399091350078E00B908C6 /* QSDownloads.h */; };
+		D493990E1350078E00B908C6 /* QSDownloads.m in Sources */ = {isa = PBXBuildFile; fileRef = D493990A1350078E00B908C6 /* QSDownloads.m */; };
 		E102347106BB6CC900143367 /* Find.icns in Resources */ = {isa = PBXBuildFile; fileRef = E102347006BB6CC900143367 /* Find.icns */; };
 		E102F9BD06625D7400843027 /* About.xib in Resources */ = {isa = PBXBuildFile; fileRef = E102F97C06625D7300843027 /* About.xib */; };
 		E102F9BE06625D7400843027 /* QSCatalog.xib in Resources */ = {isa = PBXBuildFile; fileRef = E102F97D06625D7300843027 /* QSCatalog.xib */; };
@@ -1205,6 +1207,8 @@
 		92E946180D04CCEF0013377F /* QSModifierKeyEvents.m */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.objc; path = QSModifierKeyEvents.m; sourceTree = "<group>"; };
 		CDCC200E10A4C14B009C4EED /* QSMDPredicate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = QSMDPredicate.h; sourceTree = "<group>"; };
 		CDCC200F10A4C14B009C4EED /* QSMDPredicate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = QSMDPredicate.m; sourceTree = "<group>"; };
+		D49399091350078E00B908C6 /* QSDownloads.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = QSDownloads.h; sourceTree = "<group>"; };
+		D493990A1350078E00B908C6 /* QSDownloads.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = QSDownloads.m; sourceTree = "<group>"; };
 		E102347006BB6CC900143367 /* Find.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; path = Find.icns; sourceTree = "<group>"; };
 		E102F97C06625D7300843027 /* About.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = About.xib; sourceTree = "<group>"; };
 		E102F97D06625D7300843027 /* QSCatalog.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = QSCatalog.xib; sourceTree = "<group>"; };
@@ -2470,6 +2474,8 @@
 				7FB37EB3080997EF00A2B2B4 /* QSURLDownloadWrapper.m */,
 				E1E5FBCC07B20DD20044D6EF /* QSVoyeur.h */,
 				E1E5FBCD07B20DD20044D6EF /* QSVoyeur.m */,
+				D49399091350078E00B908C6 /* QSDownloads.h */,
+				D493990A1350078E00B908C6 /* QSDownloads.m */,
 			);
 			path = "Code-QuickStepCore";
 			sourceTree = "<group>";
@@ -2695,6 +2701,7 @@
 				E1E5FC3907B20DD20044D6EF /* QSVoyeur.h in Headers */,
 				2E34EE14134CA2E6005E66A1 /* UKFileWatcher.h in Headers */,
 				2E34EE15134CA2E6005E66A1 /* UKKQueue.h in Headers */,
+				D493990D1350078E00B908C6 /* QSDownloads.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3505,6 +3512,7 @@
 				E1E5FC3A07B20DD20044D6EF /* QSVoyeur.m in Sources */,
 				7FA4ED4D09132402007DB407 /* UKKQueue.m in Sources */,
 				7FA4ED4F09132402007DB407 /* UKMainThreadProxy.m in Sources */,
+				D493990E1350078E00B908C6 /* QSDownloads.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
Things to consider before merging:
- The class is called `QSDownloads` which is pretty generic when all it handles is the proxy, but the other proxy objects seem to be provided by huge classes, so I figured it would leave room for expansion. This class would potentially handle anything to do with a user’s downloads folder. Let me know if I should pick a different name.
- The new files are in the `Code-QuickStepCore` folder, but they don’t show up under that in Xcode on the left. Not sure what that’s about.
