### PR TITLE
Compile time fixes for 10.5

### DIFF
--- a/Quicksilver/Code-App/QSAboutWindowController.h
+++ b/Quicksilver/Code-App/QSAboutWindowController.h
@@ -8,7 +8,11 @@
 
 #import <Cocoa/Cocoa.h>
 
-@interface QSAboutWindowController : NSWindowController <NSWindowDelegate> {
+@interface QSAboutWindowController : NSWindowController 
+#if MAC_OS_X_VERSION_MAX_ALLOWED >= 1060
+<NSWindowDelegate> 
+#endif
+{
 	IBOutlet id creditsView;
 	BOOL showCredits;
 	IBOutlet NSImageView *imageView;


### PR DESCRIPTION
Put <NSWindowDelegate> between an #ifdef since it is not defined in 10.5.

Once again a trivial compile time fix for 10.5
