### PR TITLE
Fix for the Get Path action (issue 182)

### DIFF
--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Code/QSActionProvider_EmbeddedProviders.m
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Code/QSActionProvider_EmbeddedProviders.m
@@ -589,14 +589,15 @@ return [self moveFiles:dObject toFolder:iObject shouldCopy:YES];
 }
 
 - (QSObject *)getFilePaths:(QSObject *)dObject {
-    // FIXME: add more smarts so the comma trick will work
-    NSString *path = [[dObject arrayForType:QSFilePathType] componentsJoinedByString:@"\n"];
-    // prefix POSIX to ensure a unique name
-    QSObject *pathResult = [QSObject objectWithName:[NSString stringWithFormat:@"POSIX:%@", path]];
-    // display the path without "POSIX"
-    [pathResult setLabel:path];
+    // get an array of paths from files in the first pane
+    NSArray *paths = [dObject arrayForType:QSFilePathType];
+    // the name/label should be a one-line string
+    QSObject *pathResult = [QSObject objectWithName:[paths componentsJoinedByString:@", "]];
+    // use something other than the path to prevent this from clobbering the existing file (if it's in the catalog)
+    [pathResult setIdentifier:@"GetPathActionResult"];
+    // store all paths separated by newlines
     // allow it to be used as text (Large Type, Paste, etc.)
-    [pathResult setObject:path forType:QSTextType];
+    [pathResult setObject:[paths componentsJoinedByString:@"\n"] forType:QSTextType];
     [pathResult setPrimaryType:QSTextType];
     return pathResult;
 }


### PR DESCRIPTION
This fixes [issue 182](https://github.com/quicksilver/Quicksilver/issues/182). While working on this, I uncovered a potentially serious problem (filed as [issue 203](https://github.com/quicksilver/Quicksilver/issues/203)).

We could wait for 203 to get fixed before accepting this request, but my opinion is that the action doesn’t work at all now. At least with this change, it can work on individual files and multiple files selected by some method other than the comma trick.
