### PR TITLE
if an action returns something, wipe out the first pane

### DIFF
--- a/Quicksilver/Code-QuickStepInterface/QSInterfaceController.m
+++ b/Quicksilver/Code-QuickStepInterface/QSInterfaceController.m
@@ -469,19 +469,19 @@
         iObject = [(QSRankedObject*)iObject object];
 	QSObject *returnValue = [action performOnDirectObject:dObject indirectObject:iObject];
 	if (returnValue) {
-		if ([returnValue isKindOfClass:[QSNullObject class]]) {
-			[self clearObjectView:dSelector];
-		} else {
-			[dSelector performSelectorOnMainThread:@selector(selectObjectValue:) withObject:returnValue waitUntilDone:YES];
-			if (action) {
-                if ([action isKindOfClass:[QSRankedObject class]] && [(QSRankedObject *)action object]) {
-                    action = [(QSRankedObject *)action object];
-                    if ([action displaysResult]) {
-                        [self showMainWindow:self];
-                    }
+        // if the action returns something, wipe out the first pane
+        /* (The main object would get replaced anyway. This is only done to
+           remove objects selected by the comma trick before the action was run.) */
+        [self clearObjectView:dSelector];
+        [dSelector performSelectorOnMainThread:@selector(selectObjectValue:) withObject:returnValue waitUntilDone:YES];
+        if (action) {
+            if ([action isKindOfClass:[QSRankedObject class]] && [(QSRankedObject *)action object]) {
+                action = [(QSRankedObject *)action object];
+                if ([action displaysResult]) {
+                    [self showMainWindow:self];
                 }
             }
-		}
+        }
 	}
 	if (VERBOSE) NSLog(@"Command executed (%dms) ", (int)(-[startDate timeIntervalSinceNow] *1000));
 	[pool release];


### PR DESCRIPTION
This fixes [issue 203](https://github.com/quicksilver/Quicksilver/issues/203)

The change looks bigger than it is because of the indentation. Essentially, all I did was make the call to `[self clearObjectView:dSelector]` unconditional (for actions that have a return value) which clears the first pane. Previously, it would only be called if `[returnValue isKindOfClass:[QSNullObject class]]`.

I checked around to see the ramifications of this and there are only two actions that return null objects (delete file and trash file). Clearing the first pane for other actions appears to be harmless. It’s unnecessary extra work in the typical case, because the returned object replaces the main selection in the first pane correctly anyway, but for the case where there are other selections (via comma trick), this clears them.
