### PR TITLE
Fixed issue #207: Display number of results in result window

### DIFF
--- a/Quicksilver/Code-QuickStepInterface/QSResultController.m
+++ b/Quicksilver/Code-QuickStepInterface/QSResultController.m
@@ -314,8 +314,9 @@ NSMutableDictionary *kindDescriptions = nil;
 	if (selectedResult < 0 || ![[self currentResults] count]) return;
 	QSObject *newSelectedItem = [[self currentResults] objectAtIndex:selectedResult];
     
-    NSString *fmt = NSLocalizedStringFromTableInBundle(@"%d of %d", nil, [NSBundle bundleForClass:[self class]], @"");
-	NSString *status = [NSString stringWithFormat:fmt, selectedResult + 1, [[self currentResults] count]];
+	// HenningJ 20110419 there is no localized version of "%d of %d". Additionally, something goes wrong while trying to localize it.
+	// NSString *fmt = NSLocalizedStringFromTableInBundle(@"%d of %d", nil, [NSBundle bundleForClass:[self class]], @"");
+	NSString *status = [NSString stringWithFormat:@"%d of %d", selectedResult + 1, [[self currentResults] count]];
 	NSString *details = [selectedItem details] ? [selectedItem details] : @"";
     
 	if ([resultTable rowHeight] < 34 && details)


### PR DESCRIPTION
Fixed issue #207

It used to attempt to localize "%d of %d", but there was no localization for that and that somehow broke that localization system, so it didn't fall back to the non-localized string. I removed the localization attempt, so now it works.
But someone should really look into how the Quicksilver localization system works.
