### PR TITLE
Fixes issue 212: Selecting "Defaults" in Appearance Tab crashes Quicksilver

### DIFF
--- a/Quicksilver/Code-QuickStepInterface/QSResultController.m
+++ b/Quicksilver/Code-QuickStepInterface/QSResultController.m
@@ -138,6 +138,9 @@ NSMutableDictionary *kindDescriptions = nil;
 }
 
 - (void)dealloc {
+	NSUserDefaultsController *sucd = [NSUserDefaultsController sharedUserDefaultsController];
+	[sucd removeObserver:self forKeyPath:@"values.QSAppearance3B"];
+
 	[[[resultTable tableColumnWithIdentifier:@"NameColumn"] dataCell] unbind:@"textColor"];
 	[resultTable unbind:@"backgroundColor"];
 	[resultTable unbind:@"highlightColor"];


### PR DESCRIPTION
Fixes issue 212: 

When clicking on "Defaults", the old QSResultsController is released and afterwards it's notified that the preferences have changed. The leads to a EXC_BAD_ACCESS.
So I removed the QSResultsController as observer for the preferences.

Note to self: Next time debugging these kind of errors, start out with "Run with Performance Tool->Zombies". It's a great help.
