### PR TITLE
Calls [QSSearchObjectView initialize] in awakeFromNib. Fixes issue #233.

### DIFF
--- a/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
@@ -48,6 +48,7 @@ NSMutableDictionary *bindingsDict = nil;
 #pragma mark Lifetime
 - (void)awakeFromNib {
 	[super awakeFromNib];
+	[QSSearchObjectView initialize];
 	resetTimer = nil;
 	searchTimer = nil;
 	resultTimer = nil;


### PR DESCRIPTION
Added a call to [QSSearchObjectView initialize] in [QSSearchObjectView awakeFromNib] to reload bindings after changing interface. Without this the bindingsDict dictionary is not repopulated upon interface change. This fixes issue #233.
