### PR TITLE
Fixed issue 233. Removed dealloc of bindingsDict.

### DIFF
--- a/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
@@ -86,7 +86,6 @@ NSMutableDictionary *bindingsDict = nil;
 
 - (void)dealloc {
 	[self unbind:@"highlightColor"];
-	[bindingsDict release], bindingsDict = nil;
 	[partialString release], partialString = nil;
 	[matchedString release], matchedString = nil;
 	[visibleString release], visibleString = nil;


### PR DESCRIPTION
Fixed issue #233 in a better way, thanks to Henning. Removed deallocation of bindingsDict in QSSearchObjectView so it is preserved across interface changes. In this way +initialize is only called once compared to 3 times per interface change.
