### PR TITLE
Partial fix for Constellation Menus plugin

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSLibrarian.m
+++ b/Quicksilver/Code-QuickStepCore/QSLibrarian.m
@@ -722,3 +722,10 @@ static float searchSpeed = 0.0;
 	return YES;
 }
 @end
+
+@implementation QSLibrarian (ConstellationMenus_Legacy)
+- (id)validActionsForDirectObject:(id)obj indirectObject:(id)obj2 {
+		// This is used by the Constellation menus plugin
+		return [QSExec validActionsForDirectObject:obj indirectObject:obj2];
+}
+@end


### PR DESCRIPTION
I know this is the wrong place for that method, but it makes the default action work for constellation menus, a plugin for which I couldn't find the source code
