### PR TITLE
Fix a crash when installing plug-ins

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSTask.m
+++ b/Quicksilver/Code-QuickStepCore/QSTask.m
@@ -81,10 +81,7 @@ static NSMutableDictionary *tasksDictionary = nil;
     // So the logging statements do not make much sense really if we get "(null)" for all parameters
     // I will disable them for now since they don't provide useful info
     
-	if (DEBUG && VERBOSE) NSLog(@"really dealloc task %@ %@ %d", name, identifier, [self retainCount]);
-	
-	NSLog(@"really dealloc task %@ %@ %d", name, identifier, [self retainCount]);
-	[self setIdentifier:nil];
+    [identifier release], identifier = nil;
 
 	[self setName:nil];
 	[self setStatus:nil];


### PR DESCRIPTION
This crash may be caused by any `QSTask` being `dealloc`'d, but it only seemed to happen when installing plug-ins. The bug seemed to be that `-[QSTask stopTask]` was being called, which removed `self` from `tasksDictionary`, which called `-release` and then `-dealloc`, which called `-setIdentifier:` with `nil`, which tried to remove `self` from `tasksDictionary` again, causing an `EXC_BAD_ACCESS`. The fix is to simply release `identifier` and clear it, since we know that's what it's going to do anyway.
