### PR TITLE
The interface will appear for actions that display results

### DIFF
--- a/Quicksilver/Code-QuickStepInterface/QSInterfaceController.m
+++ b/Quicksilver/Code-QuickStepInterface/QSInterfaceController.m
@@ -480,14 +480,15 @@
         [self clearObjectView:dSelector];
         [dSelector performSelectorOnMainThread:@selector(selectObjectValue:) withObject:returnValue waitUntilDone:YES];
 		if (action) {
-                if ([action isKindOfClass:[QSRankedObject class]] && [(QSRankedObject *)action object]) {
-                    QSAction* rankedAction = [(QSRankedObject *)action object];
-					if (rankedAction != action) {
-						[rankedAction retain];
-						[action release];
-						action = rankedAction;
-					}
+            if ([action isKindOfClass:[QSRankedObject class]] && [(QSRankedObject *)action object]) {
+                QSAction* rankedAction = [(QSRankedObject *)action object];
+                if (rankedAction != action) {
+                    [rankedAction retain];
+                    [action release];
+                    action = rankedAction;
+                }
             }
+            // bring the interface back to show the result
             if ([action displaysResult]) {
                 [self showMainWindow:self];
             }


### PR DESCRIPTION
This fixes #232

I’m not entirely sure why this was conditional on whether or not the action was a `QSRankedObject`.

One thing that occurred to me is that the actions where the `QSRankedObject` test was failing happen to be actions where the plug-in assigns a priority to the action by default. That might be coincidence, but I doubt it. Anyway, I think this change makes sense.
