### PR TITLE
Commented out a redundant comment, tidied up some code around it

### DIFF
--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Code/QSActionProvider_EmbeddedProviders.m
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Code/QSActionProvider_EmbeddedProviders.m
@@ -475,8 +475,6 @@
 
 - (QSObject *)moveFiles:(QSObject *)dObject toFolder:(QSObject *)iObject shouldCopy:(BOOL)copy {
 
-   //NSLog(@"file: %@ directory: %@", dObject, iObject);
-
 	NSString *destination = [iObject singleFilePath];
 	NSArray *filePaths = [dObject validPaths];
 	if (!filePaths)


### PR DESCRIPTION
Saw the

```
    NSLog(@"file: %@ directory: %@", dObject, iObject);
```

NSLog in the console with just regular use. Thought it was a bit silly leaving it in.

Also, noticed the 'help' NSLog just above it - not a very helpful comment.

Finally - if this is true 

```
 if (dObject == iObject) {
```

on line 470, shouldn't something like make a duplicate like Finder does, or at least give some kind of NSBeep() or something be done
