### PR TITLE
create an actions folder in QSs app support folder after running the setup assistant

### DIFF
--- a/Quicksilver/Code-App/QSSetupAssistant.m
+++ b/Quicksilver/Code-App/QSSetupAssistant.m
@@ -271,6 +271,11 @@
 }
 
 - (IBAction)finish:(id)sender {
+	
+	// Create 'Actions' folder if it doesn't already exist
+	NSString *actionsFolder = [[NSString stringWithString:@"~/Library/Application Support/Quicksilver/Actions"] stringByExpandingTildeInPath];
+	[[NSFileManager defaultManager] createDirectoryAtPath:actionsFolder withIntermediateDirectories:YES attributes:nil error:nil];
+	
 	[[NSUserDefaults standardUserDefaults] setBool:YES forKey:kSetupAssistantCompleted];
 	[[self window] close];
 	[NSApp stopModal];


### PR DESCRIPTION
RE bug #265

The

```
 createDirectoryAtPath:withIntermediateDirectories:attributes:error:
```

method only creates the folder if it doesn't exist, so it won't over-write an existing folder. (checked as well)
I initially thought a check would be necessary but this isn't the case.
