### PR TITLE
Fixes bug #267; mailto: strings not being given correct actions

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSObject_StringHandling.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject_StringHandling.m
@@ -128,7 +128,7 @@
 	
 	// Email address
 	if ([stringValue hasPrefix:@"mailto:"]) {
-		[self setObject:stringValue forType:QSEmailAddressType];
+		[self setObject:[[stringValue componentsSeparatedByString:@"mailto:"] objectAtIndex:1]  forType:QSEmailAddressType];
 		[self setObject:stringValue forType:QSURLType];
 		[self setPrimaryType:QSURLType];
 		return;


### PR DESCRIPTION
Also fixes 'define:word' not being a URL

-- addition to my 'stringSniffing' pull request that was pulled yesterday
