### PR TITLE
Fixing weird bug when entering nonBaseCharacter

### DIFF
--- a/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
@@ -1481,8 +1481,8 @@ NSMutableDictionary *bindingsDict = nil;
 
 - (void)setMarkedText:(id)aString selectedRange:(NSRange)selRange {
 	if ([(NSString *)aString length]) {
-		NSLog(@"setmark %@ %d, %d", [aString string] , selRange.location, selRange.length);
-		aString = [[[aString string] purifiedString] lowercaseString];
+		NSLog(@"setmark %@ %d, %d", aString, selRange.location, selRange.length);
+		aString = [[aString purifiedString] lowercaseString];
 		[partialString setString:aString];
 		[self partialStringChanged];
 	}


### PR DESCRIPTION
When entering a a character from the nonBaseCharacterSet (characters that are used as modifiers for other characters - like ^ ` ´), there was an ignore exception in the console. This commit fixes that exception.

But the behavior is still a little weird. When you now enter one of these characters, QS will delete everything you entered before that character.

It calls `[QSSearchObjectView setMarkedText]`, but I have no idea why.
