### PR TITLE
Fixes a display bug in the taskviewer.

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSCatalogEntry.m
+++ b/Quicksilver/Code-QuickStepCore/QSCatalogEntry.m
@@ -548,7 +548,7 @@ if (kUseNSArchiveForIndexes)
 		[pool release];
 		return nil;
 	}
-	[[[QSLibrarian sharedInstance] scanTask] setStatus:[NSString stringWithFormat:@"Checking:%@", name]];
+	[[[QSLibrarian sharedInstance] scanTask] setStatus:[NSString stringWithFormat:@"Checking:%@", [self name]]];
 	BOOL valid = [self indexIsValid];
 	if (valid && !force) {
 		if (DEBUG_CATALOG) NSLog(@"\tIndex is valid for source: %@", name);
@@ -556,7 +556,7 @@ if (kUseNSArchiveForIndexes)
 	}
 	if (DEBUG_CATALOG)
 		NSLog(@"Scanning source: %@%@", [self name] , (force?@" (forced) ":@""));
-	[[[QSLibrarian sharedInstance] scanTask] setStatus:[NSString stringWithFormat:@"Scanning:%@", name]];
+	[[[QSLibrarian sharedInstance] scanTask] setStatus:[NSString stringWithFormat:@"Scanning:%@", [self name]]];
 	[self scanAndCache];
 	return nil;
 }


### PR DESCRIPTION
Today is the day of little pull requests. ;-)

Fixes a display bug in the TaskViewer. It used to show (null) while rescanning catalog entries, because it didn't use the accessor for the name of the catalog entry.
