### PR TITLE
Fix for pressing '/' at the wrong moment could drill down to root.

### DIFF
--- a/Quicksilver/Code-External/NDClasses/NDHotKeyEvent.m
+++ b/Quicksilver/Code-External/NDClasses/NDHotKeyEvent.m
@@ -958,7 +958,6 @@ UInt32 normalizeKeyCode(UInt32 theChar, unsigned short aKeyCode) {
 		case kClearCharCode:
 			// Set the char to the '/' key
 			theChar = (aKeyCode==0x47) ? NSInsertFunctionKey : theChar;
-			NSLog(@"theChar: %@",theChar);
 			break;
 		case kLeftArrowCharCode: theChar = NSLeftArrowFunctionKey; break;
 		case kRightArrowCharCode: theChar = NSRightArrowFunctionKey; break;

--- a/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
@@ -1072,10 +1072,10 @@ NSMutableDictionary *bindingsDict = nil;
 	
 	NSEvent *upEvent = [NSApp nextEventMatchingMask:NSKeyUpMask untilDate:[NSDate dateWithTimeIntervalSinceNow:0.25] inMode:NSDefaultRunLoopMode dequeue:YES];
 	
-	// Key up from the '/' character after 0.05s
+	// Is there a key up from the '/' character after 0.25s
 	if ([[upEvent charactersIgnoringModifiers] isEqualToString:@"/"]) {
 		[self moveRight:self];
-	// If '/' is still held down (i.e. no up event in 0.25s), go to the root
+	// If '/' is still held down (i.e. no key up in the 0.25s passed), go to root
 	} else if(!upEvent) {
 		[self setObjectValue:[QSObject fileObjectWithPath:@"/"]];
 		upEvent = [NSApp nextEventMatchingMask:NSKeyUpMask untilDate:[NSDate dateWithTimeIntervalSinceNow:0.25] inMode:NSDefaultRunLoopMode dequeue:YES];
@@ -1185,11 +1185,6 @@ NSMutableDictionary *bindingsDict = nil;
      }
 	 */
 //	NSLog(@"The Event is...: %@\ and currentEditor: %@ ",theEvent,[[[self control] dSelector] currentEditor]);
-	if([self objectValue] == nil)
-	{
-		NSLog(@"it's nil");
-		return;
-	}
 	
 	if ([theEvent clickCount] > 1) {
 		[(QSInterfaceController *)[[self window] windowController] executeCommand:self];


### PR DESCRIPTION
This is a fix for bug #63.

With the current QS, if you press '/' then another character then '/' just at the right time such that the second '/' corresponds to the time of 0.25s since the first '/' press, QS would think that you've just been holding it down all that time.

The fix just checks to see if the upEvent has ever happened. If not (you've been holding your finger on '/') THEN you go to the root.

Best way to see this is to just start drilling down folders as fast as you can with '/'. You'll get redirected to the root sooner or later.
