### PR TITLE
Delete actions added sound notification

### DIFF
--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Code/QSActionProvider_EmbeddedProviders.m
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Code/QSActionProvider_EmbeddedProviders.m
@@ -410,7 +410,7 @@
 		int val = (int)CFPreferencesGetAppIntegerValue(CFSTR("com.apple.sound.uiaudio.enabled"),
 													   CFSTR("com.apple.systemsound"),
 													   &isSet);
-		if (val == 1 && isSet) {
+		if (val == 1 || !isSet) {
 			// play trash sound
 			CFURLRef soundURL = (CFURLRef)[NSURL fileURLWithPath:@"/System/Library/Components/CoreAudio.component/Contents/Resources/SystemSounds/dock/drag to trash.aif"];
 			SystemSoundID soundId;
@@ -441,7 +441,7 @@
 	int val = (int)CFPreferencesGetAppIntegerValue(CFSTR("com.apple.sound.uiaudio.enabled"),
 												   CFSTR("com.apple.systemsound"),
 												   &isSet);
-	if (val == 1 && isSet) {
+	if (val == 1 || !isSet) {
 		// play trash sound
 		CFURLRef soundURL = (CFURLRef)[NSURL fileURLWithPath:@"/System/Library/Components/CoreAudio.component/Contents/Resources/SystemSounds/dock/drag to trash.aif"];
 		SystemSoundID soundId;


### PR DESCRIPTION
This implements feature request #216.
Added sound notification to trash and delete actions (if a file was actually deleted).
If a file was deleted, put the folder that contained the file in the first pane (but don't show interface again). If several files where deleted (with comma trick), use the folder of the last file that was deleted.
If permanent delete was canceled, just leave the files in the first pane.
