### PR TITLE
Fix for #282. After actions returns result, fill the result list with just that returned object

### DIFF
--- a/Quicksilver/Code-QuickStepInterface/QSInterfaceController.m
+++ b/Quicksilver/Code-QuickStepInterface/QSInterfaceController.m
@@ -495,7 +495,7 @@
         /* (The main object would get replaced anyway. This is only done to
            remove objects selected by the comma trick before the action was run.) */
         [self clearObjectView:dSelector];
-        [dSelector performSelectorOnMainThread:@selector(selectObjectValue:) withObject:returnValue waitUntilDone:YES];
+        [dSelector performSelectorOnMainThread:@selector(setObjectValue:) withObject:returnValue waitUntilDone:YES];
 		if (action) {
             if ([action isKindOfClass:[QSRankedObject class]] && [(QSRankedObject *)action object]) {
                 QSAction* rankedAction = [(QSRankedObject *)action object];


### PR DESCRIPTION
Fixes #282.
When an action returns an object as result, the resultlist is cleared and then re-populated with just that object.

I just noticed from the bug report that @skurfer also committed a fix for this issue, but didn't make a pull request yet. See skurfer/Quicksilver@4ede77ca8eb83349871b4fc19a8d917ea260b650.
I believe my fix is better anyway. But of course I'm always ready to be convinced it's not. :-)

Btw. I believe fixing #282 will also fix the crash Rob experienced with pull request #289. Whichever fix is chosen.
