### PR TITLE
Latest Download object is now unique

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSDownloads.m
+++ b/Quicksilver/Code-QuickStepCore/QSDownloads.m
@@ -42,10 +42,7 @@
             mostRecent = modified;
             mrdpath = downloadPath;
         }
-    }    
-    QSObject *mrd = [QSObject objectWithName:mrdpath];
-    [mrd setIdentifier:@"QSLatestDownloadProxy"];
-    [mrd setObject:mrdpath forType:QSFilePathType];
-    return mrd;
+    }
+    return [QSObject fileObjectWithPath:mrdpath];
 }
 @end


### PR DESCRIPTION
It avoids the automatic smarts of `objectWithString` and sets everything up manually so the file it references won’t be affected.
