### PR TITLE
removed an annoyance where the results view is changed upon updating

### DIFF
--- a/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
@@ -483,7 +483,7 @@ NSMutableDictionary *bindingsDict = nil;
 }
 
 - (IBAction)showResultView:(id)sender {
-	if ([[self window] firstResponder] != self) [[self window] makeFirstResponder:self];
+	if ([[self window] firstResponder] != self) return;
 	if ([[resultController window] isVisible]) return; //[resultController->resultTable reloadData];
     
 	[[resultController window] setLevel:[[self window] level] +1];
@@ -542,6 +542,7 @@ NSMutableDictionary *bindingsDict = nil;
     
 	if ([[self window] isVisible]) {
 		[[resultController window] orderFront:nil];
+		// Show the results window
 		[[self window] addChildWindow:[resultController window] ordered:NSWindowAbove];
 	}
 }


### PR DESCRIPTION
This is something that's annoyed me for a while:

If you type fast in the 1st pane then tab to the 2nd pane before the icons have loaded in the 1st pane, the selection is moved from the 2nd pane back to the 1st.

Easy way to reproduce: Type a letter then tab instantly after it.

Even easier:
1. Set the 'wait before searching' time in QS Prefs to the longest (0.5s)
2. type in the 1st pane then tab.
3. when the icon in the 1st pane loads the focus goes back to the 1st pane. Really annoying, and this pull hopefully fixes it...

I've commented it out for now just so you can see what it is that I've removed. If we're all happy then I can remove it in another commit
