### PR TITLE
Compile fixes 

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSObject_FileHandling.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject_FileHandling.m
@@ -116,7 +116,7 @@ NSArray *recentDocumentsForBundle(NSString *bundleIdentifier) {
 #endif
 }
 
-@interface QSFileSystemObjectHandler (hidden) {}
+@interface QSFileSystemObjectHandler (hidden)
 -(NSImage *)prepareImageforIcon:(NSImage *)icon;
 
 @end


### PR DESCRIPTION
The refactored interface definition breaks compilation on 10.5. I do not
know if it is valid for 10.6 but change it back to something that works
with 10.5 as well.

Can someone confirm that this works with 10.6 as well? I doubt that it won't but you never know.
