### PR TITLE
Fixed an annoying crash

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSObject.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject.m
@@ -252,22 +252,22 @@ NSSize QSMaxIconSize;
 	
 	// add each object from the list of objects to the combinedData dict
 	for (id thisObject in objects) {
-		// Make sure the object's not already been stored (case when you have two of the same object with the comma trick)
-		if (![setOfObjects containsObject:thisObject]) {
-			if (!typesSet) typesSet = [NSMutableSet setWithArray:[thisObject types]];
-			else
-				[typesSet intersectSet:[NSSet setWithArray:[thisObject types]]];
-			for(type in typesSet) {
-				array = [combinedData objectForKey:type];
-				if (!array) [combinedData setObject:(array = [NSMutableArray array]) forKey:type];
-				
-				[array addObjectsFromArray:[thisObject arrayForType:type]];
-				// add the object to the setOfObjects to keep track of which objects we've added to combinedData
-				[setOfObjects addObject:thisObject];
-			}
+		if (!typesSet) {
+			typesSet = [NSMutableSet setWithArray:[thisObject types]];
+		}
+		else {
+			[typesSet intersectSet:[NSSet setWithArray:[thisObject types]]];
+		}
+		for(type in typesSet) {
+			array = [combinedData objectForKey:type];
+			if (!array) [combinedData setObject:(array = [NSMutableArray array]) forKey:type];
+			
+			[array addObjectsFromArray:[thisObject arrayForType:type]];
+			// add the object to the setOfObjects to keep track of which objects we've added to combinedData
+			[setOfObjects addObject:thisObject];
 		}
 	}
-	// get the number of objects added to combinedData, then release arrayOfObjects
+	// get the number of objects added to combinedData, then release setOfObjects
 	int objectCount = [setOfObjects count];
 	[setOfObjects release];
 	


### PR DESCRIPTION
This one's been bugging me for a while.

**I've written an essay here, sorry guys...**

I initially thought it was due to my webSearchIcons branch, but it's not. I only just came across it when testing that branch, but have been able to reproduce it in other areas. For example with just simple URLs, and also file objects - I think I came across it when testing Henning's asynchro branch and thought it was related to those commits.

One REALLY easy way to reproduce:
1. Invoke QS
2. Type something to get a search URL in the 1st pane (e.g. google )
3. Hit ',' to add it to your list of objects
4. Start opening/closing the QS window continuously.

You should get a crash after a while. The reason it's really easy to produce with web search URLs (_I think_) is because they take more time to resolve (need to get the favicon from online).
I've definitely managed to reproduce it doing the same thing with just URLs.

Now, the reason for the crash:
If you have two or more of the SAME object under the comma trick, QS would try and combine these into a single object. It would then give this object an identifier. In the case of the objects being the same, it would use the identifier of the objects. This would cause QS to go loopy, not knowing which object to access with the identifier.

The fix:
To only combine objects if you have different objects collected using the comma trick.
