### PR TITLE
quick update for HTML parser

### DIFF
--- a/Quicksilver/Resources/QSURLExtractor.py
+++ b/Quicksilver/Resources/QSURLExtractor.py
@@ -8,11 +8,13 @@ Created by Rob McBroom on 2010-04-13.
 
 import sys
 import os
-from HTMLParser import HTMLParser
+from HTMLParser import HTMLParser, HTMLParseError
 
 class ExtractLinks(HTMLParser):
-    # def __init__(self):
-    #     HTMLParser.__init__(self)
+    def __init__(self):
+        HTMLParser.__init__(self)
+        self.insideLinkTag = False
+    
     def handle_starttag(self,tag,attrs):
         # print 'start', tag, self.insideLinkTag
         if tag == 'a':
@@ -66,6 +68,7 @@ if __name__ == '__main__':
     import fileinput
     page = ''.join([line for line in fileinput.input()])
     parser = ExtractLinks()
-    parser.insideLinkTag = False
-    # parser.thisLink = dict
-    parser.feed(page)
+    try:
+        parser.feed(page)
+    except HTMLParseError, e:
+        pass


### PR DESCRIPTION
I wanted to get this in before B60 is released. It causes the HTML parsing script to die gracefully if it encounters an error. This is a short-term fix since a bad link will prevent processing of the rest of the page. I’m looking into a better fix where the bad link will just be skipped, but that’ll take longer.
