### PR TITLE
Issue #288 fix (symlinks)

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSObject_FileHandling.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject_FileHandling.m
@@ -679,8 +679,7 @@ NSArray *recentDocumentsForBundle(NSString *bundleIdentifier) {
 + (QSObject *)fileObjectWithPath:(NSString *)path {
 	if (![path length])
 		return nil;
-	path = [path stringByStandardizingPath]; // Keeps symlink paths intact
-	// ***warning * should this only resolve simlinks of ancestors?
+	path = [path stringByStandardizingPath];
 	if ([[path pathExtension] isEqualToString:@"silver"])
 		return [QSObject objectWithDictionary:[NSDictionary dictionaryWithContentsOfFile:path]];
 


### PR DESCRIPTION
Prevents QS from resolving symlinks too early, so the resulting QSObject refers to the symlink instead of the destination file of the symlink.
