### PR TITLE
created a new method that returns the full OS X version, updated all HTTP

### DIFF
--- a/Quicksilver/Code-App/QSUpdateController.m
+++ b/Quicksilver/Code-App/QSUpdateController.m
@@ -149,7 +149,7 @@
 	NSString *testVersionString = nil;
 	if (success) {
 		NSMutableURLRequest *theRequest = [NSMutableURLRequest requestWithURL:versionURL cachePolicy:NSURLRequestUseProtocolCachePolicy timeoutInterval:20.0];
-
+		[theRequest setValue:kQSUserAgent forHTTPHeaderField:@"User-Agent"];
 		NSData *data = [NSURLConnection sendSynchronousRequest:theRequest returningResponse:nil error:nil];
 		testVersionString = [[[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding] autorelease];
 		NSLog(@"Version: %@", testVersionString);

--- a/Quicksilver/Code-QuickStepCore/QSDefines.h
+++ b/Quicksilver/Code-QuickStepCore/QSDefines.h
@@ -1,4 +1,6 @@
 
-#define kQSUserAgent @"Quicksilver (Blacktree, MacOSX) "
+#define kQSUserAgent [NSString stringWithFormat:@"Quicksilver %@ (Mac OS X %@)",\
+					 (NSString *)CFBundleGetValueForInfoDictionaryKey(CFBundleGetMainBundle(), kCFBundleVersionKey),\
+					 [NSApplication macOSXFullVersion]]
 
 #define QUERY_KEY @"***"

--- a/Quicksilver/Code-QuickStepCore/QSPlugInManager.m
+++ b/Quicksilver/Code-QuickStepCore/QSPlugInManager.m
@@ -162,6 +162,7 @@
 	NSMutableURLRequest *theRequest = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:fetchURLString]
 															cachePolicy:NSURLRequestUseProtocolCachePolicy
 														timeoutInterval:20.0];
+	[theRequest setValue:kQSUserAgent forHTTPHeaderField:@"User-Agent"];
 	//if (VERBOSE)
 	NSLog(@"Fetching plugin data from %@", fetchURLString);
 

--- a/Quicksilver/Code-QuickStepFoundation/NSApplication_BLTRExtensions.h
+++ b/Quicksilver/Code-QuickStepFoundation/NSApplication_BLTRExtensions.h
@@ -59,12 +59,19 @@ typedef enum {
  
  This category of NSApplication provides class methods to check which Mac OS X 
  version Quicksilver is running on.
- Uses Gesalt API. See http://www.cocoadev.com/index.pl?DeterminingOSVersion for 
+ Uses Gestalt API. See http://www.cocoadev.com/index.pl?DeterminingOSVersion for 
  reasons this is the best choice for determining the system version.
  For future methods similar to these ones, keep the limitations of gestaltSystemVersion 
  in mind. Maybe use gestaltSystemVersionMajor/gestaltSystemVersionMinor instead.
  */
 @interface NSApplication (VersionCheck)
+
+/**
+  Returns the full Mac OS X version of the current system as a string
+ 
+ @returns an NSString of the user's current Mac OS X version, for example 10.6.7
+ */
++ (NSString *)macOSXFullVersion;
 
 /**
  Checks, if system is at least Mac OS X 10.5 (Leopard)

--- a/Quicksilver/Code-QuickStepFoundation/NSApplication_BLTRExtensions.m
+++ b/Quicksilver/Code-QuickStepFoundation/NSApplication_BLTRExtensions.m
@@ -186,6 +186,15 @@
 
 
 @implementation NSApplication (VersionCheck)
++ (NSString *)macOSXFullVersion {
+	SInt32 versionMajor, versionMinor, versionBugfix;
+	Gestalt (gestaltSystemVersionMajor, &versionMajor);
+	Gestalt (gestaltSystemVersionMinor, &versionMinor);
+	Gestalt (gestaltSystemVersionBugFix, &versionBugfix);
+	
+	return [NSString stringWithFormat:@"%i.%i.%i",versionMajor,versionMinor,versionBugfix];
+}
+
 + (BOOL)isLeopard {
 	SInt32 version;
 	Gestalt (gestaltSystemVersion, &version);


### PR DESCRIPTION
created a new method that returns the full OS X version, updated all HTTP requests to use a new User Agent

The new user agent is of the format:

Quicksilver **Quicksilver Build Number** (Mac OS X **OS Version Number in Format 10.x.x**)

@ddl_smurf - since this will likely be used by the plugins PHP script, can you let me know if this format is acceptable for the User Agent (I'm sure there's something better).
Basically - whatever would be easiest to sniff in a PHP script when QS is asking for the plugins list.
