### PR TITLE
Allowed QS to browse PHP URLs that end in ?key=value&anotherKey=AnotherVa

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSObject_URLHandling.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject_URLHandling.m
@@ -84,8 +84,8 @@
 					 @"TRAVEL",@"TT",@"TV",@"TW",@"TZ",@"UA",@"UG",@"UK",@"US",@"UY",@"UZ",@"VA",@"VC",@"VE",@"VG",@"VI",@"VN",@"VU",@"WF",@"WS",@"XXX",@"YE",@"YT",@"ZA",@"ZM",@"ZW",nil] retain];
 	}
 	NSString *urlString = [object objectForType:QSURLType];
-	// Make sure the URL type is a domain or .html/htm type
-	NSString *type = [urlString pathExtension];
+	// Check the extension of the URL. We're looking for a tld, .php, .html or .htm (set in QSCorePlugin-Info.plist)
+	NSString *type = [[[urlString pathExtension] componentsSeparatedByString:@"?"] objectAtIndex:0];
 	// Check if the URL is a tld
 	if(type.length > 0 && [tldArray containsObject:[type uppercaseString]]) {
 		type = @"tld";


### PR DESCRIPTION
Allowed QS to browse PHP URLs that end in ?key=value&anotherKey=AnotherValue

Simple really. Just get the 1st part of the string separated by ? — this'll be the domain and path

I can't think of any cases where a ? would come before the path, so I don't think this can be broken

e.g. try this in QS:
http://qsapp.com/plugins/?order=name&sort=DESC
