### PR TITLE
don't relaunch to hide the Dock icon when debugging

### DIFF
--- a/Quicksilver/Code-App/QSApp.m
+++ b/Quicksilver/Code-App/QSApp.m
@@ -63,7 +63,6 @@ BOOL QSApplicationCompletedLaunch = NO;
 
 	NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
 
-#ifndef DEBUG
 	// Honor dock hidden preference if new version
 	isUIElement = [self shouldBeUIElement];
 	if (!isUIElement && [defaults boolForKey:kHideDockIcon]) {
@@ -71,12 +70,14 @@ BOOL QSApplicationCompletedLaunch = NO;
 			[defaults setInteger:1 forKey:@"QSShowMenuIcon"];
 
 	  NSLog(@"Relaunching to honor Dock Icon Preference");
-		if ([self setShouldBeUIElement:YES])
+		if ([self setShouldBeUIElement:YES]) {
+#ifndef DEBUG
 			[self relaunch:nil];
-		else
-			[defaults setBool:NO forKey:kHideDockIcon];
-	}
 #endif
+		} else {
+			[defaults setBool:NO forKey:kHideDockIcon];
+		}
+	}
 
 	featureLevel = [defaults integerForKey:kFeatureLevel];
 	if (featureLevel < 0)


### PR DESCRIPTION
As I’m sure you all know, if the preference to hide the Dock icon is enabled, a newly built Quicksilver has to modify itself and relaunch. This confuses the hell out of Xcode when you’re doing a “Build & Run” or “Build & Debug”.

With this change, the preference to hide the icon is only respected in Release builds, which makes the code much easier to work on for those of us using this option.
