### PR TITLE
made Bezel interface work on all spaces, made moveable

### DIFF
--- a/Quicksilver/PlugIns-Main/Bezel/QSBezelInterfaceController.m
+++ b/Quicksilver/PlugIns-Main/Bezel/QSBezelInterfaceController.m
@@ -16,8 +16,11 @@
 
 	[super windowDidLoad];
 	QSWindow *window = (QSWindow *)[self window];
-	[window setLevel:kCGOverlayWindowLevel];
+	[window setLevel:NSModalPanelWindowLevel];
 	[window setBackgroundColor:[NSColor clearColor]];
+	
+	// Set the window to be visible on all spaces
+    [[self window] setCollectionBehavior:NSWindowCollectionBehaviorCanJoinAllSpaces];
 
 	[window setHideOffset:NSMakePoint(0, 0)];
 	[window setShowOffset:NSMakePoint(0, 0)];
@@ -36,7 +39,7 @@
 	[details bind:@"textColor" toObject:[NSUserDefaultsController sharedUserDefaultsController] withKeyPath:@"values.QSAppearance1T" options:[NSDictionary dictionaryWithObject:NSUnarchiveFromDataTransformerName forKey:@"NSValueTransformerName"]];
 	[commandView bind:@"textColor" toObject:[NSUserDefaultsController sharedUserDefaultsController] withKeyPath:@"values.QSAppearance1T" options:[NSDictionary dictionaryWithObject:NSUnarchiveFromDataTransformerName forKey:@"NSValueTransformerName"]];
 
-	[[self window] setMovableByWindowBackground:NO];
+	[[self window] setMovableByWindowBackground:YES];
 	[(QSWindow *)[self window] setFastShow:YES];
 
 	NSArray *theControls = [NSArray arrayWithObjects:dSelector, aSelector, iSelector, nil];


### PR DESCRIPTION
Don't know why I never issued a pull request for this.

For some reason, the Bezel interface used a different method of displaying to pretty much all other interfaces.

These changes make it use the same as most others.

The consequences are:
You can move the window
It will stay open when you change spaces
