### PR TITLE
Display the correct label in the interface

### DIFF
--- a/Quicksilver/Code-QuickStepInterface/QSObjectCell.m
+++ b/Quicksilver/Code-QuickStepInterface/QSObjectCell.m
@@ -479,8 +479,7 @@ NSRect alignRectInRect(NSRect innerRect, NSRect outerRect, int quadrant);
         id ranker = [drawObject ranker];
 		if (ranker && abbreviationString)
 			nameString = [ranker matchedStringForAbbreviation:abbreviationString hitmask:&hitMask inContext:nil];
-        if (!nameString) nameString = [drawObject name];
-        if (!nameString) nameString = [drawObject label];
+		if (!nameString) nameString = [drawObject displayName];
 		if (!nameString) nameString = @"<Unknown>";
 
 		//NSLog(@"usingname: %@", nameString);


### PR DESCRIPTION
For reasons unknown, the precedence for name and label was reversed in 861a7cfa.

Rather than simply change it back, I switched to using the object’s “display name”, which already has logic built into it to choose between name and label. (And if this isn’t an appropriate place to use `displayName`, I don’t know what is.)
