### PR TITLE
fixed a bug where http:// was prefixed to some URLs incorrectly

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSObject_URLHandling.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject_URLHandling.m
@@ -140,7 +140,7 @@
 - (void)assignURLTypesWithURL:(NSString *)urlString
 {
 		[[self dataDictionary] setObject:urlString forKey:QSURLType];
-		if ([[NSURL URLWithString:urlString] scheme])
+		if ([[NSURL URLWithString:[urlString URLEncoding]] scheme])
 		{
 			[self setObject:urlString forType:QSURLType];
 		} else {


### PR DESCRIPTION
Introduced in #370 — if you create a URL with a char that needs escaping (e.g. http://google.com/|hello| ) QS adds another http:// to the front.

Sorry @skurfer, I should have picked this up in the pull request. The URLString needs encoding first to get it to work
