### PR TITLE
simplify and improve splitObjects

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSObject.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject.m
@@ -227,26 +227,7 @@ NSSize QSMaxIconSize;
 		return [NSArray arrayWithObject:self];
 	}
 	
-	NSDictionary *dataDict = [self dataDictionary];
-
-	NSMutableArray *splitObjects = [NSMutableArray array];
-	NSArray *value;
-
-	//int resultCount = 0;
-	int i;
-
-	for(NSString *key in dataDict) {
-		value = [dataDict objectForKey:key];
-		if ([value isKindOfClass:[NSArray class]]) {
-			while([splitObjects count] <[value count])
-				[splitObjects addObject:[QSObject objectWithName:[self name]]];
-			for (i = 0; i<[value count]; i++) {
-				[[splitObjects objectAtIndex:i] setObject:[value objectAtIndex:i] forType:key];
-			}
-		} else {
-		}
-	}
-	return splitObjects;
+	return [self objectForCache:kQSObjectComponents];
 }
 
 // Method to merge objects into a single 'combined' object


### PR DESCRIPTION
The `splitObjects` method was doing a lot of work to get some details of QSObjects and return them in an array of new QSObjects.
1. It was only preserving the name and types for the object. (No metadata, details, label. etc.) Metadata in particular could be important to validate actions, etc.
2. This work is unnecessary. All of the details of the component objects have already been stored in their entirety by the `objectByMergingObjects` method. All we need to do is return it instead of creating a bunch of new (incomplete) objects.
3. This change will make it much easier for plug-ins to get objects passed in via the comma trick.

I only found three calls to `splitObjects` (in the application and all known plug-ins) and this should be compatible with all of them.
