### PR TITLE
added error checking and steps so packages (e.g. .app, .qsplugin) are not

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSDownloads.m
+++ b/Quicksilver/Code-QuickStepCore/QSDownloads.m
@@ -17,96 +17,55 @@
 	NSString *downloadPath, *mrdpath;
 	NSDate *modified = nil;
     NSDate *mostRecent = [NSDate distantPast];
-	
-	// Snow Leopard Specific Way
-	#if MAC_OS_X_VERSION_MAX_ALLOWED >= 1060
-	if([NSApplication isSnowLeopard]) {
-		NSNumber *isDir;
-		NSNumber *isPackage;
-		NSURL *downloadsURL = [NSURL URLWithString:downloads];
-		// An array of the directory contents, keeping the isDirectory key, attributeModificationDate key and skipping hidden files
-		NSArray *contents = [manager contentsOfDirectoryAtURL:downloadsURL
-								   includingPropertiesForKeys:[NSArray arrayWithObjects:NSURLIsDirectoryKey,NSURLAttributeModificationDateKey,nil]
-													  options:NSDirectoryEnumerationSkipsHiddenFiles
-														error:nil];
-		for (NSURL *downloadedFile in contents) {
-			NSError *err = nil;
 
-			NSString *fileExtension = [downloadedFile pathExtension];
-			if ([fileExtension isEqualToString:@"download"] ||
-				[fileExtension isEqualToString:@"part"] ||
-				[fileExtension isEqualToString:@"dtapart"] ||
-				[fileExtension isEqualToString:@"crdownload"]) {
-				continue;
-			}
-			
-			// Do not show folders
-			if ([downloadedFile getResourceValue:&isDir forKey:NSURLIsDirectoryKey error:&err] && [isDir boolValue]) {
-				if (err != nil) {
-					NSLog(@"Error getting resource value for %@\nError: %@",downloadPath,err);
-					continue;
-				}
-				// Show packages (e.g. .app and .qsplugin packages)
-				if ([downloadedFile getResourceValue:&isPackage forKey:NSURLIsPackageKey error:&err] && ![isPackage boolValue]) {
-					if (err != nil) {
-						NSLog(@"Error getting resource value for %@\nError: %@",downloadPath,err);
-					}
-					continue;
-				}
-			}
-				downloadPath = [downloadedFile path];
-			if([manager fileExistsAtPath:[downloadPath stringByAppendingPathExtension:@"part"]]) {
-				continue;
-			}
-			// compare the modified date of the file with the most recent download file
-			[downloadedFile getResourceValue:&modified forKey:NSURLAttributeModificationDateKey error:&err];
+	NSNumber *isDir;
+	NSNumber *isPackage;
+	NSURL *downloadsURL = [NSURL URLWithString:downloads];
+	// An array of the directory contents, keeping the isDirectory key, attributeModificationDate key and skipping hidden files
+	NSArray *contents = [manager contentsOfDirectoryAtURL:downloadsURL
+							   includingPropertiesForKeys:[NSArray arrayWithObjects:NSURLIsDirectoryKey,NSURLAttributeModificationDateKey,nil]
+												  options:NSDirectoryEnumerationSkipsHiddenFiles
+													error:nil];
+	for (NSURL *downloadedFile in contents) {
+		NSError *err = nil;
+		
+		NSString *fileExtension = [downloadedFile pathExtension];
+		if ([fileExtension isEqualToString:@"download"] ||
+			[fileExtension isEqualToString:@"part"] ||
+			[fileExtension isEqualToString:@"dtapart"] ||
+			[fileExtension isEqualToString:@"crdownload"]) {
+			continue;
+		}
+		
+		// Do not show folders
+		if ([downloadedFile getResourceValue:&isDir forKey:NSURLIsDirectoryKey error:&err] && [isDir boolValue]) {
 			if (err != nil) {
 				NSLog(@"Error getting resource value for %@\nError: %@",downloadPath,err);
 				continue;
 			}
-			if ([mostRecent compare:modified] == NSOrderedAscending) {
-				mostRecent = modified;
-				mrdpath = downloadPath;
+			// Show packages (e.g. .app and .qsplugin packages)
+			if ([downloadedFile getResourceValue:&isPackage forKey:NSURLIsPackageKey error:&err] && ![isPackage boolValue]) {
+				if (err != nil) {
+					NSLog(@"Error getting resource value for %@\nError: %@",downloadPath,err);
+				}
+				continue;
 			}
 		}
-	}
-	
-	// Leopard Way
-	else {
-	#endif
-		BOOL isDir;
-		
-		// list files in the Downloads directory
-		NSArray *contents = [manager contentsOfDirectoryAtPath:downloads error:nil];
-		// the most recent download (with the folder itself as a fallback)
-		for (NSString *downloadedFile in contents) {
-			NSString *fileExtension = [downloadedFile pathExtension];
-			if (
-				// hidden files
-				[downloadedFile characterAtIndex:0] == '.' ||
-				// Safari downloads in progress
-				[fileExtension isEqualToString:@"download"] ||
-				// Firefox downloads in progress
-				[fileExtension isEqualToString:@"part"] ||
-				[fileExtension isEqualToString:@"dtapart"] ||
-				// Chrome downloads in progress
-				[fileExtension isEqualToString:@"crdownload"]
-				) continue;
-			downloadPath = [downloads stringByAppendingPathComponent:downloadedFile];
-			// if SomeFile.part exists, SomeFile is probably an in-progress download so skip it
-			if ([manager fileExistsAtPath:[downloadPath stringByAppendingPathExtension:@"part"]]) continue;
-			// ignore folders
-			if ([manager fileExistsAtPath:downloadPath isDirectory:&isDir] && isDir) continue;
-			modified = [[manager attributesOfItemAtPath:downloadPath error:nil] fileModificationDate];
-			if ([mostRecent compare:modified] == NSOrderedAscending) {
-				mostRecent = modified;
-				mrdpath = downloadPath;
-			}
+		downloadPath = [downloadedFile path];
+		if([manager fileExistsAtPath:[downloadPath stringByAppendingPathExtension:@"part"]]) {
+			continue;
 		}
-	#if MAC_OS_X_VERSION_MAX_ALLOWED >= 1060
+		// compare the modified date of the file with the most recent download file
+		[downloadedFile getResourceValue:&modified forKey:NSURLAttributeModificationDateKey error:&err];
+		if (err != nil) {
+			NSLog(@"Error getting resource value for %@\nError: %@",downloadPath,err);
+			continue;
+		}
+		if ([mostRecent compare:modified] == NSOrderedAscending) {
+			mostRecent = modified;
+			mrdpath = downloadPath;
+		}
 	}
-	#endif
-	
 	[manager release];
     return [QSObject fileObjectWithPath:mrdpath];
 }


### PR DESCRIPTION
Basically I've just done a check for the `NSURLIsPackageKey` (Snow Leopard+ only)

Previously, .app and other packages would be ignored as they were thought to be folders. This stops that.

I've also changed the `error:nil` code to actually store, then check for an NSError
