### PR TITLE
Dropping files into text areas

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSObject_StringHandling.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject_StringHandling.m
@@ -174,7 +174,7 @@
 - (NSString *)stringValue {
 	if ([self containsType:QSFilePathType]) {
 		if ([self count] > 1) {
-			return [[self arrayForType:QSFilePathType] componentsJoinedByString:@"\n"];
+			return [[self arrayForType:QSFilePathType] componentsJoinedByString:@" "];
 		} else {
 			return [self objectForType:QSFilePathType];
 		}


### PR DESCRIPTION
See #464

This allows you to get the full path when dragging files out of Quicksilver. If multiple files are selected via the comma trick, it will insert the paths for all of them.

Ideally, it would drop the actual files rather than the path string. That way, files dropped on Terminal would have their paths properly escaped automatically. Anyone know how to do that?
