### PR TITLE
So that PHP's libxml doesn't bail.

### DIFF
--- a/Quicksilver/PropertyLists/Quicksilver-Info.plist
+++ b/Quicksilver/PropertyLists/Quicksilver-Info.plist
@@ -184,7 +184,7 @@
 			<key>NSKeyEquivalent</key>
 			<dict>
 				<key>default</key>
-				<string></string>
+				<string>&#x001b;</string>
 			</dict>
 			<key>NSMenuItem</key>
 			<dict>


### PR DESCRIPTION
That's preventing me to have a nice `qs-push-plugin Quicksilver.dmg` to provide applications updates.

Yes, it does seems innocuous ;-). I've checked that LaunchServices correctly registers the shortcut. For the record, a combination of 'lsregister -f /Applications/Quicksilver.app' and '/System/Library/CoreService/pbs -flush' was used.
