### PR TITLE
default preferences

### DIFF
--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/QSCorePlugIn-Info.plist
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/QSCorePlugIn-Info.plist
@@ -1822,7 +1822,7 @@
 				</dict>
 				<dict>
 					<key>enabled</key>
-					<false/>
+					<true/>
 					<key>feature</key>
 					<integer>1</integer>
 					<key>ID</key>

--- a/Quicksilver/Resources/QSDefaults.plist
+++ b/Quicksilver/Resources/QSDefaults.plist
@@ -113,5 +113,9 @@
 	<false/>
 	<key>Use Effects</key>
 	<true/>
+	<key>Feature Level</key>
+	<integer>1</integer>
+	<key>QSUseGlobalSelectionForGrab</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
We’ve talked about this before, but there are three things disabled by default that lead to a lot of confusion for new users.
- Advanced features
- Pull selection from front application instead of Finder
- Proxy Objects

At this point, I think it’s safe to say that running with these things enabled does not affect stability or performance.
