### PR TITLE
Altered progress float to be 0.99

### DIFF
--- a/Quicksilver/Code-QuickStepEffects/QSWindowAnimation.m
+++ b/Quicksilver/Code-QuickStepEffects/QSWindowAnimation.m
@@ -89,14 +89,14 @@
 	float _percent = progress;
 	 [super setCurrentProgress:progress];
 //- (void)_doAnimationStep {
-	if (effectFt) {
+	if (effectFt) { 
 		(*effectFt) (self);
 	}
 	if (transformFt) {
 		CGAffineTransform newTransform = (*transformFt) (self, _percent);
 
 
-		if (progress == 1.0f)
+		if (progress >= 0.99f )
 			newTransform = _transformA;
 		CGSSetWindowTransform(cgs, wid, newTransform);
 


### PR DESCRIPTION
Means singular matrices do not occur and kCGErrorIllegalArgument console error messages are gone!

Tiny fix this is:
See http://groups.google.com/group/quicksilver---development/browse_thread/thread/98c6ab4ad653a9ec for some history on this.

Basically, when the interface was closed, but _not quite closed_ the progress could be 99% whilst the window dimensions were 0 by 0 - this could cause all sorts of nan business in the matrix.

0.99 is effectively 1, so I haven't really changed much :)
