### PR TITLE
Fixed a bug where dragging multiple files onto a folder in QS's 1st pane 

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSObject_FileHandling.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject_FileHandling.m
@@ -462,7 +462,7 @@ NSArray *recentDocumentsForBundle(NSString *bundleIdentifier) {
 	if ([dObject isApplication])
 		return NSDragOperationPrivate;
 	else if ([dObject isFolder]) {
-		NSDragOperation defaultOp = [[NSFileManager defaultManager] defaultDragOperationForMovingPaths:[dObject validPaths] toDestination:[(QSObject *)iObject singleFilePath]];
+		NSDragOperation defaultOp = [[NSFileManager defaultManager] defaultDragOperationForMovingPaths:[iObject	validPaths] toDestination:[dObject singleFilePath]];
 		if (defaultOp == NSDragOperationMove) {
 			if (sourceDragMask&NSDragOperationMove)
 				return NSDragOperationMove;


### PR DESCRIPTION
Fixed a bug where dragging multiple files onto a folder in QS's 1st pane would show the copy to... action and not the move to... action.

source/destination had been accidentally mixed up.

**For files residing on the same disk**

Reproduce:
- Drag 1 file onto a folder in QS's 1st pane.
- Move To... appears
- Drag 2 or more files onto a folder in QS's 1st pane
- Copy To... appears.

This fixes that :)
