### PR TITLE
Closing command builder (in triggers prefs) correctly removes the empty trigger

### DIFF
--- a/Quicksilver/Code-QuickStepInterface/QSInterfaceController.m
+++ b/Quicksilver/Code-QuickStepInterface/QSInterfaceController.m
@@ -189,8 +189,14 @@
 	[self setHiding:YES];
 	if (effect && [[NSUserDefaults standardUserDefaults] boolForKey:kUseEffects])
 		[(QSWindow *)[self window] hideWithEffect:effect];
-	else
-		[[self window] orderOut:nil];
+	else {
+        if ([self isKindOfClass:[QSCommandBuilder class]]) {
+            [self hideWindows:nil];
+        }
+        else {
+            [[self window] orderOut:nil];
+        }
+    }
 	[self setHiding:NO];
 	[[NSNotificationCenter defaultCenter] postNotificationName:QSReleaseOldCachesNotification object:self];
     


### PR DESCRIPTION
Closing command builder (in triggers prefs) correctly removes the empty trigger.

See #537 for info on the bug.

Fixes #537
