### PR TITLE
Fix a bug where mouse trigger objects weren't being resolved

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSCommand.m
+++ b/Quicksilver/Code-QuickStepCore/QSCommand.m
@@ -307,8 +307,8 @@ NSTimeInterval QSTimeIntervalForString(NSString *intervalString) {
 
 - (QSObject *)dObject {
 	QSObject *object = dObject;
-	// Return the object if it already exists
-	if (object) {
+	// Return the object if it already exists, and has been resolved (i.e. has an identifier)
+	if (object && [object identifier]) {
 		return object;
 	}
 	


### PR DESCRIPTION
Fix: make sure the object has an identifier before returning it.

This is an absolutely tiny change.
Basically, sometimes when 'object' was set (see the line I've changed) it still didn't necessarily point to a resolved object.
If the identifier is set then it definitely points to a resolved object :)
