### PR TITLE
Display custom icons for actions

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSObject.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject.m
@@ -874,11 +874,9 @@ containg multiple objects with the same identifier. Best efforts should be made 
 		}
 	}
 
-	if (![self objectForType:QSURLType]) {
-		id handler = nil;
-		if (handler = [self handlerForSelector:@selector(loadIconForObject:)])
-			return [handler loadIconForObject:self];
-	}
+	id handler = nil;
+	if (handler = [self handlerForSelector:@selector(loadIconForObject:)])
+		return [handler loadIconForObject:self];
 
 	//// if ([primaryType hasPrefix:@"QSCsontact"])
 	//	 return NO;


### PR DESCRIPTION
This fixes #361. There was a false-start commit, but the end result is basically to undo the commit mentioned in the issue’s comments. In my testing, it now shows icons for actions as well as images from links.
