### PR TITLE
Made changes to stop QS launching twice when it tries to honour dock prefs

### DIFF
--- a/Quicksilver/Code-App/QSApp.m
+++ b/Quicksilver/Code-App/QSApp.m
@@ -46,13 +46,6 @@ BOOL QSApplicationCompletedLaunch = NO;
 }
 
 - (id)init {
-	char *relaunchingFromPid = getenv("relaunchFromPid");
-	if (relaunchingFromPid) {
-		unsetenv("relaunchFromPid");
-		int pid = atoi(relaunchingFromPid);
-		int i;
-		for (i = 0; !kill(pid, 0) && i<50; i++) usleep(100000);
-	}
 	if ((self = [super init])) {
 
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];

--- a/Quicksilver/Code-QuickStepFoundation/NSApplication_BLTRExtensions.m
+++ b/Quicksilver/Code-QuickStepFoundation/NSApplication_BLTRExtensions.m
@@ -117,12 +117,9 @@
 	else
 		path = [[NSBundle mainBundle] executablePath];
 	NSLog(@"Relaunch from path %@", path);
-	char pidstr[10];
-	sprintf(pidstr, "%d", getpid() );
-	setenv("relaunchFromPid", pidstr, YES);
 	[[NSNotificationCenter defaultCenter] postNotificationName:QSApplicationWillRelaunchNotification object:self userInfo:nil];
 	[NSTask launchedTaskWithLaunchPath:path arguments:[NSArray array]];
-
+    usleep(1000000);
 	[self terminate:self];
 }
 


### PR DESCRIPTION
See the 'ß63' discussion on the dev groups for more info.

Basically, when copying the release build app from the .dmg to my applications folder and launching it, I saw that QS would launch twice. This would also bring up the crash dialogue.

This wouldn't have been good to release, since every user is going to have to drag the file from the .dmg

There's a compiled copy in my email on the 'ß63' discussion
