### PR TITLE
Make qs-push-plugin work with DMGs (merge post 64-bit)

### DIFF
--- a/Quicksilver/Tools/qs-push-plugin
+++ b/Quicksilver/Tools/qs-push-plugin
@@ -21,6 +21,7 @@ require 'time'
 require 'fileutils'
 
 # Rubygems
+require 'rubygems'
 require 'trollop'
 require 'rest-client'
 require 'plist'


### PR DESCRIPTION
Everything's in the title ;-).

This makes qs-push-plugin :
- QS DMG images are now handled.
- Multiple arguments are better handled (w.r.t to the temp archive creation file mostly).
- Added two options, --level <i> and --secret (-l <i> and -s for short), for one-shot override of a plugins's level).
