### PR TITLE
!URGENT: Fix bug where all plugins get deleted

### DIFF
--- a/Quicksilver/Code-App/QSController.m
+++ b/Quicksilver/Code-App/QSController.m
@@ -91,11 +91,14 @@ static QSController *defaultController = nil;
 #endif
 
 - (NSString *)applicationSupportFolder {
-	FSRef foundRef;
-	FSFindFolder(kUserDomain, kApplicationSupportFolderType, kDontCreateFolder, &foundRef);
-	unsigned char path[1024];
-	FSRefMakePath(&foundRef, path, sizeof(path) );
-	return [[NSString stringWithUTF8String:(char *)path] stringByAppendingPathComponent:@"Quicksilver"];
+    NSArray *userSupportPathArray = NSSearchPathForDirectoriesInDomains (NSApplicationSupportDirectory, NSUserDomainMask, YES);
+    if ([userSupportPathArray count]) {
+        return [[userSupportPathArray objectAtIndex:0] stringByAppendingPathComponent:@"Quicksilver"];
+    }
+    else {
+        NSLog(@"Unable to find user Application Support folder");
+        return nil;
+    }
 }
 
 - (id)init {


### PR DESCRIPTION
So the 'plugins deleting' bug started happening for me today. Annoying, but good, as I've managed to debug and fix it.

Turns out (see the commit) that the plugins support path was being searched twice for plugins on launch, so the 'allBundles' array had two duplicates of the all the plugins in App Sup/QS/PlugIns.
In turn, when QS went about loading the plugins, on trying to load the plugins in the App Sup folder the second time it thought they were duplicates and so deleted them (although they were actually the same files)

Line 468 correctly adds

```
/Library/...app support path
~/Library/...app support path
/Network/Library/...app support path
```

already, so there was no need to add ~/Library/...app support path again.

It'd be interesting to see what people who aren't having this problem get if they set a breakpoint (WITHOUT this merged in) just before `for (NSString *currPath in bundleSearchPaths) {` and see what is in the array `bundleSearchPaths`
