### PR TITLE
resolve proxy objects before sending them to actions

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSAction.m
+++ b/Quicksilver/Code-QuickStepCore/QSAction.m
@@ -294,8 +294,12 @@ static BOOL gModifiersAreIgnored;
 	NSString *class = [dict objectForKey:kActionClass];
 	QSActionProvider *provider = [dict objectForKey:kActionProvider];
 	if (class || provider) {
-		if (!provider)
+		if (!provider) {
 			provider = [QSReg getClassInstance:class];
+		}
+		if ([[dObject primaryType] isEqualToString:QSProxyType]) {
+			dObject = (QSObject *)[dObject resolvedObject];
+		}
 		if ([[dict objectForKey:kActionSplitPluralArguments] boolValue] && [dObject count] > 1) {
 			NSArray *objects = [dObject splitObjects];
 			id object;


### PR DESCRIPTION
This should ensure that actions are always given a resolved object instead of a proxy (so every single action doesn’t have to test and resolve them). See #621 for more discussion.

Changing this method should catch all of the scenarios (interface controller, triggers, etc.).

One example of something that wouldn’t work before this change: Random Track → Add to Playlist… → Some Playlist
