### PR TITLE
Make sure the actions dict exists before trying to add things to it

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSAction.m
+++ b/Quicksilver/Code-QuickStepCore/QSAction.m
@@ -104,7 +104,12 @@ static BOOL gModifiersAreIgnored;
 // end patch
 
 - (NSMutableDictionary*)actionDict {
-    return [self objectForType:QSActionType];
+    NSMutableDictionary *dict = [self objectForType:QSActionType];
+    if (!dict) {
+        dict = [[NSMutableDictionary alloc] init];
+        [self setObject:dict forType:QSActionType];
+    }
+    return dict;
 }
 
 - (id)objectForKey:(NSString*)key {


### PR DESCRIPTION
If you look at any of the `setSomething` methods in QSAction.m (e.g. `setProvider`) you'll see that it tries to `setObject:something` to the `actionDict` dictionary.

Whilst debugging the Services Menu module (I've got it working for me now - yay!) I noticed that the `actionDict` wasn't always being created (so it was `nil`).
This meant that methods like `setProvider` in QSAction.m would try to:

```
[nil setObject:NSStringFromClass([newProvider class]) forKey:kActionClass];
```

you can't set an object for `nil` :o

This change makes sure the `actionDict` actually exists, so you can set objects and keys to it.
