### PR TITLE
!Urgent ß64 Fix: Show the icon in the dock if users have never changed the setting

### DIFF
--- a/Quicksilver/Code-App/QSApp.m
+++ b/Quicksilver/Code-App/QSApp.m
@@ -59,8 +59,8 @@ BOOL QSApplicationCompletedLaunch = NO;
         
 	// Honor dock hidden preference if new version
 	isUIElement = [self shouldBeUIElement];
-        if (isUIElement && [defaults objectForKey:kHideDockIcon] && ![defaults boolForKey:kHideDockIcon]) {
-		if (![defaults objectForKey:@"QSShowMenuIcon"])
+    if (isUIElement && (([defaults objectForKey:kHideDockIcon] && ![defaults boolForKey:kHideDockIcon]) || (![defaults objectForKey:kHideDockIcon]))) {
+        if (![defaults objectForKey:@"QSShowMenuIcon"])
 			[defaults setInteger:0 forKey:@"QSShowMenuIcon"];
 
             [self setShouldBeUIElement:NO];


### PR DESCRIPTION
If 'Show Dock Icon' has never been set in the prefs, there's no corresponding key in the preferences .plist.
The old behaviour was to show the icon if there was no key, so we should respect this.

I learnt about this problem here: https://twitter.com/sadhuramrourato/status/163805906470047746

The change just shows the dock icon if the pref is set, or if it doesn't exist.
