### PR TITLE
!URGENT ß74 Fix: Show the icon in the dock if users have never changed the setting

### DIFF
--- a/Quicksilver/Code-App/QSApp.m
+++ b/Quicksilver/Code-App/QSApp.m
@@ -59,7 +59,7 @@ BOOL QSApplicationCompletedLaunch = NO;
         
 	// Honor dock hidden preference if new version
 	isUIElement = [self shouldBeUIElement];
-    if (isUIElement && (![defaults objectForKey:kHideDockIcon] || ![defaults boolForKey:kHideDockIcon])) {
+    if (isUIElement && ![defaults boolForKey:kHideDockIcon]) {
         [defaults setObject:[NSNumber numberWithBool:NO] forKey:kHideDockIcon];
         if (![defaults objectForKey:@"QSShowMenuIcon"])
 			[defaults setInteger:0 forKey:@"QSShowMenuIcon"];


### PR DESCRIPTION
If 'Show Dock Icon' has never been set in the prefs, there's no corresponding key in the preferences .plist. The old behaviour was to show the icon if there was no key, so we should respect this.

I learnt about this problem here: https://twitter.com/sadhuramrourato/status/163805906470047746

The change just shows the dock icon if the pref is set, or if it doesn't exist.

P.S. sorry for sending this twice. I wanted to try and make it merge automatically into Quicksilver/release france, but alas it doesn't seem possible. I'll get onto GitHub about it.
