### PR TITLE
Prevent docking windows (shelf and clipboard) from showing on launch

### DIFF
--- a/Quicksilver/Code-QuickStepInterface/QSDockingWindow.m
+++ b/Quicksilver/Code-QuickStepInterface/QSDockingWindow.m
@@ -160,8 +160,6 @@
 }
 
 - (IBAction)hide:(id)sender {
-	if (hidden) return;
-	
 	[self saveFrame];
 	if ([self isKeyWindow])
 		[self fakeResignKey];


### PR DESCRIPTION
On my system, the value for `hidden` was being toggled every time Quicksilver shut down.

I noticed that there wasn’t necessarily an explicit value for `(BOOL)hidden`, but there are several places where behavior is determined by its value.

If `hidden` is initially YES, the plug-ins will still show the window based on the saved state, so this doesn’t break the state-preserving behavior. If it’s initially undefined, then it evaluates to NO (and the plug-ins do nothing to override that), which is what caused the problem.
