### PR TITLE
Sniff all strings to check if they're valid mathematical expressions

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSObject_StringHandling.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject_StringHandling.m
@@ -64,14 +64,21 @@
 	static NSArray *tldArray = nil;
 
 	NSString *stringValue = [self objectForType:QSTextType];
-
-	// A string for the calculator
-	if ([stringValue hasPrefix:@"="]) {
-		[self setObject:stringValue forType:QSFormulaType];
-		[self setObject:nil forType:QSTextType];
-		[self setPrimaryType:QSFormulaType];
-		return;
-	}
+    if (![stringValue length]) {
+        return;
+    }
+    
+    id calculatorHandler = [self handlerForType:QSFormulaType selector:nil];
+    if (calculatorHandler) {
+        QSObject *calculatorResult = [calculatorHandler performCalculation:self];
+        if (![calculatorResult isEqual:self]) {
+            [self setObject:stringValue forType:QSFormulaType];
+            [self setObject:nil forType:QSTextType];
+            [self setDetails:[calculatorResult stringValue]];
+            [self setPrimaryType:QSFormulaType];
+            [self loadIcon];
+         }
+    }
 	
 	// It's an AppleScript
 	if ([stringValue hasPrefix:@"tell app"]) {


### PR DESCRIPTION
This now sniffs
=5_5
5_5
555

and correctly sets them to be formula types

It means there's no _obligation_ to type '=', but you still can to go into text mode.
It also won't assign a QSFormula type unless you have the Calculator Module installed. 

If anybody has any ideas on the warning with `performAction` then that'd be appreciated. Not sure how to get rid of it.
