### PR TITLE
Perform `showEntryInCatalog` method on main thread

### DIFF
--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Code/QSCatalogEntrySource.m
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Code/QSCatalogEntrySource.m
@@ -132,8 +132,8 @@ static NSImage *prefsCatalogImage = nil;
 }
 
 - (QSObject *)show:(QSObject *)dObject {
-	[NSClassFromString(@"QSCatalogPrefPane") showEntryInCatalog:[[QSLibrarian sharedInstance] entryForID:[dObject objectForType:QSCatalogEntryPboardType]]];
-	return nil;
+    [NSClassFromString(@"QSCatalogPrefPane") performSelectorOnMainThread:@selector(showEntryInCatalog:) withObject:[[QSLibrarian sharedInstance] entryForID:[dObject objectForType:QSCatalogEntryPboardType]] waitUntilDone:NO];
+    return nil;
 }
 
 - (QSObject *)rescan:(QSObject *)dObject {

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Code/QSObjectActions.m
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Code/QSObjectActions.m
@@ -77,8 +77,9 @@
 
 	QSCatalogEntry *theEntry = [[QSLibrarian sharedInstance] firstEntryContainingObject:dObject];
 
-	[NSClassFromString(@"QSCatalogPrefPane") showEntryInCatalog:theEntry];
-	return nil;
+    [NSClassFromString(@"QSCatalogPrefPane") performSelectorOnMainThread:@selector(showEntryInCatalog:) withObject:theEntry waitUntilDone:NO];
+    
+    return nil;
 }
 
 - (NSWindow *)windowForObject:(QSObject *)object atPoint:(NSPoint)loc {


### PR DESCRIPTION
Fixes #714

This action needs to run on the main thread or you can get an exception if the QS preferences hasn't been opened previously.
