### PR TITLE
don't hard-code the path to CpMac

### DIFF
--- a/Quicksilver/Tools/buildDMG.pl
+++ b/Quicksilver/Tools/buildDMG.pl
@@ -158,8 +158,8 @@ my ($dest) = ($output =~ /Apple_HFS\s+(.+?)\s*$/im);
 
 # copy the files onto the dmg
 print "Copying files to $dest...\n";
-print "> /Developer/Tools/CpMac -r $files \"$dest\"\n" if $debug;
-$output = `/Developer/Tools/CpMac -r $files \"$dest\"`;
+print "> CpMac -r $files \"$dest\"\n" if $debug;
+$output = `CpMac -r $files \"$dest\"`;
 
 die "FATAL: Error while copying files (Error: $err)\n" if $?;
 


### PR DESCRIPTION
I installed Xcode 4.3 today and everything is moved around. The build fails because `CpMac` is missing.

Anyway, `CpMac` should be in everyone’s path by default. No need to be specific.
