### PR TITLE
Ensure large type text is sized based on screen HEIGHT as well as width

### DIFF
--- a/Quicksilver/Code-QuickStepInterface/QSLargeTypeDisplay.m
+++ b/Quicksilver/Code-QuickStepInterface/QSLargeTypeDisplay.m
@@ -76,9 +76,8 @@ void QSShowLargeType(NSString *aString) {
 		index = NSMaxRange(lineRange);
 	}
 	//NSLog(@"size %f %d %f", height, numberOfLines, numberOfLines*[layoutManager defaultLineHeightForFont:[NSFont boldSystemFontOfSize:size]]);
-	textFrame.size.height = (numberOfLines) *[layoutManager defaultLineHeightForFont:[NSFont boldSystemFontOfSize:size]] + 2*EDGEINSET;
+	textFrame.size.height = (numberOfLines+0.1) *[layoutManager defaultLineHeightForFont:[NSFont boldSystemFontOfSize:size]];
 	textFrame.size.height = MIN(NSHeight(screenRect) -80, NSHeight(textFrame));
-    textFrame.size.width = MIN(NSWidth(screenRect) - 80, textSize.width + 2*EDGEINSET);
 	[textView setFrame:textFrame];
 	//[numberView setAlignment:NSCenterTextAlignment];
 	NSRect windowRect = centerRectInRect(textFrame, screenRect);


### PR DESCRIPTION
Also, change the string name from `number` to `aString`. Makes more sense

If you have a string that is really really long, or has many lies, then Quicksilver would previously not set the font size to ensure all the lines are included in the large type display.

e.g. paste this into QS's 1st pane before, and after this fix.

a
b
c
d
e
f
g
h
i
j
k
