### PR TITLE
Update the list of actionSources for every action added to Quicksilver -...

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSExecutor.m
+++ b/Quicksilver/Code-QuickStepCore/QSExecutor.m
@@ -221,6 +221,9 @@ QSExecutor *QSExec = nil;
 			[[self actionsArrayForFileType:type] addObject:action];
 		}
 	}
+    if ([action bundle] && [[action bundle] bundleIdentifier]) {
+        [[self makeArrayForSource:[[action bundle] bundleIdentifier]] addObject:action];	
+    }
 }
 
 - (void)updateRanks {
@@ -518,7 +521,6 @@ QSExecutor *QSExec = nil;
             
             if (action) {
                 [self addAction:action];
-                [[self makeArrayForSource:[bundle bundleIdentifier]] addObject:action];
             }
         }
 	} else {


### PR DESCRIPTION
... not just those added when loading plugins

This is associated to https://github.com/quicksilver/Services-qsplugin/pull/1 to get the Service Menu Module actions to show under the actions preferences.

Previously, only actions added when loading plugins were put in the `actionSources` array. Now, every action is put there (if it has an associated bundle)
