### PR TITLE
remove the `moreComing` test

### DIFF
--- a/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.h
+++ b/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.h
@@ -73,7 +73,6 @@ typedef enum QSSearchMode {
 	BOOL browsing;
 	BOOL validMnemonic;
 	BOOL hasHistory;
-	BOOL moreComing;
 	BOOL allowText;
 	BOOL allowNonActions;
     

--- a/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
@@ -69,7 +69,6 @@ NSMutableDictionary *bindingsDict = nil;
 	[self setTextCellFontColor:[NSColor blackColor]];
     
 	searchMode = SearchFilterAll;
-	moreComing = NO;
 	[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(hideResultView:) name:@"NSWindowDidResignKeyNotification" object:[self window]];
 	[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(sourceArrayChanged:) name:@"QSSourceArrayUpdated" object:nil];
 	[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(clearAll) name:QSReleaseAllNotification object:nil];
@@ -946,18 +945,13 @@ NSMutableDictionary *bindingsDict = nil;
     
 	double searchDelay = [[NSUserDefaults standardUserDefaults] floatForKey:kSearchDelay];
         
-	if (moreComing) {
-		if ([searchTimer isValid]) [searchTimer invalidate];
-	} else {
-		if (![searchTimer isValid]) {
-			[searchTimer release];
-			searchTimer = [[NSTimer scheduledTimerWithTimeInterval:searchDelay target:self selector:@selector(performSearch:) userInfo:nil repeats:NO] retain];
-		}
-		[searchTimer setFireDate:[NSDate dateWithTimeIntervalSinceNow:searchDelay]];
-        
-		if ([self searchMode] != SearchFilterAll) [searchTimer fire];
-        
+	if (![searchTimer isValid]) {
+		[searchTimer release];
+		searchTimer = [[NSTimer scheduledTimerWithTimeInterval:searchDelay target:self selector:@selector(performSearch:) userInfo:nil repeats:NO] retain];
 	}
+	[searchTimer setFireDate:[NSDate dateWithTimeIntervalSinceNow:searchDelay]];
+	
+	if ([self searchMode] != SearchFilterAll) [searchTimer fire];
 	if (validSearch) {
 		[resultController->searchStringField setTextColor:[NSColor blueColor]];
 	}
@@ -1064,12 +1058,6 @@ NSMutableDictionary *bindingsDict = nil;
 		}
 		[self setShouldResetSearchString:NO];
 	}
-    
-	// check for additional keydowns up to now so the search isn't done too often.
-    moreComing = nil != [NSApp nextEventMatchingMask:NSKeyDownMask untilDate:[NSDate dateWithTimeIntervalSinceNow:SEARCH_RESULT_DELAY] inMode:NSDefaultRunLoopMode dequeue:NO];
-#ifdef DEBUG
-    if (VERBOSE && moreComing) NSLog(@"moreComing");
-#endif
     
 	// ***warning  * have downshift move to indirect object
 	if ([[theEvent charactersIgnoringModifiers] isEqualToString:@"/"] && [self handleSlashEvent:theEvent])


### PR DESCRIPTION
I can’t find a purpose for this check, but it definitely causes a problem (#758).
I’ve been running with this for over a week and haven’t seen any ill effects.

If I understand what it was trying to do (avoid unnecessary expensive searching), this is handled quite well by the “Wait before searching” user preference so it seems redundant. Setting that preference seems to make it wait based on the last keystroke entered (not the first).

It could predate this change, but as I’ve started paying more attention, I’ve never seen Quicksilver faster. No matter how quickly I type, results are in the first pane immediately. So this certainly doesn’t hurt and might speed things up.
