### PR TITLE
don't jump to the second pane unnecessarily

### DIFF
--- a/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
@@ -1486,8 +1486,6 @@ NSMutableDictionary *bindingsDict = nil;
 	if (commandSelector == @selector(insertNewline:) ) {
 		[[self window] makeFirstResponder:self];
 		[[[self window] windowController] executeCommand:self];
-		if ([[self window] isVisible])
-			[[self window] selectKeyViewFollowingView:self];
 		return YES;
 	}
 	if (commandSelector == @selector(complete:) ) {


### PR DESCRIPTION
Finally fixed #283.

The call that was removed would only be reached in very rare circumstances.
1. “Run tasks in background” must be disabled
2. When hitting return to run the action, you must be in text mode.
3. The default action that gets run must display results.

I can’t imagine why that should have triggered a jump to the second pane. This behavior goes back to the initial commit.

If having “Run tasks in background” doesn’t trigger this behavior, and escaping out of text mode before hitting return doesn’t trigger it, it’s hard to make a case that it’s necessary.
