### PR TITLE
Get real localised names of display and fix #789

### DIFF
--- a/Quicksilver/Code-QuickStepFoundation/NSScreen_BLTRExtensions.m
+++ b/Quicksilver/Code-QuickStepFoundation/NSScreen_BLTRExtensions.m
@@ -15,8 +15,6 @@
 //#include <Carbon/Carbon.h>
 #include <ApplicationServices/ApplicationServices.h>
 
-static void KeyArrayCallback(const void *key, const void *value, void *context) { CFArrayAppendValue(context, key);  }
-
 @implementation NSScreen (BLTRExtensions)
 
 + (NSScreen *)screenWithNumber:(int)number {


### PR DESCRIPTION
See http://stackoverflow.com/questions/1236498/how-to-get-the-display-name-with-the-display-id-in-mac-os-x for method used.

Currently, if you install the Displays module and check the modules catalog preset, the names of the displays aren't necessarily in your localised language (I was getting Portuguese, whilst the poster in the above link was getting Japanese).

This change uses a more cocoa-friendly method as per the above discussion. It also removes the function that crashed in #789 potentially fixing the problem.
