### PR TITLE
Force a refresh of plugins when checking for updates

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSPlugInManager.m
+++ b/Quicksilver/Code-QuickStepCore/QSPlugInManager.m
@@ -626,7 +626,7 @@
 	if (!updatedPlugIns) updatedPlugIns = [[NSMutableArray array] retain];
 	else [updatedPlugIns removeAllObjects];
 
-	[self downloadWebPlugInInfoFromDate:plugInWebDownloadDate forUpdateVersion:version synchronously:YES];
+	[self downloadWebPlugInInfoFromDate:nil forUpdateVersion:version synchronously:YES];
 
 	for (QSPlugIn *thisPlugIn in [self knownPlugInsWithWebInfo]) {
 		if ([thisPlugIn needsUpdate]) {


### PR DESCRIPTION
Currently, clicking 'Update Now' in the prefs doesn't necessarily mean you'll get the info on the latest plugins, you have to click the refresh icon in the plugins pref pane first to be sure.
This small change forces an entire refresh of the local plugins list when checking for updates (either manually or by QS automatically)
