### PR TITLE
Recent documents changes

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSObject_FileHandling.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject_FileHandling.m
@@ -43,7 +43,7 @@ NSArray *recentDocumentsForBundle(NSString *bundleIdentifier) {
 	CFPreferencesSynchronize((CFStringRef) [bundleIdentifier stringByAppendingString:@".LSSharedFileList"],
 							 kCFPreferencesCurrentUser,
 							 kCFPreferencesAnyHost);
-	NSDictionary *recentDocuments106 = [(NSArray *)CFPreferencesCopyValue((CFStringRef) @"RecentDocuments",
+	NSDictionary *recentDocuments106 = [(NSDictionary *)CFPreferencesCopyValue((CFStringRef) @"RecentDocuments",
 																		  (CFStringRef) [bundleIdentifier stringByAppendingString:@".LSSharedFileList"],
 																		  kCFPreferencesCurrentUser,
 																		  kCFPreferencesAnyHost) autorelease];


### PR DESCRIPTION
Updated code for showing recent documents when right arrowing into applications:
- Removed pre-10.6 code
- Moved special code for QuickTime Player to its own plugin. See quicksilver/QuickTimePlayer-qsplugin#1
- Added synchronization of preferences, so latest values will be available. Note: The application still has to synchronized its recent documents for them to show up in QS. That's unavoidable. But at least the additional level of delay that was caused by the caching on QS's side is removed with this.
