### PR TITLE
Reinstate the 'load previews' preference (as a hidden preference)

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSObject_FileHandling.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject_FileHandling.m
@@ -330,7 +330,7 @@ NSArray *recentDocumentsForBundle(NSString *bundleIdentifier) {
 	LSCopyItemInfoForURL((CFURLRef) [NSURL fileURLWithPath:path] , kLSRequestBasicFlagsOnly, &infoRec);
 		
 	// try preview icon
-	if (!theImage) {
+	if (!theImage && [[NSUserDefaults standardUserDefaults] boolForKey:@"QSLoadImagePreviews"]) {
 		// do preview icon loading in separate thread (using NSOperationQueue)
 		theImage = [NSImage imageWithPreviewOfFileAtPath:path ofSize:QSMaxIconSize asIcon:YES];
 	}
@@ -351,7 +351,7 @@ NSArray *recentDocumentsForBundle(NSString *bundleIdentifier) {
 	}
 	
 	// try QS's own methods to generate a preview
-	if (!theImage) {
+	if (!theImage && [[NSUserDefaults standardUserDefaults] boolForKey:@"QSLoadImagePreviews"]) {
 		NSString *type = [manager typeOfFile:path];
 		if ([[NSImage imageUnfilteredFileTypes] containsObject:type])
 			theImage = [[[NSImage alloc] initWithContentsOfFile:path] autorelease];

--- a/Quicksilver/Resources/QSDefaults.plist
+++ b/Quicksilver/Resources/QSDefaults.plist
@@ -8,8 +8,8 @@
 	<integer>9</integer>
 	<key>Check for Update Frequency</key>
 	<integer>7</integer>
-    <key>Delay Before Quitting</key>
-    <true/>
+	<key>Delay Before Quitting</key>
+	<true/>
 	<key>QSAccentColor</key>
 	<data>BAt0eXBlZHN0cmVhbYED6IQBQISEhAdOU0NvbG9yAISECE5TT2JqZWN0AIWEAWMGhANAQECEhIQITlNTdHJpbmcBlIQBKwZTeXN0ZW2GhJaYFHNlbGVjdGVkQ29udHJvbENvbG9yhoSTlQOEAmZmAQGGhg==</data>
 	<key>QSActionAppReopenBehavior</key>
@@ -51,6 +51,8 @@
 	<string>QSBezelInterfaceController</string>
 	<key>QSFSBrowserMediators</key>
 	<string>com.apple.finder</string>
+	<key>QSLoadImagePreviews</key>
+	<true/>
 	<key>QSNotifiers</key>
 	<string>com.blacktree.Quicksilver</string>
 	<key>QSResultViewRowHeight</key>


### PR DESCRIPTION
This basically re-adds the code changes from dbafefff437606a50dca38adf2fb3ec1ffb01c90
One user claimed that QS is now almost completely unusable for him [see here](http://blog.qsapp.com/post/21225132753/quicksilver-makes-itself-clear#comment-499287965) since this setting got removed.

It'll now be a hidden prefs and is shown here: http://qsapp.com/wiki/Hidden_Defaults
