### PR TITLE
Revert "If the current actions array and the new actions array are the s...

### DIFF
--- a/Quicksilver/Code-QuickStepInterface/QSInterfaceController.m
+++ b/Quicksilver/Code-QuickStepInterface/QSInterfaceController.m
@@ -298,22 +298,16 @@
 }
 
 - (void)updateActionsNow {
-    NSArray *actions = [self rankedActions];
-    // Don't reload the 2nd pane if the actions are identical
-    if ([actions isEqualToArray:[aSelector resultArray]]) {
-        return;
-    }
-
     // Clear the current results in the aSelector ready for the new results
     [aSelector setResultArray:nil];
     [aSelector clearObjectValue];
 	[actionsUpdateTimer invalidate];
 
 	[aSelector setEnabled:YES];
+	NSString *type = [NSString stringWithFormat:@"QSActionMnemonic:%@", [[dSelector objectValue] primaryType]];
+	NSArray *actions = [self rankedActions];
 
-    [self updateControl:aSelector withArray:actions];
-
-    NSString *type = [NSString stringWithFormat:@"QSActionMnemonic:%@", [[dSelector objectValue] primaryType]];
+	[self updateControl:aSelector withArray:actions];
 
 	[aSelector setMatchedString:type];
 	[aSelector setSearchString:nil];


### PR DESCRIPTION
...ame, don't update the 2nd pane"

Revert an over-ambitious optimisation
This reverts commit b7a9a87eb5aabdccf8d6c8e68ab843d4d3bd2bcf.

The optimisation meant that if the 1st pane object was the same (hadn't changed) or the sam type (e.g. web searches) the lift of actions wasn't getting updated.

This was causes the following two problems:
- The action icon was not updating properly
- 3rd pane contents were not being updated
