### PR TITLE
Validate all setObject:ForKey: methods in QSObject.m to ensure nil isn't...

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSObject.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject.m
@@ -279,9 +279,7 @@ NSSize QSMaxIconSize;
 	// Create the 'combined' object
 	QSObject *object = [[[QSObject alloc] init] autorelease];
 	[object setDataDictionary:combinedData];
-    if (objects) {
-        [object setObject:objects forCache:kQSObjectComponents];
-    }
+    [object setObject:objects forCache:kQSObjectComponents];
 	if ([combinedData objectForKey:QSFilePathType])
 		// try to guess a name based on the file types
 		[object guessName];
@@ -462,8 +460,13 @@ NSSize QSMaxIconSize;
 }
 
 - (void)setObject:(id)object forCache:(id)aKey {
-    if (object && aKey) {
+    if (!aKey) {
+        return;
+    }
+    if (object) {
         [[self cache] setObject:object forKey:aKey];
+    } else {
+        [[self cache] removeObjectForKey:aKey];
     }
 }
 
@@ -472,8 +475,14 @@ NSSize QSMaxIconSize;
 }
 
 - (void)setObject:(id)object forMeta:(id)aKey {
-    if (object && aKey)
+    if (!aKey) {
+        return;
+    }
+    if (object) {
         [meta setObject:object forKey:aKey];
+    } else {
+        [meta removeObjectForKey:aKey];
+    }
 }
 
 - (NSMutableDictionary *)cache {


### PR DESCRIPTION
... being set

There was a crash report with the following info. It could possible be because the method `setObject:anObject forKey:aKey` had a nil `anObject` or `aKey`. Even if that's not the cause of the crash, we shouldn't try and use the methods if either of the parameters are nil.

From the docs...

> Raises an NSInvalidArgumentException if aKey or anObject is nil. If you need to represent a nil value in the dictionary, use NSNull.

```
Version:         ß68 (3927)
Code Type:       X86 (Native)
Parent Process:  ??? [1]

Date/Time:       2012-05-10 18:19:17.851 -0400
OS Version:      Mac OS X 10.7.3 (11D50b)
Report Version:  9

Crashed Thread:  4

Exception Type:  EXC_BAD_ACCESS (SIGSEGV)
Exception Codes: KERN_INVALID_ADDRESS at 0x0000000069746361

VM Regions Near 0x69746361:
    CG raster data         000000000cf95000-000000000cfa6000 [   68K] rw-/rwx SM=COW  
--> 
    __TEXT                 000000008fe89000-000000008febc000 [  204K] r-x/rwx SM=CO

Thread 4 Crashed:
0   libobjc.A.dylib                 0x97908d47 objc_msgSend + 23
1   com.apple.CoreFoundation        0x938072d9 CFRelease + 169
2   com.apple.CoreFoundation        0x9381580f __CFDictionaryStandardReleaseKey + 79
3   com.apple.CoreFoundation        0x9380c8e1 __CFBasicHashAddValue + 1377
4   com.apple.CoreFoundation        0x9380c317 CFBasicHashSetValue + 2759
5   com.apple.CoreFoundation        0x9380b804 CFDictionarySetValue + 228
6   com.apple.CoreFoundation        0x93864122 -[__NSCFDictionary setObject:forKey:] + 306
7   com.blacktree.QSCore            0x000ae6b9 -[QSObject setObject:forMeta:] + 55
8   com.blacktree.QSCore            0x000a0edf -[QSCatalogEntry scannedObjects] + 208
```
