### PR TITLE
Respect the user's setting for '32 bit mode' when relaunching

### DIFF
--- a/Quicksilver/Code-QuickStepFoundation/NSApplication_BLTRExtensions.m
+++ b/Quicksilver/Code-QuickStepFoundation/NSApplication_BLTRExtensions.m
@@ -120,7 +120,8 @@
 	sprintf(pidstr, "%d", getpid() );
 	setenv("relaunchFromPid", pidstr, YES);
 	[[NSNotificationCenter defaultCenter] postNotificationName:QSApplicationWillRelaunchNotification object:self userInfo:nil];
-	[NSTask launchedTaskWithLaunchPath:path arguments:[NSArray array]];
+    NSString *arch = @"/usr/bin/arch";
+	[NSTask launchedTaskWithLaunchPath:arch arguments:[NSArray arrayWithObjects:@"-i386", @"-x86_64", path,nil]];
 
 	[self terminate:self];
 }


### PR DESCRIPTION
Use `/usr/bin/arch` to launch the new application as opposed to just launching it straight off.

See http://superuser.com/questions/314266/launch-application-from-osx-terminal-in-32bit-mode
