### PR TITLE
General tidyups and bug fixes. Fixes #948

### DIFF
--- a/Quicksilver/Code-QuickStepFoundation/NSString_BLTRExtensions.m
+++ b/Quicksilver/Code-QuickStepFoundation/NSString_BLTRExtensions.m
@@ -176,7 +176,8 @@ NSComparisonResult prefixCompare(NSString *aString, NSString *bString) {
 	NSString *replacedString = [self stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
 	// Try Cocoa's way of replacing % escapes
 	if (replacedString !=nil) {
-		// Return the replaced string if Cocoa's method works
+		// Return the replaced string if Cocoa's method works, but we don't want to decode the '+' symbol
+        replacedString = [replacedString stringByReplacingOccurrencesOfString:@"%2B" withString:@"+"];
 		return replacedString;
 	}
 	else {

--- a/Quicksilver/Code-QuickStepInterface/QSInterfaceController.m
+++ b/Quicksilver/Code-QuickStepInterface/QSInterfaceController.m
@@ -321,7 +321,7 @@
 
 - (void)updateViewLocations {
     QSAction *obj = [aSelector objectValue];
-	if (([obj respondsToSelector:@selector(argumentCount)]) && ([obj argumentCount] == 2))
+	if (obj && ([obj respondsToSelector:@selector(argumentCount)]) && ([obj argumentCount] == 2))
 		[self showIndirectSelector:nil];
 	else
 		[self hideIndirectSelector:nil];
@@ -397,6 +397,9 @@
 	[[self window] disableFlushWindow];
 	if ([notif object] == dSelector) {
             [iSelector setObjectValue:nil];
+        if (![dSelector objectValue]) {
+            [aSelector setObjectValue:nil];
+        }
             [self updateActions];
             [self updateViewLocations];
 	} else if ([notif object] == aSelector) {

--- a/Quicksilver/Code-QuickStepInterface/QSResizingInterfaceController.h
+++ b/Quicksilver/Code-QuickStepInterface/QSResizingInterfaceController.h
@@ -1,15 +1,13 @@
 
-
 #import <Foundation/Foundation.h>
 
 #import "QSInterfaceController.h"
 
 @interface QSResizingInterfaceController : QSInterfaceController {
 	BOOL expanded;
-	NSTimer *expandTimer;
 }
 - (void)firstResponderChanged:(NSResponder *)aResponder;
-- (void)resetAdjustTimer;
+- (void)resetAdjustTimer DEPRECATED_ATTRIBUTE;
 - (void)expandWindow:(id)sender;
 - (void)contractWindow:(id)sender;
 

--- a/Quicksilver/Code-QuickStepInterface/QSResizingInterfaceController.m
+++ b/Quicksilver/Code-QuickStepInterface/QSResizingInterfaceController.m
@@ -10,7 +10,6 @@
 - (id)initWithWindowNibName:(NSString *)nib {
 	self = [super initWithWindowNibName:nib];
 	if (self) {
-		expandTimer = nil;
 		expanded = YES;
 	}
 	return self;
@@ -18,25 +17,16 @@
 
 - (void)showIndirectSelector:(id)sender {
 	[super showIndirectSelector:sender];
-	[self resetAdjustTimer];
+	[self adjustWindow:nil];
 }
 - (void)hideIndirectSelector:(id)sender {
 	[super hideIndirectSelector:sender];
-	[self resetAdjustTimer];
+	[self adjustWindow:nil];
 }
 
 - (void)resetAdjustTimer {
-
-	if ([[self window] isVisible]) {
-		if (![expandTimer isValid]) {
-			[expandTimer release];
-			expandTimer = [[NSTimer scheduledTimerWithTimeInterval:0.1 target:self selector:@selector(adjustWindow:) userInfo:nil repeats:NO] retain];
-		} else {
-			[expandTimer setFireDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];
-		}
-	} else {
-		[self adjustWindow:self];
-	}
+    NSLog(@"This method is deprecated, call [self adjustWindow:nil] instead\nUsing interface: %@",[[NSUserDefaults standardUserDefaults] stringForKey:@"QSCommandInterfaceControllers"]);
+    [self adjustWindow:nil];
 }
 
 - (void)adjustWindow:(id)sender {
@@ -67,14 +57,7 @@
 }
 
 - (void)firstResponderChanged:(NSResponder *)aResponder {
-	if (aResponder == iSelector || aResponder == [iSelector currentEditor]) {
-		QSAction *action = (QSAction *)[aSelector objectValue];
-		NSInteger argumentCount = [action argumentCount];
-		BOOL indirectOptional = [action indirectOptional];
-		
-		if (argumentCount == 2 && indirectOptional)
-			[self adjustWindow:self];
-	}
+    [self adjustWindow:nil];
 }
 
 - (void)expandWindow:(id)sender {

--- a/Quicksilver/Code-QuickStepInterface/QSResultController.m
+++ b/Quicksilver/Code-QuickStepInterface/QSResultController.m
@@ -617,6 +617,11 @@ NSMutableDictionary *kindDescriptions = nil;
 	if ([[aTableColumn identifier] isEqualToString:COLUMNID_NAME]) {
 		NSArray *array = [self currentResults];
 		if (aTableView == resultChildTable) array = [selectedItem children];
+        
+        // avoid attempting to access objects in a nonexistent array or an index out of bounds
+        if (!array || rowIndex >= (NSInteger)[array count]) {
+            return;
+        }
 		QSObject *thisObject = [array objectAtIndex:rowIndex];
 
 		[aCell setRepresentedObject:thisObject];
@@ -625,6 +630,9 @@ NSMutableDictionary *kindDescriptions = nil;
 	if ([[aTableColumn identifier] isEqualToString:COLUMNID_RANK]) {
 		NSArray *array = [self currentResults];
 
+        if (!array || rowIndex >= (NSInteger)[array count]) {
+            return;
+        }
 		QSRankedObject *thisObject = [array objectAtIndex:rowIndex];
 
 		[(QSRankCell *)aCell setScore:[thisObject score]];

--- a/Quicksilver/PlugIns-Main/PrimerInterface/QSPrimerInterfaceController.m
+++ b/Quicksilver/PlugIns-Main/PrimerInterface/QSPrimerInterfaceController.m
@@ -113,7 +113,7 @@
 
 	[indirectView setHidden:YES];
 
-	[self resetAdjustTimer];
+	[self adjustWindow:nil];
 }
 
 
@@ -125,7 +125,7 @@
 
 		//  [super showIndirectSelector:sender];
 
-		[self resetAdjustTimer];
+		[self adjustWindow:nil];
 	}
 }
 


### PR DESCRIPTION
- Properly clear the 2nd pane/1st pane when setting objects
- Remove the resize timer - improves 'snappiness' and fixes #948
- Avoid some crashes/exceptions
- Don't encode the '+' character in the URLEncoding method - it's a valid char (e.g. for searches)
