### PR TITLE
remove redundant xcconfig files

### DIFF
--- a/Quicksilver/Configuration/QSPlugIn_Debug.xcconfig
+++ b/Quicksilver/Configuration/QSPlugIn_Debug.xcconfig
@@ -1,2 +1,0 @@
-#include "Debug.xcconfig"
-#include "QSPlugIn.xcconfig"

--- a/Quicksilver/Configuration/QSPlugIn_Release.xcconfig
+++ b/Quicksilver/Configuration/QSPlugIn_Release.xcconfig
@@ -1,2 +1,0 @@
-#include "Release.xcconfig"
-#include "QSPlugIn.xcconfig"

--- a/Quicksilver/Quicksilver.xcodeproj/project.pbxproj
+++ b/Quicksilver/Quicksilver.xcodeproj/project.pbxproj
@@ -1114,8 +1114,6 @@
 		4D66BC3A1487024500351C42 /* NDScriptData.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NDScriptData.m; sourceTree = "<group>"; };
 		4D66BC3B1487024500351C42 /* NSString+NDUtilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSString+NDUtilities.h"; sourceTree = "<group>"; };
 		4D66BC3C1487024500351C42 /* NSString+NDUtilities.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSString+NDUtilities.m"; sourceTree = "<group>"; };
-		4D7A90010E39E7B400A7E6BE /* QSPlugIn_Release.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = QSPlugIn_Release.xcconfig; sourceTree = "<group>"; };
-		4D7A90020E39E7C200A7E6BE /* QSPlugIn_Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = QSPlugIn_Debug.xcconfig; sourceTree = "<group>"; };
 		4D89177614758620009C1C14 /* English */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = English; path = English.lproj/QSMainMenuPrefPane.strings; sourceTree = "<group>"; };
 		4D89177814758641009C1C14 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/QSMainMenuPrefPane.strings; sourceTree = "<group>"; };
 		4D89177C14758DC6009C1C14 /* English */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = English; path = English.lproj/QSApplicationPrefPane.strings; sourceTree = "<group>"; };
@@ -2077,8 +2075,6 @@
 				4DC3DD0D0E0BB27B009902EF /* Debug.xcconfig */,
 				4DA1CCCF0E0BB61100CA6002 /* Developer.xcconfig */,
 				4DC3DD110E0BB27B009902EF /* QSPlugIn.xcconfig */,
-				4D7A90020E39E7C200A7E6BE /* QSPlugIn_Debug.xcconfig */,
-				4D7A90010E39E7B400A7E6BE /* QSPlugIn_Release.xcconfig */,
 				4D002D52131147FF009040B7 /* Quicksilver.pch */,
 				4DC3DD130E0BB27B009902EF /* Release.xcconfig */,
 			);
@@ -4771,7 +4767,7 @@
 /* Begin XCBuildConfiguration section */
 		4D002D041311465B009040B7 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4D7A90020E39E7C200A7E6BE /* QSPlugIn_Debug.xcconfig */;
+			baseConfigurationReference = 4DC3DD110E0BB27B009902EF /* QSPlugIn.xcconfig */;
 			buildSettings = {
 				INFOPLIST_FILE = "PlugIns-Main/Bezel/Info.plist";
 				PRODUCT_NAME = "Bezel Interface";
@@ -4780,7 +4776,7 @@
 		};
 		4D002D051311465B009040B7 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4D7A90010E39E7B400A7E6BE /* QSPlugIn_Release.xcconfig */;
+			baseConfigurationReference = 4DC3DD110E0BB27B009902EF /* QSPlugIn.xcconfig */;
 			buildSettings = {
 				INFOPLIST_FILE = "PlugIns-Main/Bezel/Info.plist";
 				PRODUCT_NAME = "Bezel Interface";
@@ -4789,7 +4785,7 @@
 		};
 		4D002D63131148C3009040B7 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4D7A90020E39E7C200A7E6BE /* QSPlugIn_Debug.xcconfig */;
+			baseConfigurationReference = 4DC3DD110E0BB27B009902EF /* QSPlugIn.xcconfig */;
 			buildSettings = {
 				INFOPLIST_FILE = "PlugIns-Main/Finder/Info.plist";
 				PRODUCT_NAME = "Finder Module";
@@ -4798,7 +4794,7 @@
 		};
 		4D002D64131148C3009040B7 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4D7A90010E39E7B400A7E6BE /* QSPlugIn_Release.xcconfig */;
+			baseConfigurationReference = 4DC3DD110E0BB27B009902EF /* QSPlugIn.xcconfig */;
 			buildSettings = {
 				INFOPLIST_FILE = "PlugIns-Main/Finder/Info.plist";
 				PRODUCT_NAME = "Finder Module";
@@ -4807,7 +4803,7 @@
 		};
 		4D002D8A131149A4009040B7 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4D7A90020E39E7C200A7E6BE /* QSPlugIn_Debug.xcconfig */;
+			baseConfigurationReference = 4DC3DD110E0BB27B009902EF /* QSPlugIn.xcconfig */;
 			buildSettings = {
 				INFOPLIST_FILE = "PlugIns-Main/PrimerInterface/Info.plist";
 				PRODUCT_NAME = "Primer Interface";
@@ -4816,7 +4812,7 @@
 		};
 		4D002D8B131149A4009040B7 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4D7A90010E39E7B400A7E6BE /* QSPlugIn_Release.xcconfig */;
+			baseConfigurationReference = 4DC3DD110E0BB27B009902EF /* QSPlugIn.xcconfig */;
 			buildSettings = {
 				INFOPLIST_FILE = "PlugIns-Main/PrimerInterface/Info.plist";
 				PRODUCT_NAME = "Primer Interface";
@@ -4825,7 +4821,7 @@
 		};
 		4D002DAF13114A2E009040B7 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4D7A90020E39E7C200A7E6BE /* QSPlugIn_Debug.xcconfig */;
+			baseConfigurationReference = 4DC3DD110E0BB27B009902EF /* QSPlugIn.xcconfig */;
 			buildSettings = {
 				INFOPLIST_FILE = "PlugIns-Main/QSHotKeyPlugIn/Info.plist";
 				PRODUCT_NAME = "HotKey Triggers";
@@ -4834,7 +4830,7 @@
 		};
 		4D002DB013114A2E009040B7 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4D7A90010E39E7B400A7E6BE /* QSPlugIn_Release.xcconfig */;
+			baseConfigurationReference = 4DC3DD110E0BB27B009902EF /* QSPlugIn.xcconfig */;
 			buildSettings = {
 				INFOPLIST_FILE = "PlugIns-Main/QSHotKeyPlugIn/Info.plist";
 				PRODUCT_NAME = "HotKey Triggers";
@@ -5270,7 +5266,7 @@
 		};
 		7F6B3E64085CE68E000735A8 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4D7A90020E39E7C200A7E6BE /* QSPlugIn_Debug.xcconfig */;
+			baseConfigurationReference = 4DC3DD110E0BB27B009902EF /* QSPlugIn.xcconfig */;
 			buildSettings = {
 				INFOPLIST_FILE = "PlugIns-Main/QSCorePlugIn/QSCorePlugIn-Info.plist";
 				PRODUCT_NAME = "Core Support";
@@ -5279,7 +5275,7 @@
 		};
 		7F6B3E65085CE68E000735A8 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4D7A90010E39E7B400A7E6BE /* QSPlugIn_Release.xcconfig */;
+			baseConfigurationReference = 4DC3DD110E0BB27B009902EF /* QSPlugIn.xcconfig */;
 			buildSettings = {
 				INFOPLIST_FILE = "PlugIns-Main/QSCorePlugIn/QSCorePlugIn-Info.plist";
 				PRODUCT_NAME = "Core Support";


### PR DESCRIPTION
Just for simplification. I’ve already discussed this with @pjrobertson on IRC.

The removed files just combine Debug/Release with QSPlugIn. Since the Debug/Release configs are already included at the project level, all the targets really need is the QSPlugIn config.

There are several plug-ins referring to the QSPlugIn_Debug and QSPlugIn_Release files, but the surest way to see that we fix that is to not give us a choice. :-)

If these files are necessary for reasons I’m not aware of, let me know.
