### PR TITLE
Set direct file types

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSAction.h
+++ b/Quicksilver/Code-QuickStepCore/QSAction.h
@@ -2,45 +2,6 @@
 #import <QSCore/QSObject.h>
 #import <QSCore/QSObjectRanker.h>
 
-/* TODO : Split this in QSAppleScript action ? */
-
-// strings:
-#define kActionClass                @"actionClass"
-#define kActionProvider             @"actionProvider"
-#define kActionSelector             @"actionSelector"
-#define kActionSendMessageToClass   @"actionSendToClass"
-#define kActionAlternate            @"alternateAction"
-#define kActionScript               @"actionScript"
-#define kActionHandler              @"actionHandler"
-#define kActionEventClass           @"actionEventClass"
-#define kActionEventID              @"actionEventID"
-
-#define kActionArgumentCount        @"argumentCount" // Number, if undefined, calculates from selector
-
-// strings:
-#define kActionIcon                 @"icon"
-#define kActionName                 @"name"
-#define kActionUserData             @"userData"
-#define kActionIdentifier           @"id"
-
-// arrays:
-#define kActionDirectTypes          @"directTypes"
-#define kActionIndirectTypes        @"indirectTypes"
-#define kActionResultType           @"resultTypes" // Unused ?
-
-// BOOLs:
-#define kActionRunsInMainThread     @"runInMainThread"
-#define kActionDisplaysResult       @"displaysResult"
-#define kActionIndirectOptional     @"indirectOptional"
-#define kActionReverseArguments     @"reverseArguments"
-#define kActionSplitPluralArguments @"splitPlural"
-#define kActionValidatesObjects     @"validatesObjects"
-#define kActionInitialize           @"initialize"
-#define kActionEnabled              @"enabled"
-
-// NSNumber (float) :
-#define kActionPrecedence @"precedence"
-
 @interface QSAction : QSObject {
 	NSInteger rank;
 }
@@ -90,8 +51,10 @@
 
 - (NSArray*)directTypes;
 - (void)setDirectTypes:(NSArray*)types;
+- (NSArray*)directFileTypes;
+- (void)setDirectFileTypes:(NSArray *)types;
 - (NSArray*)indirectTypes;
-- (void)setIndirectTypes:(NSArray*)types;
+- (void)setIndirectTypes:(NSArray *)types;
 /*- (NSArray*)resultTypes;
 - (void)setResultTypes:(NSArray*)types;*/
 

--- a/Quicksilver/Code-QuickStepCore/QSAction.m
+++ b/Quicksilver/Code-QuickStepCore/QSAction.m
@@ -251,6 +251,14 @@ static BOOL gModifiersAreIgnored;
     [[self actionDict] setObject:types forKey:kActionDirectTypes];
 }
 
+- (NSArray*)directFileTypes {
+    return [[self actionDict] objectForKey:kActionDirectFileTypes];
+}
+
+- (void)setDirectFileTypes:(NSArray *)types {
+    [[self actionDict] setObject:types forKey:kActionDirectFileTypes];
+}
+
 - (NSArray*)indirectTypes {
     return [[self actionDict] objectForKey:kActionIndirectTypes];
 }

--- a/Quicksilver/Code-QuickStepCore/QSDefines.h
+++ b/Quicksilver/Code-QuickStepCore/QSDefines.h
@@ -1,9 +1,57 @@
+#pragma mark User Agent
 
 #define kQSUserAgent [NSString stringWithFormat:@"Quicksilver/%@ OSX/%@ (%@)",\
 					 (NSString *)CFBundleGetValueForInfoDictionaryKey(CFBundleGetMainBundle(), kCFBundleVersionKey),\
 					 [NSApplication macOSXFullVersion], @"x86"]
 
+#pragma mark Search URLs
+
 #define QUERY_KEY @"***"
+
+#pragma mark Syncrhonous Results
+
 #define kQSResultArrayKey @"resultArray"
 
+#pragma mark Bundle ID
+
 #define kQSBundleID @"com.blacktree.Quicksilver"
+
+#pragma mark Actions
+
+// strings:
+#define kActionClass                @"actionClass"
+#define kActionProvider             @"actionProvider"
+#define kActionSelector             @"actionSelector"
+#define kActionSendMessageToClass   @"actionSendToClass"
+#define kActionAlternate            @"alternateAction"
+#define kActionScript               @"actionScript"
+#define kActionHandler              @"actionHandler"
+#define kActionEventClass           @"actionEventClass"
+#define kActionEventID              @"actionEventID"
+
+#define kActionArgumentCount        @"argumentCount" // Number, if undefined, calculates from selector
+
+// strings:
+#define kActionIcon                 @"icon"
+#define kActionName                 @"name"
+#define kActionUserData             @"userData"
+#define kActionIdentifier           @"id"
+
+// arrays:
+#define kActionDirectTypes          @"directTypes"
+#define kActionDirectFileTypes      @"directFileTypes"
+#define kActionIndirectTypes        @"indirectTypes"
+#define kActionResultType           @"resultTypes" // Unused ?
+
+// BOOLs:
+#define kActionRunsInMainThread     @"runInMainThread"
+#define kActionDisplaysResult       @"displaysResult"
+#define kActionIndirectOptional     @"indirectOptional"
+#define kActionReverseArguments     @"reverseArguments"
+#define kActionSplitPluralArguments @"splitPlural"
+#define kActionValidatesObjects     @"validatesObjects"
+#define kActionInitialize           @"initialize"
+#define kActionEnabled              @"enabled"
+
+// NSNumber (float) :
+#define kActionPrecedence @"precedence"

--- a/Quicksilver/Code-QuickStepCore/QSExecutor.m
+++ b/Quicksilver/Code-QuickStepCore/QSExecutor.m
@@ -208,14 +208,14 @@ QSExecutor *QSExec = nil;
 		[action _setRank:index];
 	}
 	NSDictionary *actionDict = [action objectForType:QSActionType];
-	NSArray *directTypes = [actionDict objectForKey:@"directTypes"];
+	NSArray *directTypes = [actionDict objectForKey:kActionDirectTypes];
 	if (![directTypes count]) directTypes = [NSArray arrayWithObject:@"*"];
 	for (NSString *type in directTypes) {
         [[self actionsArrayForType:type] addObject:action];
     }
     
 	if ([directTypes containsObject:QSFilePathType]) {
-		directTypes = [actionDict objectForKey:@"directFileTypes"];
+		directTypes = [actionDict objectForKey:kActionDirectFileTypes];
 		if (![directTypes count]) directTypes = [NSArray arrayWithObject:@"*"];
 		for (NSString *type in directTypes) {
 			[[self actionsArrayForFileType:type] addObject:action];


### PR DESCRIPTION
This allows direct file types to be set programmatically, as opposed to just in the Info.plist. Used in the (updated) Services Menu Module (which I will release once this is merged)

I've set this to commit to the 'release' branch as I'd like to see it in with the 64 bit stuff so I can get a new Services Menu Plugin out at the same time
