### PR TITLE
Set search mode

### DIFF
--- a/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
@@ -337,7 +337,7 @@ NSMutableDictionary *bindingsDict = nil;
 - (QSSearchMode)searchMode { return searchMode;  }
 - (void)setSearchMode:(QSSearchMode)newSearchMode {
 	// Do not allow the setting of 'Filter Catalog' when in the aSelector (action)
-	if (!([[self class] isEqual:[QSSearchObjectView class]] && newSearchMode == SearchFilterAll)) {
+	if (!((self == [self actionSelector]) && newSearchMode == SearchFilterAll)) {
 		searchMode = newSearchMode;
 	}
 	


### PR DESCRIPTION
For some reason the dSelector and iSelector for certain interfaces are QSSearchObjectViews not QSCollectingSearchObjectViews (I guess because they don't support the comma trick)

As such, testing by class was causing problems setting the 'filter catalog' setting for the 1st and 3rd panes.
It's better to explicitly test for the aSelector (2nd pane)

see https://groups.google.com/forum/?fromgroups#!topic/blacktree-quicksilver/PNkT00yQVmo

It'd be good if this could be merged into release as it's small, and will mean several interfaces will be fixed
