### PR TITLE
When there's no internet connection, return the original items for web sources, fixes #634

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSParser.m
+++ b/Quicksilver/Code-QuickStepCore/QSParser.m
@@ -26,17 +26,21 @@
 
 - (NSArray *)objectsFromURL:(NSURL *)url withSettings:(NSDictionary *)settings {
  // NSData *data = [NSData dataWithContentsOfURL:url];
-	NSError *error;
+	NSError *error = nil;
 
 	NSMutableURLRequest *theRequest = [NSMutableURLRequest requestWithURL:url
 															cachePolicy:NSURLRequestUseProtocolCachePolicy
-														timeoutInterval:10.0];
+														timeoutInterval:5.0];
 	[theRequest setValue:kQSUserAgent forHTTPHeaderField:@"User-Agent"];
 	NSStringEncoding encoding = NSUTF8StringEncoding;
 
 	NSURLResponse *response = nil;
 	//if (VERBOSE) NSLog(@"Downloading from %@", url);
 	NSData *data = [NSURLConnection sendSynchronousRequest:theRequest returningResponse:&response error:&error];
+    // in the case where an error occurred, returning 'nil' causes the original catalog entry contents to be returned (see QSWebSource ojectsForEntry: )
+    if (error) {
+        return nil;
+    }
 	  if ([response textEncodingName])
 		  encoding = CFStringConvertEncodingToNSStringEncoding(CFStringConvertIANACharSetNameToEncoding((CFStringRef) [response textEncodingName]));
 //if (VERBOSE) NSLog(@"Downloading complete - %@", url);

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Code/QSWebSource.m
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Code/QSWebSource.m
@@ -24,10 +24,16 @@
 - (NSArray *)objectsForEntry:(NSDictionary *)theEntry {
 	NSMutableDictionary *settings = [theEntry objectForKey:kItemSettings];
 	NSString *location = [settings objectForKey:kItemPath];
-	if (location)
-		return [(QSHTMLLinkParser *)[QSReg getClassInstance:@"QSHTMLLinkParser"] objectsFromURL:[NSURL URLWithString:location] withSettings:settings];
-	else
-		return nil;
+	if (location) {
+		NSArray *contents = [(QSHTMLLinkParser *)[QSReg getClassInstance:@"QSHTMLLinkParser"] objectsFromURL:[NSURL URLWithString:location] withSettings:settings];
+        if (!contents) {
+            // return the original contents of the catalog entry if there was a problem getting data from the internet
+            return [[QSLib entryForID:[theEntry objectForKey:kItemID]] _contents];
+        } else {
+            return contents;    
+        }
+    }
+    return nil;
 }
 
 - (BOOL)indexIsValidFromDate:(NSDate *)indexDate forEntry:(NSDictionary *)theEntry {


### PR DESCRIPTION
Unfortunately, as suggested by @skurfer in #634, altering the `indexIsValidFromDate:forEntry` method won't work because it is already set to return `YES` always.

The solution is to check for an error when retrieving internet contents - if there is one, then return the original catalog entry items.
This doesn't affect the behaviour if a web source is valid, but returns no results. In that case an empty array (`[NSArray array]`) is returned, and the catalog entry is actually set to have 0 contents.
