### PR TITLE
Don't activate text mode when QS is 'browsing'

### DIFF
--- a/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
@@ -867,10 +867,12 @@ NSMutableDictionary *bindingsDict = nil;
 			}
 		}
 	} else {
-		if ([[NSUserDefaults standardUserDefaults] boolForKey:@"QSTransformBadSearchToText"])
+        if ([[NSUserDefaults standardUserDefaults] boolForKey:@"QSTransformBadSearchToText"] && [self searchMode] == SearchFilterAll) {
+            // activate text mode if the prefs setting is set and QS is in the 'Search Catalog' mode
 			[self transmogrifyWithText:partialString];
-		else
+		} else { 
 			NSBeep();
+        }
         
 		validMnemonic = NO;
 		[resultController->searchStringField setTextColor:[NSColor redColor]];


### PR DESCRIPTION
Only applicable when the "switch to text mode when no match is found" option is ticked in the prefs (yes, I've just started using it! But it does have its annoying quirks...)
