### PR TITLE
obscure the true location of iCloud documents

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSObject_FileHandling.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject_FileHandling.m
@@ -189,10 +189,13 @@ NSArray *recentDocumentsForBundle(NSString *bundleIdentifier) {
 	NSArray *theFiles = [object arrayForType:QSFilePathType];
 	if ([theFiles count] == 1) {
 		NSString *path = [theFiles lastObject];
-		if ([path hasPrefix:NSTemporaryDirectory()])
+		if ([path hasPrefix:NSTemporaryDirectory()]) {
 			return [@"(Quicksilver) " stringByAppendingPathComponent:[path lastPathComponent]];
-		else
+		} else if ([path hasPrefix:[@"~/Library/Mobile Documents/" stringByStandardizingPath]]) {
+			return @"iCloud";
+		} else {
 			return [path stringByAbbreviatingWithTildeInPath];
+		}
 	} else if ([theFiles count] >1) {
 		return [[theFiles arrayByPerformingSelector:@selector(lastPathComponent)] componentsJoinedByString:@", "];
 	}


### PR DESCRIPTION
To be consistent with Finder’s Info panel for these files, show “iCloud” instead of the full path.

No, users aren’t supposed to go poking around in that directory, and most probably won’t. However, these files are very likely to appear as recent documents when right-arrowing into an application.
