### PR TITLE
Disable the "Quicksilver Catalog Entries" catalog entry by default.

### DIFF
--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/QSCorePlugIn-Info.plist
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/QSCorePlugIn-Info.plist
@@ -529,6 +529,8 @@
 					<string>QSCatalogEntrySource</string>
 					<key>ID</key>
 					<string>QSPresetQSCatalogEntries</string>
+					<key>enabled</key>
+					<false/>
 				</dict>
 				<dict>
 					<key>source</key>


### PR DESCRIPTION
Fixes #1039

Tiniest change. Doesn't really warrant its own issue :)
