### PR TITLE
do not add actions that are for applications only to the files & folders...

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSExecutor.m
+++ b/Quicksilver/Code-QuickStepCore/QSExecutor.m
@@ -126,7 +126,7 @@ QSExecutor *QSExec = nil;
 	NSMutableSet *set = [NSMutableSet set];
 	for (NSString *type in types) {
 		if ([type isEqualToString:QSFilePathType]) {
-			[set addObjectsFromArray:[self actionsForFileTypes:fileTypes]];
+            [set addObjectsFromArray:[self actionsForFileTypes:fileTypes]];
 		} else {
 			[set addObjectsFromArray:[directObjectTypes objectForKey:type]];
 		}
@@ -211,7 +211,9 @@ QSExecutor *QSExec = nil;
 	NSArray *directTypes = [actionDict objectForKey:kActionDirectTypes];
 	if (![directTypes count]) directTypes = [NSArray arrayWithObject:@"*"];
 	for (NSString *type in directTypes) {
-        [[self actionsArrayForType:type] addObject:action];
+        if (!([type isEqualToString:QSFilePathType] && [[action directFileTypes] containsObject:@"'APPL'"])) {
+            [[self actionsArrayForType:type] addObject:action];
+        }
     }
     
 	if ([directTypes containsObject:QSFilePathType]) {


### PR DESCRIPTION
... actions list

If you look in the QS actions prefs, you'll see that the 'toggle' application appears under the 'files & folders' section. This is due to the poor implementation of the `directTypes` and `directFileTypes` arrays for actions.
With #1057 I attempted to address this problem, but of course it's not really possible since all plugins use the old format.

This change is a 'hack' to not add actions that are for 'applications' to the 'files & folders' list.

The real fix: Change all actions to remove the `directFileTypes` array and define UTIs within the `directTypes` array, just like I have done for the `indirectTypes`
