### PR TITLE
make qs-push-plugin check that the file has a 32/64 bit binary before up...

### DIFF
--- a/Quicksilver/Tools/qs-push-plugin
+++ b/Quicksilver/Tools/qs-push-plugin
@@ -33,10 +33,14 @@ def checkIsUniversalBinary(plist, file)
   # Make sure the file is a 32/64 bit binary
   bin_file = plist['CFBundleName']
   bin_path = File.join(file, "Contents","MacOS",bin_file)
+  # Some plugins don't contain binaries
+  if not File.exists?(bin_path)
+    return
+  end
   arch_details = %x(file "#{bin_path}")
   if not (arch_details.include? "Mach-O 64-bit bundle x86_64" and arch_details.include? "Mach-O bundle i386")
       Trollop::die "#{file} does not contain a 32/64 bit binary. Aborting"
-  end
+    end
 end
 
 # MAIN SCRIPT


### PR DESCRIPTION
...loading. Fixes #1060

I just made #1060 for the stats, hehe ;-)

An interesting note for @tiennou
At the moment you're using `Trollop::die` for when something fails, but this breaks things if you push a list of files to the script

`qs-push-plugin a.qsplugin b.qsplugin...`

It looks like you've done the right thing at one point (using `puts` then `next`). Should this be done everywhere?
Just wanted your opinion, but it shouldn't stop this pull request from going ahead
