### PR TITLE
when searching, only show the name if label didn't match at all

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSObjectRanker.m
+++ b/Quicksilver/Code-QuickStepCore/QSObjectRanker.m
@@ -121,8 +121,7 @@ QSScoreForAbbrevIMP scoreForAbbrevIMP;
 - (NSString*)matchedStringForAbbreviation:(NSString*)anAbbreviation hitmask:(NSIndexSet **)hitmask inContext:(NSString *)context {
 	if (!anAbbreviation) return nil;
     
-	CGFloat nameScore = [nameRanker scoreForAbbreviation:anAbbreviation];
-	if (labelRanker && [labelRanker scoreForAbbreviation:anAbbreviation] >= nameScore) {
+	if (labelRanker && [labelRanker scoreForAbbreviation:anAbbreviation] > 0) {
 		*hitmask = [labelRanker maskForAbbreviation:anAbbreviation];
 		return [labelRanker rankedString];
 	} else {


### PR DESCRIPTION
If you think of 4c9b9edb4c83f3a288574cc9b758142cd7628926 as a rifle, then this is a bazooka. :-)

Ever since we made [this change](https://github.com/quicksilver/Quicksilver/pull/1029/files#diff-4), I've started to see more URL strings in my results. Especially with URLs for web searches. For example, I just added a search for PyPI. The object ends up with

```
name  = http://pypi.python.org/pypi?%3Aaction=search&term=***&submit=search
label = Python Package Index
```

A search for "pypi" was always showing the name, even though the label was also a match. Obviously, the name has a higher rank, so Quicksilver is doing exactly what we told it to do.

But I had a thought: The only reason the label exists is that it (theoretically) looks nicer than the name. Shouldn't we show that if it matches _at all_, not just if it outranks the name?

So that's what I did. Seems too good to be true that it was this easy and has no drawbacks. Am I missing anything? As far as I know, this has no influence on the order of results, only which string is displayed with the mask applied. Even if it did affect ranking, it would only be noticeable in rare cases where name and label are very dissimilar, and training could quickly restore the expected behavior anyway.

**Bonus**: It doesn't have to compute both name and label ranks for every single keystroke, so it should speed up matching.
