### PR TITLE
fix incorrect nesting of braces in if() statements. Always add the paren...

### DIFF
--- a/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
@@ -1708,11 +1708,11 @@ NSMutableDictionary *bindingsDict = nil;
                 }
                 newObjects = (NSArray *)filteredObjects;
             }
-            if ([newObjects count]) {
-                [parentStack addObject:newSelectedObject];
-            }
-            newSelectedObject = nil;
         }
+        if ([newObjects count]) {
+            [parentStack addObject:newSelectedObject];
+        }
+        newSelectedObject = nil;
     } else {
 		parent = [newSelectedObject parent];
 


### PR DESCRIPTION
...t is files exist, not just when alt is not held. Fixes #1069

Basically, in refactoring the pull request to avoid the merge conflict, I accidentally put the code in the wrong brackets (grrrrr should never have fixed that Info.plist merge conflict Rob!) Hehe :)
