### PR TITLE
allow Xcode to re-arrange property lists

### DIFF
--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/QSCorePlugIn-Info.plist
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/QSCorePlugIn-Info.plist
@@ -2,707 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>CFBundleName</key>
-	<string>Core Support</string>
-	<key>CFBundleDisplayName</key>
-	<string>Core Support</string>
-	<key>CFBundleIdentifier</key>
-	<string>com.blacktree.Quicksilver.QSCorePlugIn</string>
-	<key>CFBundleInfoDictionaryVersion</key>
-	<string>6.0</string>
-	<key>QSPresetAdditions</key>
-	<array>
-		<dict>
-			<key>name</key>
-			<string>Applications</string>
-			<key>source</key>
-			<string>QSGroupObjectSource</string>
-			<key>children</key>
-			<array>
-				<dict>
-					<key>source</key>
-					<string>QSFileSystemObjectSource</string>
-					<key>settings</key>
-					<dict>
-						<key>parser</key>
-						<string>QSDirectoryParser</string>
-						<key>folderTypes</key>
-						<array>
-							<string>com.apple.application</string>
-						</array>
-						<key>folderDepth</key>
-						<integer>3</integer>
-						<key>scanContents</key>
-						<integer>1</integer>
-						<key>watchTarget</key>
-						<true/>
-						<key>kind</key>
-						<string>Folder</string>
-						<key>path</key>
-						<string>/Applications/</string>
-						<key>type</key>
-						<string></string>
-						<key>watchPaths</key>
-						<array>
-							<string>/Applications/Utilities</string>
-						</array>
-					</dict>
-					<key>ID</key>
-					<string>QSPresetMainApplications</string>
-					<key>name</key>
-					<string>Applications</string>
-				</dict>
-				<dict>
-					<key>source</key>
-					<string>QSFileSystemObjectSource</string>
-					<key>requiresSettingsPath</key>
-					<true/>
-					<key>watchTarget</key>
-					<true/>
-					<key>settings</key>
-					<dict>
-						<key>parser</key>
-						<string>QSDirectoryParser</string>
-						<key>folderTypes</key>
-						<array>
-							<string>com.apple.application</string>
-						</array>
-						<key>folderDepth</key>
-						<integer>3</integer>
-						<key>scanContents</key>
-						<integer>1</integer>
-						<key>kind</key>
-						<string>Folder</string>
-						<key>path</key>
-						<string>~/Applications/</string>
-						<key>skipItem</key>
-						<false/>
-					</dict>
-					<key>ID</key>
-					<string>QSPresetUserApplications</string>
-					<key>name</key>
-					<string>Applications (User)</string>
-				</dict>
-				<dict>
-					<key>source</key>
-					<string>QSProcessObjectSource</string>
-					<key>ID</key>
-					<string>QSPresetRunningProcesses</string>
-				</dict>
-				<dict>
-					<key>source</key>
-					<string>QSAllApplicationsObjectSource</string>
-					<key>enabled</key>
-					<false/>
-					<key>ID</key>
-					<string>QSPresetAllApplications</string>
-				</dict>
-			</array>
-			<key>catalogPath</key>
-			<string>/</string>
-			<key>icon</key>
-			<string>GenericApplicationIcon</string>
-			<key>ID</key>
-			<string>QSPresetApplications</string>
-		</dict>
-		<dict>
-			<key>source</key>
-			<string>QSGroupObjectSource</string>
-			<key>children</key>
-			<array>
-				<dict>
-					<key>source</key>
-					<string>QSGroupObjectSource</string>
-					<key>children</key>
-					<array>
-						<dict>
-							<key>source</key>
-							<string>QSGroupObjectSource</string>
-							<key>supressChildren</key>
-							<true/>
-							<key>children</key>
-							<array>
-								<dict>
-									<key>source</key>
-									<string>QSFileSystemObjectSource</string>
-									<key>requiresSettingsPath</key>
-									<true/>
-									<key>settings</key>
-									<dict>
-										<key>parser</key>
-										<string>QSDirectoryParser</string>
-										<key>folderTypes</key>
-										<array>
-											<string>com.apple.systempreference.prefpane</string>
-										</array>
-										<key>folderDepth</key>
-										<integer>1</integer>
-										<key>scanContents</key>
-										<integer>1</integer>
-										<key>kind</key>
-										<string>Folder</string>
-										<key>path</key>
-										<string>/Library/PreferencePanes</string>
-										<key>skipItem</key>
-										<integer>1</integer>
-									</dict>
-									<key>icon</key>
-									<string>PrefFileIcon</string>
-									<key>ID</key>
-									<string>QSPresetLibraryPreferencePanes</string>
-								</dict>
-								<dict>
-									<key>name</key>
-									<string>System Preferences (User)</string>
-									<key>requiresSettingsPath</key>
-									<true/>
-									<key>source</key>
-									<string>QSFileSystemObjectSource</string>
-									<key>settings</key>
-									<dict>
-										<key>parser</key>
-										<string>QSDirectoryParser</string>
-										<key>folderTypes</key>
-										<array>
-											<string>com.apple.systempreference.prefpane</string>
-										</array>
-										<key>folderDepth</key>
-										<integer>1</integer>
-										<key>scanContents</key>
-										<integer>1</integer>
-										<key>kind</key>
-										<string>Folder</string>
-										<key>path</key>
-										<string>~/Library/PreferencePanes</string>
-										<key>skipItem</key>
-										<integer>1</integer>
-										<key>type</key>
-										<string></string>
-									</dict>
-									<key>icon</key>
-									<string>PrefFileIcon</string>
-									<key>ID</key>
-									<string>QSPresetUserPreferencePanes</string>
-								</dict>
-								<dict>
-									<key>name</key>
-									<string>System Preferences (System)</string>
-									<key>source</key>
-									<string>QSFileSystemObjectSource</string>
-									<key>settings</key>
-									<dict>
-										<key>parser</key>
-										<string>QSDirectoryParser</string>
-										<key>folderTypes</key>
-										<array>
-											<string>com.apple.systempreference.prefpane</string>
-										</array>
-										<key>folderDepth</key>
-										<integer>1</integer>
-										<key>scanContents</key>
-										<integer>1</integer>
-										<key>kind</key>
-										<string>Folder</string>
-										<key>path</key>
-										<string>/System/Library/PreferencePanes</string>
-										<key>skipItem</key>
-										<integer>1</integer>
-									</dict>
-									<key>icon</key>
-									<string>PrefFileIcon</string>
-									<key>ID</key>
-									<string>QSPresetSystemPreferencePanes</string>
-								</dict>
-							</array>
-							<key>icon</key>
-							<string>SystemPreferencesIcon</string>
-							<key>ID</key>
-							<string>QSPresetPreferencePanes</string>
-						</dict>
-					</array>
-					<key>icon</key>
-					<string>prefsGeneral</string>
-					<key>ID</key>
-					<string>QSPresetConfiguration</string>
-				</dict>
-				<dict>
-					<key>source</key>
-					<string>QSGroupObjectSource</string>
-					<key>children</key>
-					<array>
-						<dict>
-							<key>source</key>
-							<string>QSVolumesObjectSource</string>
-							<key>ID</key>
-							<string>QSPresetVolumes</string>
-						</dict>
-						<dict>
-							<key>source</key>
-							<string>QSFileSystemObjectSource</string>
-							<key>settings</key>
-							<dict>
-								<key>parser</key>
-								<string>QSDirectoryParser</string>
-								<key>folderTypes</key>
-								<array>
-									<string>com.apple.application</string>
-								</array>
-								<key>folderDepth</key>
-								<integer>1</integer>
-								<key>scanContents</key>
-								<integer>1</integer>
-								<key>path</key>
-								<string>~/Library/Printers</string>
-								<key>skipItem</key>
-								<integer>1</integer>
-							</dict>
-							<key>icon</key>
-							<string>PrintCenterIcon</string>
-							<key>ID</key>
-							<string>QSPresetPrinters</string>
-						</dict>
-					</array>
-					<key>ID</key>
-					<string>QSPresetDevices</string>
-				</dict>
-			</array>
-			<key>catalogPath</key>
-			<string>/</string>
-			<key>icon</key>
-			<string>FinderIcon</string>
-			<key>ID</key>
-			<string>QSPresetSystemGroup</string>
-		</dict>
-		<dict>
-			<key>source</key>
-			<string>QSGroupObjectSource</string>
-			<key>children</key>
-			<array>
-				<dict>
-					<key>source</key>
-					<string>QSFileSystemObjectSource</string>
-					<key>settings</key>
-					<dict>
-						<key>parser</key>
-						<string>QSDirectoryParser</string>
-						<key>folderDepth</key>
-						<integer>1</integer>
-						<key>watchTarget</key>
-						<true/>
-						<key>path</key>
-						<string>~</string>
-					</dict>
-					<key>ID</key>
-					<string>QSPresetHome</string>
-				</dict>
-				<dict>
-					<key>source</key>
-					<string>QSFileSystemObjectSource</string>
-					<key>settings</key>
-					<dict>
-						<key>parser</key>
-						<string>QSDirectoryParser</string>
-						<key>folderDepth</key>
-						<integer>2</integer>
-						<key>watchTarget</key>
-						<true/>
-						<key>path</key>
-						<string>~/Downloads</string>
-					</dict>
-					<key>ID</key>
-					<string>QSPresetDownloads</string>
-				</dict>
-				<dict>
-					<key>source</key>
-					<string>QSFileSystemObjectSource</string>
-					<key>settings</key>
-					<dict>
-						<key>parser</key>
-						<string>QSDirectoryParser</string>
-						<key>folderDepth</key>
-						<integer>1</integer>
-						<key>watchTarget</key>
-						<true/>
-						<key>path</key>
-						<string>~/Documents</string>
-					</dict>
-					<key>ID</key>
-					<string>QSPresetDocuments</string>
-				</dict>
-				<dict>
-					<key>source</key>
-					<string>QSFileSystemObjectSource</string>
-					<key>settings</key>
-					<dict>
-						<key>parser</key>
-						<string>QSDirectoryParser</string>
-						<key>watchTarget</key>
-						<true/>
-						<key>path</key>
-						<string>~/Desktop</string>
-					</dict>
-					<key>ID</key>
-					<string>QSPresetDesktop</string>
-				</dict>
-				<dict>
-					<key>source</key>
-					<string>QSFileSystemObjectSource</string>
-					<key>settings</key>
-					<dict>
-						<key>path</key>
-						<string>~/.Trash</string>
-					</dict>
-					<key>icon</key>
-					<string>TrashIcon</string>
-					<key>ID</key>
-					<string>QSPresetTrash</string>
-				</dict>
-				<dict>
-					<key>source</key>
-					<string>QSGroupObjectSource</string>
-					<key>children</key>
-					<array>
-						<dict>
-							<key>source</key>
-							<string>QSDefaultsObjectSource</string>
-							<key>settings</key>
-							<dict>
-								<key>bundle</key>
-								<string>com.apple.dock</string>
-								<key>type</key>
-								<integer>5</integer>
-								<key>keypath</key>
-								<array>
-									<string>persistent-apps</string>
-									<string>*</string>
-									<string>tile-data</string>
-									<string>file-data</string>
-								</array>
-							</dict>
-							<key>ID</key>
-							<string>QSPresetDockApplications</string>
-						</dict>
-						<dict>
-							<key>source</key>
-							<string>QSDefaultsObjectSource</string>
-							<key>settings</key>
-							<dict>
-								<key>bundle</key>
-								<string>com.apple.dock</string>
-								<key>type</key>
-								<integer>5</integer>
-								<key>keypath</key>
-								<array>
-									<string>persistent-others</string>
-									<string>*</string>
-									<string>tile-data</string>
-									<string>file-data</string>
-								</array>
-							</dict>
-							<key>ID</key>
-							<string>QSPresetDockOthers</string>
-						</dict>
-					</array>
-					<key>icon</key>
-					<string>DockIcon</string>
-					<key>ID</key>
-					<string>QSPresetDockGroup</string>
-				</dict>
-				<dict>
-					<key>source</key>
-					<string>QSGroupObjectSource</string>
-					<key>children</key>
-					<array>
-						<dict>
-							<key>source</key>
-							<string>QSDefaultsObjectSource</string>
-							<key>settings</key>
-							<dict>
-								<key>bundle</key>
-								<string>com.apple.recentitems</string>
-								<key>watchTarget</key>
-								<true/>
-								<key>type</key>
-								<integer>3</integer>
-								<key>keypath</key>
-								<array>
-									<string>RecentApplications</string>
-									<string>CustomListItems</string>
-									<string>*</string>
-									<string>Bookmark</string>
-								</array>
-							</dict>
-							<key>icon</key>
-							<string>GenericApplicationIcon</string>
-							<key>ID</key>
-							<string>QSPresetRecentApplications106</string>
-						</dict>
-						<dict>
-							<key>source</key>
-							<string>QSDefaultsObjectSource</string>
-							<key>watchTarget</key>
-							<true/>
-							<key>settings</key>
-							<dict>
-								<key>bundle</key>
-								<string>com.apple.recentitems</string>
-								<key>type</key>
-								<integer>3</integer>
-								<key>keypath</key>
-								<array>
-									<string>RecentDocuments</string>
-									<string>CustomListItems</string>
-									<string>*</string>
-									<string>Bookmark</string>
-								</array>
-							</dict>
-							<key>icon</key>
-							<string>GenericDocumentIcon</string>
-							<key>ID</key>
-							<string>QSPresetRecentDocuments106</string>
-						</dict>
-						<dict>
-							<key>source</key>
-							<string>QSDefaultsObjectSource</string>
-							<key>watchTarget</key>
-							<true/>
-							<key>settings</key>
-							<dict>
-								<key>bundle</key>
-								<string>com.apple.recentitems</string>
-								<key>type</key>
-								<integer>3</integer>
-								<key>keypath</key>
-								<array>
-									<string>RecentServers</string>
-									<string>CustomListItems</string>
-									<string>*</string>
-									<string>Alias</string>
-								</array>
-							</dict>
-							<key>icon</key>
-							<string>GenericFileServerIcon</string>
-							<key>ID</key>
-							<string>QSPresetRecentServers</string>
-						</dict>
-						<dict>
-							<key>source</key>
-							<string>QSDefaultsObjectSource</string>
-							<key>settings</key>
-							<dict>
-								<key>bundle</key>
-								<string>.GlobalPreferences</string>
-								<key>type</key>
-								<integer>1</integer>
-								<key>keypath</key>
-								<array>
-									<string>NSNavRecentPlaces</string>
-									<string>*</string>
-								</array>
-							</dict>
-							<key>icon</key>
-							<string>GenericFolderIcon</string>
-							<key>ID</key>
-							<string>QSPresetGlobalPrefsRecentFolders</string>
-						</dict>
-					</array>
-					<key>icon</key>
-					<string>SafariHistoryIcon</string>
-					<key>ID</key>
-					<string>QSPresetRecentItems</string>
-				</dict>
-			</array>
-			<key>catalogPath</key>
-			<string>/</string>
-			<key>icon</key>
-			<string>HomeFolderIcon</string>
-			<key>ID</key>
-			<string>QSPresetUserGroup</string>
-		</dict>
-		<dict>
-			<key>source</key>
-			<string>QSGroupObjectSource</string>
-			<key>children</key>
-			<array>
-				<dict>
-					<key>source</key>
-					<string>QSCatalogEntrySource</string>
-					<key>ID</key>
-					<string>QSPresetQSCatalogEntries</string>
-					<key>enabled</key>
-					<false/>
-				</dict>
-				<dict>
-					<key>source</key>
-					<string>QSProxyObjectSource</string>
-					<key>enabled</key>
-					<true/>
-					<key>ID</key>
-					<string>QSPresetProxies</string>
-					<key>feature</key>
-					<integer>1</integer>
-				</dict>
-				<dict>
-					<key>source</key>
-					<string>QSObjCMessageSource</string>
-					<key>enabled</key>
-					<false/>
-					<key>ID</key>
-					<string>QSPresetInternalMessages</string>
-					<key>feature</key>
-					<integer>1</integer>
-				</dict>
-				<dict>
-					<key>source</key>
-					<string>QSHandledObjectHandler</string>
-					<key>enabled</key>
-					<false/>
-					<key>ID</key>
-					<string>QSPresetInternalObjects</string>
-					<key>feature</key>
-					<integer>1</integer>
-				</dict>
-				<dict>
-					<key>source</key>
-					<string>QSHistoryObjectSource</string>
-					<key>userInfo</key>
-					<string>commands</string>
-					<key>enabled</key>
-					<false/>
-					<key>ID</key>
-					<string>QSPresetCommandHistory</string>
-					<key>feature</key>
-					<integer>3</integer>
-				</dict>
-				<dict>
-					<key>name</key>
-					<string>Recent Objects</string>
-					<key>source</key>
-					<string>QSHistoryObjectSource</string>
-					<key>enabled</key>
-					<false/>
-					<key>userInfo</key>
-					<string>objects</string>
-					<key>ID</key>
-					<string>QSPresetObjectHistory</string>
-					<key>feature</key>
-					<integer>1</integer>
-				</dict>
-			</array>
-			<key>catalogPath</key>
-			<string>/</string>
-			<key>icon</key>
-			<string>Quicksilver</string>
-			<key>ID</key>
-			<string>QSPresetQSGroup</string>
-		</dict>
-		<dict>
-			<key>source</key>
-			<string>QSGroupObjectSource</string>
-			<key>children</key>
-			<array>
-				<dict>
-					<key>source</key>
-					<string>QSFileSystemObjectSource</string>
-					<key>requiresSettingsPath</key>
-					<integer>1</integer>
-					<key>enabled</key>
-					<false/>
-					<key>settings</key>
-					<dict>
-						<key>parser</key>
-						<string>QSDirectoryParser</string>
-						<key>folderTypes</key>
-						<array>
-							<string>public.script</string>
-							<string>public.plain-text</string>
-							<string>com.apple.applescript.script</string>
-							<string>dyn.age8u</string>
-						</array>
-						<key>folderDepth</key>
-						<integer>3</integer>
-						<key>scanContents</key>
-						<integer>1</integer>
-						<key>path</key>
-						<string>/Library/Scripts</string>
-						<key>skipItem</key>
-						<integer>1</integer>
-					</dict>
-					<key>icon</key>
-					<string>ScriptIcon</string>
-					<key>ID</key>
-					<string>QSPresetLibraryScripts</string>
-				</dict>
-				<dict>
-					<key>name</key>
-					<string>Scripts (User)</string>
-					<key>requiresSettingsPath</key>
-					<integer>1</integer>
-					<key>source</key>
-					<string>QSFileSystemObjectSource</string>
-					<key>modificationDate</key>
-					<real>103923120</real>
-					<key>settings</key>
-					<dict>
-						<key>parser</key>
-						<string>QSDirectoryParser</string>
-						<key>folderTypes</key>
-						<array>
-							<string>public.script</string>
-							<string>public.plain-text</string>
-							<string>com.apple.applescript.script</string>
-							<string>dyn.age8u</string>
-						</array>
-						<key>folderDepth</key>
-						<integer>4</integer>
-						<key>scanContents</key>
-						<integer>1</integer>
-						<key>path</key>
-						<string>~/Library/Scripts</string>
-						<key>skipItem</key>
-						<integer>1</integer>
-					</dict>
-					<key>icon</key>
-					<string>ScriptIcon</string>
-					<key>ID</key>
-					<string>QSPresetUserScripts</string>
-				</dict>
-				<dict>
-					<key>source</key>
-					<string>QSFileSystemObjectSource</string>
-					<key>requiresSettingsPath</key>
-					<integer>1</integer>
-					<key>settings</key>
-					<dict>
-						<key>parser</key>
-						<string>QSDirectoryParser</string>
-						<key>folderTypes</key>
-						<array>
-							<string>com.apple.applescript.script</string>
-						</array>
-						<key>folderDepth</key>
-						<integer>3</integer>
-						<key>path</key>
-						<string>~/Library/Application Support/DVD Player Scripts</string>
-						<key>skipItem</key>
-						<integer>1</integer>
-					</dict>
-					<key>icon</key>
-					<string>com.apple.DVDPlayer</string>
-					<key>ID</key>
-					<string>QSPresetDVDPlayerScripts</string>
-				</dict>
-			</array>
-			<key>catalogPath</key>
-			<string>/</string>
-			<key>icon</key>
-			<string>CompiledScriptIcon</string>
-			<key>ID</key>
-			<string>QSPresetScriptsGroup</string>
-		</dict>
-	</array>
-	<key>CFBundleVersion</key>
-	<string>98</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2004, Blacktree, Inc.</string>
 	<key>QSTriggerAdditions</key>
 	<array>
 		<dict>
@@ -726,35 +27,34 @@
 			<string>QSActivateTextModeTrigger</string>
 		</dict>
 	</array>
+	<key>CFBundleIdentifier</key>
+	<string>com.blacktree.Quicksilver.QSCorePlugIn</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleVersion</key>
+	<string>98</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0.0</string>
 	<key>CFBundleExecutable</key>
 	<string>Core Support</string>
-	<key>QSPlugIn</key>
-	<dict>
-		<key>author</key>
-		<string>Blacktree, Inc.</string>
-		<key>extendedDescription</key>
-		<string>Provides support and actions for basic types such as files, strings, and URLs.</string>
-		<key>helpPage</key>
-		<string>plugins:Core Support</string>
-		<key>hidden</key>
-		<true/>
-		<key>description</key>
-		<string>Provides basic file and URL handling</string>
-		<key>icon</key>
-		<string>Quicksilver</string>
-	</dict>
+	<key>CFBundleDisplayName</key>
+	<string>Core Support</string>
 	<key>QSActions</key>
 	<dict>
-		<key>FileToTrashAction</key>
+		<key>QSObjectSelectAction</key>
 		<dict>
 			<key>actionClass</key>
-			<string>FSActions</string>
+			<string>QSObjectActions</string>
 			<key>directTypes</key>
 			<array>
-				<string>NSFilenamesPboardType</string>
+				<string>*</string>
 			</array>
+			<key>enabled</key>
+			<false/>
 			<key>actionSelector</key>
-			<string>trashFile:</string>
+			<string>selectObjectInCommandWindow:</string>
+			<key>icon</key>
+			<string>Quicksilver</string>
 		</dict>
 		<key>QSCommandAddTriggerAction</key>
 		<dict>
@@ -801,44 +101,6 @@
 			<key>icon</key>
 			<string>QSDirectObjectIconProxy</string>
 		</dict>
-		<key>FileGetInfoAction</key>
-		<dict>
-			<key>actionClass</key>
-			<string>FSActions</string>
-			<key>directTypes</key>
-			<array>
-				<string>NSFilenamesPboardType</string>
-			</array>
-			<key>actionSelector</key>
-			<string>getInfo:</string>
-		</dict>
-		<key>QSCreateFileAction</key>
-		<dict>
-			<key>displaysResult</key>
-			<integer>1</integer>
-			<key>validatesObjects</key>
-			<false/>
-			<key>actionClass</key>
-			<string>QSObjectActions</string>
-			<key>directTypes</key>
-			<array>
-				<string>NSStringPboardType</string>
-			</array>
-			<key>indirectTypes</key>
-			<array>
-				<string>public.folder</string>
-			</array>
-			<key>indirectOptional</key>
-			<true/>
-			<key>actionSelector</key>
-			<string>saveObject:toDirectory:</string>
-			<key>runInMainThread</key>
-			<true/>
-			<key>icon</key>
-			<string>GenericDocumentIcon</string>
-			<key>name</key>
-			<string>Create File [...]</string>
-		</dict>
 		<key>QSObjectShowChildrenAction</key>
 		<dict>
 			<key>validatesObjects</key>
@@ -853,6 +115,59 @@
 			<string>showChildren:</string>
 			<key>icon</key>
 			<string>Find</string>
+		</dict>
+		<key>QSCreateFileAction</key>
+		<dict>
+			<key>displaysResult</key>
+			<integer>1</integer>
+			<key>validatesObjects</key>
+			<false/>
+			<key>actionClass</key>
+			<string>QSObjectActions</string>
+			<key>directTypes</key>
+			<array>
+				<string>NSStringPboardType</string>
+			</array>
+			<key>indirectOptional</key>
+			<true/>
+			<key>indirectTypes</key>
+			<array>
+				<string>public.folder</string>
+			</array>
+			<key>actionSelector</key>
+			<string>saveObject:toDirectory:</string>
+			<key>runInMainThread</key>
+			<true/>
+			<key>icon</key>
+			<string>GenericDocumentIcon</string>
+			<key>name</key>
+			<string>Create File [...]</string>
+		</dict>
+		<key>QSTextShowDialogAction</key>
+		<dict>
+			<key>actionClass</key>
+			<string>QSTextActions</string>
+			<key>directTypes</key>
+			<array>
+				<string>NSStringPboardType</string>
+			</array>
+			<key>enabled</key>
+			<false/>
+			<key>actionSelector</key>
+			<string>showDialog:</string>
+			<key>name</key>
+			<string>Display Dialog</string>
+		</dict>
+		<key>FileGetInfoAction</key>
+		<dict>
+			<key>actionClass</key>
+			<string>FSActions</string>
+			<key>directTypes</key>
+			<array>
+				<string>NSFilenamesPboardType</string>
+			</array>
+			<key>actionSelector</key>
+			<string>getInfo:</string>
 		</dict>
 		<key>QSShellScriptRunAction</key>
 		<dict>
@@ -885,40 +200,25 @@
 			<key>name</key>
 			<string>Run</string>
 		</dict>
-		<key>QSTextShowDialogAction</key>
+		<key>FileOpenWithAction</key>
 		<dict>
 			<key>actionClass</key>
-			<string>QSTextActions</string>
+			<string>FSActions</string>
 			<key>directTypes</key>
 			<array>
-				<string>NSStringPboardType</string>
+				<string>NSFilenamesPboardType</string>
 			</array>
-			<key>enabled</key>
-			<false/>
-			<key>actionSelector</key>
-			<string>showDialog:</string>
-			<key>name</key>
-			<string>Display Dialog</string>
-		</dict>
-		<key>URLOpenWithAction</key>
-		<dict>
-			<key>validatesObjects</key>
-			<true/>
-			<key>actionClass</key>
-			<string>URLActions</string>
-			<key>directTypes</key>
-			<array>
-				<string>Apple URL pasteboard type</string>
-			</array>
+			<key>precedence</key>
+			<real>0.1</real>
 			<key>indirectTypes</key>
 			<array>
 				<string>com.apple.application-file</string>
 				<string>com.apple.application-bundle</string>
 			</array>
-			<key>enabled</key>
-			<false/>
 			<key>actionSelector</key>
-			<string>doURLOpenAction:with:</string>
+			<string>openFile:with:</string>
+			<key>icon</key>
+			<string>GenericApplicationIcon</string>
 		</dict>
 		<key>PasteboardPasteActionAsPlainText</key>
 		<dict>
@@ -1015,14 +315,14 @@
 			<array>
 				<string>NSFilenamesPboardType</string>
 			</array>
-			<key>indirectTypes</key>
-			<array>
-				<string>public.folder</string>
-			</array>
 			<key>enabled</key>
 			<false/>
 			<key>precedence</key>
 			<real>-0.5</real>
+			<key>indirectTypes</key>
+			<array>
+				<string>public.folder</string>
+			</array>
 			<key>actionSelector</key>
 			<string>makeLinkTo:inFolder:</string>
 			<key>name</key>
@@ -1056,8 +356,8 @@
 		</dict>
 		<key>QSObjectShowChildMenu</key>
 		<dict>
-			<key>name</key>
-			<string>Show Contents Menu</string>
+			<key>feature</key>
+			<integer>1</integer>
 			<key>actionClass</key>
 			<string>QSObjectActions</string>
 			<key>directTypes</key>
@@ -1068,10 +368,10 @@
 			<string>showChildMenu:</string>
 			<key>runInMainThread</key>
 			<true/>
+			<key>name</key>
+			<string>Show Contents Menu</string>
 			<key>icon</key>
 			<string>Menu</string>
-			<key>feature</key>
-			<integer>1</integer>
 		</dict>
 		<key>FileMakeAliasInAction</key>
 		<dict>
@@ -1083,12 +383,12 @@
 			<array>
 				<string>NSFilenamesPboardType</string>
 			</array>
+			<key>precedence</key>
+			<real>-0.5</real>
 			<key>indirectTypes</key>
 			<array>
 				<string>public.folder</string>
 			</array>
-			<key>precedence</key>
-			<real>-0.5</real>
 			<key>actionSelector</key>
 			<string>makeAliasTo:inFolder:</string>
 			<key>name</key>
@@ -1132,20 +432,20 @@
 		<dict>
 			<key>displaysResult</key>
 			<integer>1</integer>
-			<key>reverseArguments</key>
-			<true/>
+			<key>name</key>
+			<string>Make New...</string>
 			<key>actionClass</key>
 			<string>QSFileTemplateManager</string>
 			<key>directTypes</key>
 			<array>
 				<string>NSFilenamesPboardType</string>
 			</array>
+			<key>indirectOptional</key>
+			<false/>
 			<key>indirectTypes</key>
 			<array>
 				<string>public.folder</string>
 			</array>
-			<key>indirectOptional</key>
-			<false/>
 			<key>actionSelector</key>
 			<string>instantiateTemplate:inDirectory:</string>
 			<key>directFileTypes</key>
@@ -1157,8 +457,8 @@
 			<false/>
 			<key>icon</key>
 			<string>GenericDocumentIcon</string>
-			<key>name</key>
-			<string>Make New...</string>
+			<key>reverseArguments</key>
+			<true/>
 		</dict>
 		<key>URLOpenAction</key>
 		<dict>
@@ -1222,17 +522,17 @@
 			<array>
 				<string>NSFilenamesPboardType</string>
 			</array>
+			<key>indirectTypes</key>
+			<array>
+				<string>com.apple.application-file</string>
+				<string>com.apple.application-bundle</string>
+			</array>
 			<key>actionSelector</key>
 			<string>openFile:with:</string>
 			<key>directFileTypes</key>
 			<array>
 				<string>&apos;APPL&apos;</string>
 				<string>app</string>
-			</array>
-			<key>indirectTypes</key>
-			<array>
-				<string>com.apple.application-file</string>
-				<string>com.apple.application-bundle</string>
 			</array>
 			<key>icon</key>
 			<string>QSDirectObjectIconProxy</string>
@@ -1341,8 +641,8 @@
 		</dict>
 		<key>QSLoginItemRemoveAction</key>
 		<dict>
-			<key>name</key>
-			<string>Do Not Open at Login</string>
+			<key>feature</key>
+			<integer>1</integer>
 			<key>actionClass</key>
 			<string>FSActions</string>
 			<key>directTypes</key>
@@ -1353,10 +653,29 @@
 			<false/>
 			<key>actionSelector</key>
 			<string>doNotOpenItemAtLogin:</string>
+			<key>name</key>
+			<string>Do Not Open at Login</string>
 			<key>icon</key>
 			<string>HomeFolderIcon</string>
+		</dict>
+		<key>QSObjectShowMenu</key>
+		<dict>
 			<key>feature</key>
 			<integer>1</integer>
+			<key>actionClass</key>
+			<string>QSObjectActions</string>
+			<key>directTypes</key>
+			<array>
+				<string>*</string>
+			</array>
+			<key>actionSelector</key>
+			<string>showMenu:</string>
+			<key>runInMainThread</key>
+			<true/>
+			<key>name</key>
+			<string>Show Menu</string>
+			<key>icon</key>
+			<string>Menu</string>
 		</dict>
 		<key>PasteboardPasteAction</key>
 		<dict>
@@ -1376,25 +695,6 @@
 			<string>pasteObject:</string>
 			<key>icon</key>
 			<string>Clipboard</string>
-		</dict>
-		<key>QSObjectShowMenu</key>
-		<dict>
-			<key>name</key>
-			<string>Show Menu</string>
-			<key>actionClass</key>
-			<string>QSObjectActions</string>
-			<key>directTypes</key>
-			<array>
-				<string>*</string>
-			</array>
-			<key>actionSelector</key>
-			<string>showMenu:</string>
-			<key>runInMainThread</key>
-			<true/>
-			<key>icon</key>
-			<string>Menu</string>
-			<key>feature</key>
-			<integer>1</integer>
 		</dict>
 		<key>FileGetPathAction</key>
 		<dict>
@@ -1421,6 +721,8 @@
 		<dict>
 			<key>displaysResult</key>
 			<integer>1</integer>
+			<key>validatesObjects</key>
+			<true/>
 			<key>actionClass</key>
 			<string>QSObjectActions</string>
 			<key>precedence</key>
@@ -1429,8 +731,6 @@
 			<string>findObjectInCatalog:</string>
 			<key>name</key>
 			<string>Show Source in Catalog</string>
-			<key>validatesObjects</key>
-			<true/>
 		</dict>
 		<key>QSObjectAssignMnemonic</key>
 		<dict>
@@ -1589,8 +889,8 @@
 		</dict>
 		<key>QSObjectShowActionMenu</key>
 		<dict>
-			<key>name</key>
-			<string>Show Action Menu</string>
+			<key>feature</key>
+			<integer>1</integer>
 			<key>actionClass</key>
 			<string>QSObjectActions</string>
 			<key>directTypes</key>
@@ -1601,10 +901,10 @@
 			<string>showActionMenu:</string>
 			<key>runInMainThread</key>
 			<true/>
+			<key>name</key>
+			<string>Show Action Menu</string>
 			<key>icon</key>
 			<string>Menu</string>
-			<key>feature</key>
-			<integer>1</integer>
 		</dict>
 		<key>QSLoginItemAddAction</key>
 		<dict>
@@ -1652,14 +952,14 @@
 			<array>
 				<string>NSFilenamesPboardType</string>
 			</array>
-			<key>indirectTypes</key>
-			<array>
-				<string>public.folder</string>
-			</array>
 			<key>enabled</key>
 			<false/>
 			<key>precedence</key>
 			<real>-0.5</real>
+			<key>indirectTypes</key>
+			<array>
+				<string>public.folder</string>
+			</array>
 			<key>actionSelector</key>
 			<string>makeHardLinkTo:inFolder:</string>
 			<key>name</key>
@@ -1847,6 +1147,26 @@
 			<key>name</key>
 			<string>Quit Others</string>
 		</dict>
+		<key>URLOpenWithAction</key>
+		<dict>
+			<key>validatesObjects</key>
+			<true/>
+			<key>actionClass</key>
+			<string>URLActions</string>
+			<key>directTypes</key>
+			<array>
+				<string>Apple URL pasteboard type</string>
+			</array>
+			<key>enabled</key>
+			<false/>
+			<key>indirectTypes</key>
+			<array>
+				<string>com.apple.application-file</string>
+				<string>com.apple.application-bundle</string>
+			</array>
+			<key>actionSelector</key>
+			<string>doURLOpenAction:with:</string>
+		</dict>
 		<key>QSCommandExecuteAction</key>
 		<dict>
 			<key>actionClass</key>
@@ -1877,22 +1197,7 @@
 			<key>icon</key>
 			<string>Rocket</string>
 		</dict>
-		<key>QSObjectSelectAction</key>
-		<dict>
-			<key>actionClass</key>
-			<string>QSObjectActions</string>
-			<key>directTypes</key>
-			<array>
-				<string>*</string>
-			</array>
-			<key>enabled</key>
-			<false/>
-			<key>actionSelector</key>
-			<string>selectObjectInCommandWindow:</string>
-			<key>icon</key>
-			<string>Quicksilver</string>
-		</dict>
-		<key>FileOpenWithAction</key>
+		<key>FileToTrashAction</key>
 		<dict>
 			<key>actionClass</key>
 			<string>FSActions</string>
@@ -1900,21 +1205,27 @@
 			<array>
 				<string>NSFilenamesPboardType</string>
 			</array>
-			<key>precedence</key>
-			<real>0.1</real>
-			<key>indirectTypes</key>
-			<array>
-				<string>com.apple.application-file</string>
-				<string>com.apple.application-bundle</string>
-			</array>
 			<key>actionSelector</key>
-			<string>openFile:with:</string>
-			<key>icon</key>
-			<string>GenericApplicationIcon</string>
+			<string>trashFile:</string>
 		</dict>
 	</dict>
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
+	<key>QSPlugIn</key>
+	<dict>
+		<key>author</key>
+		<string>Blacktree, Inc.</string>
+		<key>extendedDescription</key>
+		<string>Provides support and actions for basic types such as files, strings, and URLs.</string>
+		<key>helpPage</key>
+		<string>plugins:Core Support</string>
+		<key>hidden</key>
+		<true/>
+		<key>description</key>
+		<string>Provides basic file and URL handling</string>
+		<key>icon</key>
+		<string>Quicksilver</string>
+	</dict>
 	<key>QSRegistration</key>
 	<dict>
 		<key>QSObjectSources</key>
@@ -2260,11 +1571,700 @@
 			<string>Rocket.png</string>
 		</dict>
 	</dict>
+	<key>QSPresetAdditions</key>
+	<array>
+		<dict>
+			<key>source</key>
+			<string>QSGroupObjectSource</string>
+			<key>ID</key>
+			<string>QSPresetApplications</string>
+			<key>children</key>
+			<array>
+				<dict>
+					<key>source</key>
+					<string>QSFileSystemObjectSource</string>
+					<key>settings</key>
+					<dict>
+						<key>parser</key>
+						<string>QSDirectoryParser</string>
+						<key>folderTypes</key>
+						<array>
+							<string>com.apple.application</string>
+						</array>
+						<key>folderDepth</key>
+						<integer>3</integer>
+						<key>scanContents</key>
+						<integer>1</integer>
+						<key>watchTarget</key>
+						<true/>
+						<key>kind</key>
+						<string>Folder</string>
+						<key>path</key>
+						<string>/Applications/</string>
+						<key>type</key>
+						<string></string>
+						<key>watchPaths</key>
+						<array>
+							<string>/Applications/Utilities</string>
+						</array>
+					</dict>
+					<key>ID</key>
+					<string>QSPresetMainApplications</string>
+					<key>name</key>
+					<string>Applications</string>
+				</dict>
+				<dict>
+					<key>source</key>
+					<string>QSFileSystemObjectSource</string>
+					<key>requiresSettingsPath</key>
+					<true/>
+					<key>watchTarget</key>
+					<true/>
+					<key>settings</key>
+					<dict>
+						<key>parser</key>
+						<string>QSDirectoryParser</string>
+						<key>folderTypes</key>
+						<array>
+							<string>com.apple.application</string>
+						</array>
+						<key>folderDepth</key>
+						<integer>3</integer>
+						<key>scanContents</key>
+						<integer>1</integer>
+						<key>kind</key>
+						<string>Folder</string>
+						<key>path</key>
+						<string>~/Applications/</string>
+						<key>skipItem</key>
+						<false/>
+					</dict>
+					<key>ID</key>
+					<string>QSPresetUserApplications</string>
+					<key>name</key>
+					<string>Applications (User)</string>
+				</dict>
+				<dict>
+					<key>source</key>
+					<string>QSProcessObjectSource</string>
+					<key>ID</key>
+					<string>QSPresetRunningProcesses</string>
+				</dict>
+				<dict>
+					<key>source</key>
+					<string>QSAllApplicationsObjectSource</string>
+					<key>enabled</key>
+					<false/>
+					<key>ID</key>
+					<string>QSPresetAllApplications</string>
+				</dict>
+			</array>
+			<key>catalogPath</key>
+			<string>/</string>
+			<key>name</key>
+			<string>Applications</string>
+			<key>icon</key>
+			<string>GenericApplicationIcon</string>
+		</dict>
+		<dict>
+			<key>source</key>
+			<string>QSGroupObjectSource</string>
+			<key>children</key>
+			<array>
+				<dict>
+					<key>source</key>
+					<string>QSGroupObjectSource</string>
+					<key>children</key>
+					<array>
+						<dict>
+							<key>source</key>
+							<string>QSGroupObjectSource</string>
+							<key>ID</key>
+							<string>QSPresetPreferencePanes</string>
+							<key>children</key>
+							<array>
+								<dict>
+									<key>source</key>
+									<string>QSFileSystemObjectSource</string>
+									<key>requiresSettingsPath</key>
+									<true/>
+									<key>settings</key>
+									<dict>
+										<key>parser</key>
+										<string>QSDirectoryParser</string>
+										<key>folderTypes</key>
+										<array>
+											<string>com.apple.systempreference.prefpane</string>
+										</array>
+										<key>folderDepth</key>
+										<integer>1</integer>
+										<key>scanContents</key>
+										<integer>1</integer>
+										<key>kind</key>
+										<string>Folder</string>
+										<key>path</key>
+										<string>/Library/PreferencePanes</string>
+										<key>skipItem</key>
+										<integer>1</integer>
+									</dict>
+									<key>icon</key>
+									<string>PrefFileIcon</string>
+									<key>ID</key>
+									<string>QSPresetLibraryPreferencePanes</string>
+								</dict>
+								<dict>
+									<key>source</key>
+									<string>QSFileSystemObjectSource</string>
+									<key>requiresSettingsPath</key>
+									<true/>
+									<key>ID</key>
+									<string>QSPresetUserPreferencePanes</string>
+									<key>settings</key>
+									<dict>
+										<key>parser</key>
+										<string>QSDirectoryParser</string>
+										<key>folderTypes</key>
+										<array>
+											<string>com.apple.systempreference.prefpane</string>
+										</array>
+										<key>folderDepth</key>
+										<integer>1</integer>
+										<key>scanContents</key>
+										<integer>1</integer>
+										<key>kind</key>
+										<string>Folder</string>
+										<key>path</key>
+										<string>~/Library/PreferencePanes</string>
+										<key>skipItem</key>
+										<integer>1</integer>
+										<key>type</key>
+										<string></string>
+									</dict>
+									<key>name</key>
+									<string>System Preferences (User)</string>
+									<key>icon</key>
+									<string>PrefFileIcon</string>
+								</dict>
+								<dict>
+									<key>source</key>
+									<string>QSFileSystemObjectSource</string>
+									<key>ID</key>
+									<string>QSPresetSystemPreferencePanes</string>
+									<key>settings</key>
+									<dict>
+										<key>parser</key>
+										<string>QSDirectoryParser</string>
+										<key>folderTypes</key>
+										<array>
+											<string>com.apple.systempreference.prefpane</string>
+										</array>
+										<key>folderDepth</key>
+										<integer>1</integer>
+										<key>scanContents</key>
+										<integer>1</integer>
+										<key>kind</key>
+										<string>Folder</string>
+										<key>path</key>
+										<string>/System/Library/PreferencePanes</string>
+										<key>skipItem</key>
+										<integer>1</integer>
+									</dict>
+									<key>name</key>
+									<string>System Preferences (System)</string>
+									<key>icon</key>
+									<string>PrefFileIcon</string>
+								</dict>
+							</array>
+							<key>supressChildren</key>
+							<true/>
+							<key>icon</key>
+							<string>SystemPreferencesIcon</string>
+						</dict>
+					</array>
+					<key>icon</key>
+					<string>prefsGeneral</string>
+					<key>ID</key>
+					<string>QSPresetConfiguration</string>
+				</dict>
+				<dict>
+					<key>source</key>
+					<string>QSGroupObjectSource</string>
+					<key>children</key>
+					<array>
+						<dict>
+							<key>source</key>
+							<string>QSVolumesObjectSource</string>
+							<key>ID</key>
+							<string>QSPresetVolumes</string>
+						</dict>
+						<dict>
+							<key>source</key>
+							<string>QSFileSystemObjectSource</string>
+							<key>settings</key>
+							<dict>
+								<key>parser</key>
+								<string>QSDirectoryParser</string>
+								<key>folderTypes</key>
+								<array>
+									<string>com.apple.application</string>
+								</array>
+								<key>folderDepth</key>
+								<integer>1</integer>
+								<key>scanContents</key>
+								<integer>1</integer>
+								<key>path</key>
+								<string>~/Library/Printers</string>
+								<key>skipItem</key>
+								<integer>1</integer>
+							</dict>
+							<key>icon</key>
+							<string>PrintCenterIcon</string>
+							<key>ID</key>
+							<string>QSPresetPrinters</string>
+						</dict>
+					</array>
+					<key>ID</key>
+					<string>QSPresetDevices</string>
+				</dict>
+			</array>
+			<key>catalogPath</key>
+			<string>/</string>
+			<key>icon</key>
+			<string>FinderIcon</string>
+			<key>ID</key>
+			<string>QSPresetSystemGroup</string>
+		</dict>
+		<dict>
+			<key>source</key>
+			<string>QSGroupObjectSource</string>
+			<key>children</key>
+			<array>
+				<dict>
+					<key>source</key>
+					<string>QSFileSystemObjectSource</string>
+					<key>settings</key>
+					<dict>
+						<key>parser</key>
+						<string>QSDirectoryParser</string>
+						<key>folderDepth</key>
+						<integer>1</integer>
+						<key>watchTarget</key>
+						<true/>
+						<key>path</key>
+						<string>~</string>
+					</dict>
+					<key>ID</key>
+					<string>QSPresetHome</string>
+				</dict>
+				<dict>
+					<key>source</key>
+					<string>QSFileSystemObjectSource</string>
+					<key>settings</key>
+					<dict>
+						<key>parser</key>
+						<string>QSDirectoryParser</string>
+						<key>folderDepth</key>
+						<integer>2</integer>
+						<key>watchTarget</key>
+						<true/>
+						<key>path</key>
+						<string>~/Downloads</string>
+					</dict>
+					<key>ID</key>
+					<string>QSPresetDownloads</string>
+				</dict>
+				<dict>
+					<key>source</key>
+					<string>QSFileSystemObjectSource</string>
+					<key>settings</key>
+					<dict>
+						<key>parser</key>
+						<string>QSDirectoryParser</string>
+						<key>folderDepth</key>
+						<integer>1</integer>
+						<key>watchTarget</key>
+						<true/>
+						<key>path</key>
+						<string>~/Documents</string>
+					</dict>
+					<key>ID</key>
+					<string>QSPresetDocuments</string>
+				</dict>
+				<dict>
+					<key>source</key>
+					<string>QSFileSystemObjectSource</string>
+					<key>settings</key>
+					<dict>
+						<key>parser</key>
+						<string>QSDirectoryParser</string>
+						<key>watchTarget</key>
+						<true/>
+						<key>path</key>
+						<string>~/Desktop</string>
+					</dict>
+					<key>ID</key>
+					<string>QSPresetDesktop</string>
+				</dict>
+				<dict>
+					<key>source</key>
+					<string>QSFileSystemObjectSource</string>
+					<key>settings</key>
+					<dict>
+						<key>path</key>
+						<string>~/.Trash</string>
+					</dict>
+					<key>icon</key>
+					<string>TrashIcon</string>
+					<key>ID</key>
+					<string>QSPresetTrash</string>
+				</dict>
+				<dict>
+					<key>source</key>
+					<string>QSGroupObjectSource</string>
+					<key>children</key>
+					<array>
+						<dict>
+							<key>source</key>
+							<string>QSDefaultsObjectSource</string>
+							<key>settings</key>
+							<dict>
+								<key>bundle</key>
+								<string>com.apple.dock</string>
+								<key>type</key>
+								<integer>5</integer>
+								<key>keypath</key>
+								<array>
+									<string>persistent-apps</string>
+									<string>*</string>
+									<string>tile-data</string>
+									<string>file-data</string>
+								</array>
+							</dict>
+							<key>ID</key>
+							<string>QSPresetDockApplications</string>
+						</dict>
+						<dict>
+							<key>source</key>
+							<string>QSDefaultsObjectSource</string>
+							<key>settings</key>
+							<dict>
+								<key>bundle</key>
+								<string>com.apple.dock</string>
+								<key>type</key>
+								<integer>5</integer>
+								<key>keypath</key>
+								<array>
+									<string>persistent-others</string>
+									<string>*</string>
+									<string>tile-data</string>
+									<string>file-data</string>
+								</array>
+							</dict>
+							<key>ID</key>
+							<string>QSPresetDockOthers</string>
+						</dict>
+					</array>
+					<key>icon</key>
+					<string>DockIcon</string>
+					<key>ID</key>
+					<string>QSPresetDockGroup</string>
+				</dict>
+				<dict>
+					<key>source</key>
+					<string>QSGroupObjectSource</string>
+					<key>children</key>
+					<array>
+						<dict>
+							<key>source</key>
+							<string>QSDefaultsObjectSource</string>
+							<key>settings</key>
+							<dict>
+								<key>bundle</key>
+								<string>com.apple.recentitems</string>
+								<key>watchTarget</key>
+								<true/>
+								<key>type</key>
+								<integer>3</integer>
+								<key>keypath</key>
+								<array>
+									<string>RecentApplications</string>
+									<string>CustomListItems</string>
+									<string>*</string>
+									<string>Bookmark</string>
+								</array>
+							</dict>
+							<key>icon</key>
+							<string>GenericApplicationIcon</string>
+							<key>ID</key>
+							<string>QSPresetRecentApplications106</string>
+						</dict>
+						<dict>
+							<key>source</key>
+							<string>QSDefaultsObjectSource</string>
+							<key>watchTarget</key>
+							<true/>
+							<key>settings</key>
+							<dict>
+								<key>bundle</key>
+								<string>com.apple.recentitems</string>
+								<key>type</key>
+								<integer>3</integer>
+								<key>keypath</key>
+								<array>
+									<string>RecentDocuments</string>
+									<string>CustomListItems</string>
+									<string>*</string>
+									<string>Bookmark</string>
+								</array>
+							</dict>
+							<key>icon</key>
+							<string>GenericDocumentIcon</string>
+							<key>ID</key>
+							<string>QSPresetRecentDocuments106</string>
+						</dict>
+						<dict>
+							<key>source</key>
+							<string>QSDefaultsObjectSource</string>
+							<key>watchTarget</key>
+							<true/>
+							<key>settings</key>
+							<dict>
+								<key>bundle</key>
+								<string>com.apple.recentitems</string>
+								<key>type</key>
+								<integer>3</integer>
+								<key>keypath</key>
+								<array>
+									<string>RecentServers</string>
+									<string>CustomListItems</string>
+									<string>*</string>
+									<string>Alias</string>
+								</array>
+							</dict>
+							<key>icon</key>
+							<string>GenericFileServerIcon</string>
+							<key>ID</key>
+							<string>QSPresetRecentServers</string>
+						</dict>
+						<dict>
+							<key>source</key>
+							<string>QSDefaultsObjectSource</string>
+							<key>settings</key>
+							<dict>
+								<key>bundle</key>
+								<string>.GlobalPreferences</string>
+								<key>type</key>
+								<integer>1</integer>
+								<key>keypath</key>
+								<array>
+									<string>NSNavRecentPlaces</string>
+									<string>*</string>
+								</array>
+							</dict>
+							<key>icon</key>
+							<string>GenericFolderIcon</string>
+							<key>ID</key>
+							<string>QSPresetGlobalPrefsRecentFolders</string>
+						</dict>
+					</array>
+					<key>icon</key>
+					<string>SafariHistoryIcon</string>
+					<key>ID</key>
+					<string>QSPresetRecentItems</string>
+				</dict>
+			</array>
+			<key>catalogPath</key>
+			<string>/</string>
+			<key>icon</key>
+			<string>HomeFolderIcon</string>
+			<key>ID</key>
+			<string>QSPresetUserGroup</string>
+		</dict>
+		<dict>
+			<key>source</key>
+			<string>QSGroupObjectSource</string>
+			<key>children</key>
+			<array>
+				<dict>
+					<key>source</key>
+					<string>QSCatalogEntrySource</string>
+					<key>enabled</key>
+					<false/>
+					<key>ID</key>
+					<string>QSPresetQSCatalogEntries</string>
+				</dict>
+				<dict>
+					<key>source</key>
+					<string>QSProxyObjectSource</string>
+					<key>enabled</key>
+					<true/>
+					<key>ID</key>
+					<string>QSPresetProxies</string>
+					<key>feature</key>
+					<integer>1</integer>
+				</dict>
+				<dict>
+					<key>source</key>
+					<string>QSObjCMessageSource</string>
+					<key>enabled</key>
+					<false/>
+					<key>ID</key>
+					<string>QSPresetInternalMessages</string>
+					<key>feature</key>
+					<integer>1</integer>
+				</dict>
+				<dict>
+					<key>source</key>
+					<string>QSHandledObjectHandler</string>
+					<key>enabled</key>
+					<false/>
+					<key>ID</key>
+					<string>QSPresetInternalObjects</string>
+					<key>feature</key>
+					<integer>1</integer>
+				</dict>
+				<dict>
+					<key>source</key>
+					<string>QSHistoryObjectSource</string>
+					<key>feature</key>
+					<integer>3</integer>
+					<key>enabled</key>
+					<false/>
+					<key>userInfo</key>
+					<string>commands</string>
+					<key>ID</key>
+					<string>QSPresetCommandHistory</string>
+				</dict>
+				<dict>
+					<key>source</key>
+					<string>QSHistoryObjectSource</string>
+					<key>ID</key>
+					<string>QSPresetObjectHistory</string>
+					<key>enabled</key>
+					<false/>
+					<key>feature</key>
+					<integer>1</integer>
+					<key>name</key>
+					<string>Recent Objects</string>
+					<key>userInfo</key>
+					<string>objects</string>
+				</dict>
+			</array>
+			<key>catalogPath</key>
+			<string>/</string>
+			<key>icon</key>
+			<string>Quicksilver</string>
+			<key>ID</key>
+			<string>QSPresetQSGroup</string>
+		</dict>
+		<dict>
+			<key>source</key>
+			<string>QSGroupObjectSource</string>
+			<key>children</key>
+			<array>
+				<dict>
+					<key>source</key>
+					<string>QSFileSystemObjectSource</string>
+					<key>requiresSettingsPath</key>
+					<integer>1</integer>
+					<key>enabled</key>
+					<false/>
+					<key>settings</key>
+					<dict>
+						<key>parser</key>
+						<string>QSDirectoryParser</string>
+						<key>folderTypes</key>
+						<array>
+							<string>public.script</string>
+							<string>public.plain-text</string>
+							<string>com.apple.applescript.script</string>
+							<string>dyn.age8u</string>
+						</array>
+						<key>folderDepth</key>
+						<integer>3</integer>
+						<key>scanContents</key>
+						<integer>1</integer>
+						<key>path</key>
+						<string>/Library/Scripts</string>
+						<key>skipItem</key>
+						<integer>1</integer>
+					</dict>
+					<key>icon</key>
+					<string>ScriptIcon</string>
+					<key>ID</key>
+					<string>QSPresetLibraryScripts</string>
+				</dict>
+				<dict>
+					<key>source</key>
+					<string>QSFileSystemObjectSource</string>
+					<key>requiresSettingsPath</key>
+					<integer>1</integer>
+					<key>ID</key>
+					<string>QSPresetUserScripts</string>
+					<key>modificationDate</key>
+					<real>103923120</real>
+					<key>settings</key>
+					<dict>
+						<key>parser</key>
+						<string>QSDirectoryParser</string>
+						<key>folderTypes</key>
+						<array>
+							<string>public.script</string>
+							<string>public.plain-text</string>
+							<string>com.apple.applescript.script</string>
+							<string>dyn.age8u</string>
+						</array>
+						<key>folderDepth</key>
+						<integer>4</integer>
+						<key>scanContents</key>
+						<integer>1</integer>
+						<key>path</key>
+						<string>~/Library/Scripts</string>
+						<key>skipItem</key>
+						<integer>1</integer>
+					</dict>
+					<key>name</key>
+					<string>Scripts (User)</string>
+					<key>icon</key>
+					<string>ScriptIcon</string>
+				</dict>
+				<dict>
+					<key>source</key>
+					<string>QSFileSystemObjectSource</string>
+					<key>requiresSettingsPath</key>
+					<integer>1</integer>
+					<key>settings</key>
+					<dict>
+						<key>parser</key>
+						<string>QSDirectoryParser</string>
+						<key>folderTypes</key>
+						<array>
+							<string>com.apple.applescript.script</string>
+						</array>
+						<key>folderDepth</key>
+						<integer>3</integer>
+						<key>path</key>
+						<string>~/Library/Application Support/DVD Player Scripts</string>
+						<key>skipItem</key>
+						<integer>1</integer>
+					</dict>
+					<key>icon</key>
+					<string>com.apple.DVDPlayer</string>
+					<key>ID</key>
+					<string>QSPresetDVDPlayerScripts</string>
+				</dict>
+			</array>
+			<key>catalogPath</key>
+			<string>/</string>
+			<key>icon</key>
+			<string>CompiledScriptIcon</string>
+			<key>ID</key>
+			<string>QSPresetScriptsGroup</string>
+		</dict>
+	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>English</string>
-	<key>NSHumanReadableCopyright</key>
-	<string>Copyright © 2004, Blacktree, Inc.</string>
-	<key>CFBundleShortVersionString</key>
-	<string>1.0.0</string>
+	<key>CFBundleName</key>
+	<string>Core Support</string>
 </dict>
 </plist>

--- a/Quicksilver/PropertyLists/Quicksilver-Info.plist
+++ b/Quicksilver/PropertyLists/Quicksilver-Info.plist
@@ -2,8 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>QSReleaseStatus</key>
-	<integer>0</integer>
+	<key>LSUIElement</key>
+	<true/>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>NSHumanReadableCopyright</key>
@@ -18,6 +18,8 @@
 	<string>QSApp</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
+	<key>CFBundleShortVersionString</key>
+	<string>${QS_INFO_VERSION}</string>
 	<key>CFBundleDocumentTypes</key>
 	<array>
 		<dict>
@@ -127,8 +129,6 @@
 	<string>APPL</string>
 	<key>CFBundleIconFile</key>
 	<string>Quicksilver</string>
-	<key>CFBundleShortVersionString</key>
-	<string>${QS_INFO_VERSION}</string>
 	<key>CFBundleHelpBookName</key>
 	<string>Quicksilver Help</string>
 	<key>CFBundleInfoDictionaryVersion</key>
@@ -304,7 +304,7 @@
 			</dict>
 		</dict>
 	</array>
-	<key>LSUIElement</key>
-	<true/>
+	<key>QSReleaseStatus</key>
+	<integer>0</integer>
 </dict>
 </plist>

--- a/Quicksilver/Resources/ClientDescription.plist
+++ b/Quicksilver/Resources/ClientDescription.plist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>DisplayName</key>

--- a/Quicksilver/Resources/DefaultMnemonics.plist
+++ b/Quicksilver/Resources/DefaultMnemonics.plist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>abbreviation</key>

--- a/Quicksilver/Resources/FileTypeGroups.plist
+++ b/Quicksilver/Resources/FileTypeGroups.plist
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>QSApplicationFileTypes</key>
 	<array>
 		<string>app</string>
-		<string>'APPL'</string>
+		<string>&apos;APPL&apos;</string>
 	</array>
 	<key>QSCompressedFileTypes</key>
 	<array>

--- a/Quicksilver/Resources/PlugInVersionRequirements.plist
+++ b/Quicksilver/Resources/PlugInVersionRequirements.plist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>com.blacktree.Quicksilver.QSClipboardPlugIn</key>

--- a/Quicksilver/Resources/QSKindDescriptions.plist
+++ b/Quicksilver/Resources/QSKindDescriptions.plist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>ABPeopleUIDsPboardType</key>

--- a/Quicksilver/Resources/ResourceLocations.plist
+++ b/Quicksilver/Resources/ResourceLocations.plist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>AFPClient</key>
@@ -28,7 +28,7 @@
 	<array>
 		<dict>
 			<key>type</key>
-			<string>'osas'</string>
+			<string>&apos;osas&apos;</string>
 		</dict>
 	</array>
 	<key>Computer</key>

--- a/Quicksilver/Scripting/Automator/Get Quicksilver Selection/Info.plist
+++ b/Quicksilver/Scripting/Automator/Get Quicksilver Selection/Info.plist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>AMApplication</key>

--- a/Quicksilver/Scripting/Automator/Send to Quicksilver/Info.plist
+++ b/Quicksilver/Scripting/Automator/Send to Quicksilver/Info.plist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>AMAccepts</key>
@@ -28,7 +28,7 @@
 	<key>AMDescription</key>
 	<dict>
 		<key>AMDSummary</key>
-		<string>Sends items to Quicksilver's command window</string>
+		<string>Sends items to Quicksilver&apos;s command window</string>
 	</dict>
 	<key>AMIconName</key>
 	<string>Action</string>

--- a/Quicksilver/Tools/org.quicksilver.plist
+++ b/Quicksilver/Tools/org.quicksilver.plist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>KeepAlive</key>
-    <true/>
-    <key>Label</key>
-    <string>com.blacktree.Quicksilver</string>
-    <key>LimitLoadToSessionType</key>
-    <string>Aqua</string>
-    <key>ProgramArguments</key>
-    <array>
-      <string>/Applications/Quicksilver.app/Contents/MacOS/Quicksilver</string>
-    </array>
-  </dict>
+<dict>
+	<key>KeepAlive</key>
+	<true/>
+	<key>Label</key>
+	<string>com.blacktree.Quicksilver</string>
+	<key>LimitLoadToSessionType</key>
+	<string>Aqua</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/Applications/Quicksilver.app/Contents/MacOS/Quicksilver</string>
+	</array>
+</dict>
 </plist>


### PR DESCRIPTION
There are **no functional changes** in here. All I did was open each plist and save it to allow Xcode to rewrite them the way it wants. This will hopefully prevent small changes in the future from resulting in dozens of "changes" to a file and merge conflicts that are impossible to resolve.
