### PR TITLE
add a dedicated type for Web Search URLs - close #625

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSObject_URLHandling.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject_URLHandling.m
@@ -136,7 +136,7 @@
 	if (!urlString) return NO;
     
 	// For search URLs
-	if([[object stringValue] rangeOfString:QUERY_KEY].location !=NSNotFound) {
+	if([object containsType:QSSearchURLType]) {
         NSInvocationOperation *theOp = [[[NSInvocationOperation alloc] initWithTarget:self
 																			 selector:@selector(buildWebSearchIconForObject:)
 																			   object:object] autorelease];
@@ -265,6 +265,11 @@
         [self setObject:urlString forType:QSTextType];
         [self setPrimaryType:QSURLType];
     }
+	// search URLs
+	if ([urlString rangeOfString:QUERY_KEY].location != NSNotFound) {
+		[self setObject:urlString forType:QSSearchURLType];
+		[self setPrimaryType:QSSearchURLType];
+	}
 }
 
 @end

--- a/Quicksilver/Code-QuickStepCore/QSTypes.h
+++ b/Quicksilver/Code-QuickStepCore/QSTypes.h
@@ -6,6 +6,7 @@ extern NSString *QSTextType; 			//NSString
 extern NSString *QSAliasDataType; 		//NSData
 extern NSString *QSAliasFilePathType; 	//NSString
 extern NSString *QSURLType; 				//NSString
+extern NSString *QSSearchURLType; 		//NSString
 extern NSString *QSEmailAddressType; 	//NSString
 //extern NSString *QSContactEmailType; 	//NSString
 extern NSString *QSContactPhoneType; 	//NSString

--- a/Quicksilver/Code-QuickStepCore/QSTypes.m
+++ b/Quicksilver/Code-QuickStepCore/QSTypes.m
@@ -13,6 +13,7 @@ NSString *QSTextType = @"NSStringPboardType";
 NSString *QSAliasDataType = @"public.data.alias";
 NSString *QSAliasFilePathType = @"public.alias";
 NSString *QSURLType = @"Apple URL pasteboard type";
+NSString *QSSearchURLType = @"qs.url.search";
 NSString *QSEmailAddressType = @"qs.contact.email";
 NSString *QSContactEmailType = @"qs.contact.email";
 NSString *QSContactPhoneType = @"qs.contact.phone";

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Code/QSActionProvider_EmbeddedProviders.m
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Code/QSActionProvider_EmbeddedProviders.m
@@ -121,7 +121,7 @@
 		// Escape characters (but not # or %)
 		NSURL *url = [NSURL URLWithString:[urlString URLEncoding]];
 		// replace QUERY_KEY *** with nothing if we're just opening the URL
-		if ([urlString rangeOfString:QUERY_KEY].location != NSNotFound) {
+		if ([dObject containsType:QSSearchURLType]) {
 			NSInteger pathLoc = [urlString rangeOfString:[url path]].location;
 			if (pathLoc != NSNotFound)
 				url = [NSURL URLWithString:[[urlString substringWithRange:NSMakeRange(0, pathLoc)] URLEncoding]];
@@ -151,7 +151,7 @@
 
 	for (NSString *urlString in [dObject arrayForType:QSURLType]) {
 		NSURL *url = [NSURL URLWithString:[urlString URLEncoding]];
-		if ([urlString rangeOfString:QUERY_KEY].location != NSNotFound) {
+		if ([dObject containsType:QSSearchURLType]) {
 			NSInteger pathLoc = [urlString rangeOfString:[url path]].location;
 			if (pathLoc != NSNotFound)
 				url = [NSURL URLWithString:[[urlString substringWithRange:NSMakeRange(0, pathLoc)] URLEncoding]];

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/QSCorePlugIn-Info.plist
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/QSCorePlugIn-Info.plist
@@ -2164,6 +2164,8 @@
 			<string>QSHandledObjectHandler</string>
 			<key>Apple URL pasteboard type</key>
 			<string>QSURLObjectHandler</string>
+			<key>qs.url.search</key>
+			<string>QSURLObjectHandler</string>
 			<key>NSColor pasteboard type</key>
 			<string>QSColorObjectHandler</string>
 			<key>NSStringPboardType</key>


### PR DESCRIPTION
As previously discussed, this adds a specific type for search URLs.

The old versions of the web search plug-in will continue to work because the type they depend on, `QSURLType`, is still set for search URLs. A _new_ version of the web search plug-in that takes advantage of this is in the works.
