### PR TITLE
Fix: menu interface iSelector size isn't updated with text. Fixes #1067

### DIFF
--- a/Quicksilver/Code-QuickStepInterface/QSInterfaceController.m
+++ b/Quicksilver/Code-QuickStepInterface/QSInterfaceController.m
@@ -423,9 +423,8 @@
 - (void)searchObjectChanged:(NSNotification*)notif {
 	[[self window] disableFlushWindow];
 	if ([notif object] == dSelector) {
-        if ([iSelector objectValue] != nil) {
-            [iSelector setObjectValue:nil];
-        }
+        [iSelector setObjectValue:nil];
+        [self updateViewLocations];
         [self updateActions];
 	} else if ([notif object] == aSelector) {
         QSAction *obj = [aSelector objectValue];


### PR DESCRIPTION
Reverts an over optimisation I did at https://github.com/quicksilver/Quicksilver/commit/877b3365df88eb94aeb4354dcda7d465b58692df#L0L412
