### PR TITLE
Allow you to copy to.../move to… into all packages/bundles. Fixes #1068

### DIFF
--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/QSCorePlugIn-Info.plist
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/QSCorePlugIn-Info.plist
@@ -969,6 +969,7 @@
 			<key>indirectTypes</key>
 			<array>
 				<string>public.folder</string>
+				<string>public.directory</string>
 			</array>
 			<key>actionSelector</key>
 			<string>moveFiles:toFolder:</string>
@@ -1547,6 +1548,7 @@
 			<key>indirectTypes</key>
 			<array>
 				<string>public.folder</string>
+				<string>public.directory</string>
 			</array>
 			<key>actionSelector</key>
 			<string>copyFiles:toFolder:</string>


### PR DESCRIPTION
With the new indirectTypes options, I'd originally made it so you could only copy to folders

Properly set against the release branch
