### PR TITLE
bump the build number to 3936

### DIFF
--- a/Quicksilver/Configuration/Developer.xcconfig
+++ b/Quicksilver/Configuration/Developer.xcconfig
@@ -4,4 +4,4 @@
 QS_INFO_VERSION = ß70
 
 // The current development version shown in About Box
-QS_BUNDLE_VERSION = 3935
+QS_BUNDLE_VERSION = 3936


### PR DESCRIPTION
There are three open pull requests for plug-ins that require the next build number after B70, which will be 3936. All of the features these plug-ins need are merged to master, but they won't load (without some fiddling), so I propose we go ahead and increase the build number now.
