### PR TITLE
Don't perform key equivalents if the dSelector is empty. Fixes #1122

### DIFF
--- a/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
@@ -1255,6 +1255,9 @@ NSMutableDictionary *bindingsDict = nil;
 }
 
 - (BOOL)performKeyEquivalent:(NSEvent *)theEvent {
+    if (![[self directSelector] objectValue]) {
+        return NO;
+    }
 	if ([[theEvent charactersIgnoringModifiers] isEqualToString:@"\r"] && ([theEvent modifierFlags] & NSCommandKeyMask) > 0) {
 		[self insertNewline:nil];
 		return YES;


### PR DESCRIPTION
Does what it says on the tin :)
