### PR TITLE
disable the paste action for multiple items. Fixes #593

### DIFF
--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Code/QSActionProvider_EmbeddedProviders.m
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Code/QSActionProvider_EmbeddedProviders.m
@@ -788,8 +788,17 @@
 @end
 
 # define kPasteboardPasteAction @"PasteboardPasteAction"
+# define kPasteboardPasteActionAsPlainText @"PasteboardPasteActionAsPlainText"
 
 @implementation ClipboardActions
+
+- (NSArray *)validActionsForDirectObject:(QSObject *)dObject indirectObject:(QSObject *)iObject {
+	if ([dObject count] == 1) {
+		return [NSArray arrayWithObjects:kPasteboardPasteAction,kPasteboardPasteActionAsPlainText,nil];	
+	}
+	return nil;
+}
+	 
 - (QSObject *)copyObject:(QSObject *)dObject {
 	[dObject putOnPasteboard:[NSPasteboard generalPasteboard]];
 	return nil;

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/QSCorePlugIn-Info.plist
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/QSCorePlugIn-Info.plist
@@ -956,6 +956,8 @@
 		</dict>
 		<key>PasteboardPasteActionAsPlainText</key>
 		<dict>
+			<key>validatesObjects</key>
+			<true/>
 			<key>actionClass</key>
 			<string>ClipboardActions</string>
 			<key>directTypes</key>
@@ -1374,6 +1376,8 @@
 		</dict>
 		<key>PasteboardPasteAction</key>
 		<dict>
+			<key>validatesObjects</key>
+			<true/>
 			<key>alternateAction</key>
 			<string>PasteboardPasteActionAsPlainText</string>
 			<key>actionClass</key>


### PR DESCRIPTION
The best solution would be to implement the new NSPasteboard methods introduced in 10.6, as you can pass an array of items to the pasteboard, and it will paste them all. This is a lot harder than it looks

This is an interim fix to avoid the crash.
