### PR TITLE
Preview Icons and other file-related changes

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSObject_FileHandling.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject_FileHandling.m
@@ -266,53 +266,41 @@ NSArray *recentDocumentsForBundle(NSString *bundleIdentifier) {
 
 -(void)previewIcon:(id)object {
 	NSImage *theImage = nil;
-	NSArray *theFiles = [object arrayForType:QSFilePathType];
-	NSString *path = [theFiles lastObject];
-	NSString *firstFile = [theFiles objectAtIndex:0];
+	NSString *path = [[object arrayForType:QSFilePathType] lastObject];
 	NSFileManager *manager = [NSFileManager defaultManager];
 	
 	// the object isn't a file/doesn't exist, so return. shouldn't actually happen
 	if (![manager fileExistsAtPath:path]) {
 		return;
 	}
-	LSItemInfoRecord infoRec;
-	//OSStatus status=
-	LSCopyItemInfoForURL((CFURLRef) [NSURL fileURLWithPath:path] , kLSRequestBasicFlagsOnly, &infoRec);
-		
-	// try preview icon
-	if (!theImage && [[NSUserDefaults standardUserDefaults] boolForKey:@"QSLoadImagePreviews"]) {
-		// do preview icon loading in separate thread (using NSOperationQueue)
-		theImage = [NSImage imageWithPreviewOfFileAtPath:path ofSize:QSMaxIconSize asIcon:YES];
-	}
-		
-	// Just for prefpanes?
-	if (!theImage && infoRec.flags & kLSItemInfoIsPackage) {
-		NSBundle *bundle = [NSBundle bundleWithPath:firstFile];
-		NSString *bundleImageName = nil;
-		if ([[firstFile pathExtension] isEqualToString:@"prefPane"]) {
-			bundleImageName = [[bundle infoDictionary] objectForKey:@"NSPrefPaneIconFile"];
-			
-			if (!bundleImageName) bundleImageName = [[bundle infoDictionary] objectForKey:@"CFBundleIconFile"];
-			if (bundleImageName) {
-				NSString *bundleImagePath = [bundle pathForResource:bundleImageName ofType:nil];
-				theImage = [[[NSImage alloc] initWithContentsOfFile:bundleImagePath] autorelease];
-			}
-		}
-	}
-	
-	// try QS's own methods to generate a preview
-	if (!theImage && [[NSUserDefaults standardUserDefaults] boolForKey:@"QSLoadImagePreviews"]) {
-		NSString *type = [manager typeOfFile:path];
-		if ([[NSImage imageUnfilteredFileTypes] containsObject:type])
-			theImage = [[[NSImage alloc] initWithContentsOfFile:path] autorelease];
-		else {
-			id provider = [QSReg instanceForKey:type inTable:@"QSFSFileTypePreviewers"];
-			//NSLog(@"provider %@", [QSReg tableNamed:@"QSFSFileTypePreviewers"]);
-			theImage = [provider iconForFile:path ofType:type];
-		}
-	}
-	
-	// fallback, if no of the other methods worked: just use icon for filetype
+    
+    if ([[NSUserDefaults standardUserDefaults] boolForKey:@"QSLoadImagePreviews"]) {
+        // try to create a preview icon
+        NSString *uti = [object objectForMeta:@"UTI"];
+        // try customized methods (from plug-ins) to generate a preview
+        NSArray *specialTypes = [[QSReg tableNamed:@"QSFSFileTypePreviewers"] allKeys];
+        for (NSString *type in specialTypes) {
+            if (UTTypeConformsTo((CFStringRef)uti, (CFStringRef)type)) {
+                id provider = [QSReg instanceForKey:type inTable:@"QSFSFileTypePreviewers"];
+                if (provider) {
+                    //NSLog(@"provider %@", [QSReg tableNamed:@"QSFSFileTypePreviewers"]);
+                    theImage = [provider iconForFile:path ofType:type];
+                }
+                break;
+            }
+        }
+        if (!theImage) {
+            NSArray *previewTypes = [[NSUserDefaults standardUserDefaults] objectForKey:@"QSFilePreviewTypes"];
+            for (NSString *type in previewTypes) {
+                if (UTTypeConformsTo((CFStringRef)uti, (CFStringRef)type)) {
+                    // do preview icon loading in separate thread
+                    theImage = [NSImage imageWithPreviewOfFileAtPath:path ofSize:QSMaxIconSize asIcon:YES];
+                    break;
+                }
+            }
+        }
+    }
+	// if no of the other methods worked or previews are disabled: just use icon for filetype
 	if (!theImage) {
 		theImage = [[NSWorkspace sharedWorkspace] iconForFile:path];
 	}

--- a/Quicksilver/Resources/QSDefaults.plist
+++ b/Quicksilver/Resources/QSDefaults.plist
@@ -73,5 +73,12 @@
 	<false/>
 	<key>Use Effects</key>
 	<true/>
+	<key>QSFilePreviewTypes</key>
+	<array>
+		<string>public.image</string>
+		<string>public.movie</string>
+		<string>public.audio</string>
+		<string>com.adobe.pdf</string>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
As discussed in #1149, this changes things so the most useful/appealing icon is chosen, instead of blindly using whatever Quick Look throws out. The list of types that get Quick Look previews was put into the user's preferences so they can be tweaked without modification to the application.
### QSFSFileTypePreviewers

Some history: The only known example of a QSFSFileTypePreviewer was the Music Support plug-in. It would show album covers in QS back before the OS could do it for us. It's no longer used. These previewers [worked based on file extensions](https://github.com/quicksilver/Plugins/blob/master/elements.support.music/Info.plist#L30).

If someone goes to the trouble to implement one of these, there's probably a good reason, so I've moved it to be the first thing checked. I was concerned about this because the `typeOfFile:` method seems pretty expensive and there are currently no QSFSFileTypePreviewers so we'd be getting the type for nothing. So I took advantage of the fact that there are no implementations of this and changed it to use UTI instead of extension. Since the UTI is stored in the object's metadata now, it's much faster to get.
### Other changes
- Since UTI was being determined for every new file object anyway, I stuck it in the object's metadata. This should allow all other operations on file objects to get the UTI without going to disk again. (There are probably a few places we could take advantage of this.)
- There's a small, mostly unrelated, optimization in the `getNameFromFiles` method (d016bd6f7f)
