### PR TITLE
fix the action that handles `mailto:` URLs

### DIFF
--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/QSCorePlugIn-Info.plist
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/QSCorePlugIn-Info.plist
@@ -1527,6 +1527,8 @@
 			<true/>
 			<key>actionClass</key>
 			<string>URLActions</string>
+			<key>actionSelector</key>
+			<string>doURLOpenAction:</string>
 			<key>directTypes</key>
 			<array>
 				<string>Apple URL pasteboard type</string>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/en.lproj/QSAction.commandFormat.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/en.lproj/QSAction.commandFormat.strings
@@ -169,7 +169,7 @@
 	<key>ShellScriptRunAction</key>
 	<string>Run script: %@</string>
 	<key>URLEmailAction</key>
-	<string>Email %@</string>
+	<string>E-mail %@</string>
 	<key>URLFindWithAction</key>
 	<string>Find %@ With %@</string>
 	<key>URLJSAction</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/en.lproj/QSAction.description.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/en.lproj/QSAction.description.strings
@@ -83,7 +83,7 @@
 	<key>AppQuitOthersAction</key>
 	<string>Quit all other Applications</string>
 	<key>URLEmailAction</key>
-	<string>Compose an Email to an Email Address</string>
+	<string>Compose an E-mail using mailto:</string>
 	<key>AppleScriptProcessTextAction</key>
 	<string>Execute an AppleScript with Text</string>
 	<key>FileToTrashAction</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/en.lproj/QSAction.name.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/en.lproj/QSAction.name.strings
@@ -233,7 +233,7 @@
 	<key>ShellScriptRunAction</key>
 	<string>Run Shell Script</string>
 	<key>URLEmailAction</key>
-	<string>Email</string>
+	<string>Open E-mail URL</string>
 	<key>URLFindWithAction</key>
 	<string>Find on Site...</string>
 	<key>URLJSAction</key>


### PR DESCRIPTION
A user asked on IRC yesterday why Quicksilver couldn't just use `mailto:` for e-mail addresses and let the system take care of the rest.

I know all e-mail address objects have `mailto:whatever@wherever` assigned as their URL type, so I was going to tell him to use the “Open URL” action, but I found that it wasn't available. Looking into it, I saw that the validation checked for `mailto:` specifically and returned a different action, and that action wasn’t set up correctly.

I was going to just remove it and treat `mailto:` URL’s like all others, but it occurred to me that using the “Open URL” action on e-mail addresses isn't particularly obvious, and since this other action was 98% defined anyway, I assigned it an `actionSelector` instead (which is all it was missing).
