### PR TITLE
Only filter disabled catalog items if in 'Filter Catalog' search mode. Fixes #1195

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSLibrarian.m
+++ b/Quicksilver/Code-QuickStepCore/QSLibrarian.m
@@ -646,7 +646,6 @@ static CGFloat searchSpeed = 0.0;
 }
 
 - (NSMutableArray *)scoredArrayForString:(NSString *)searchString inSet:(NSArray *)set mnemonicsOnly:(BOOL)mnemonicsOnly {
-	if (!set) set = [defaultSearchSet allObjects];
 	NSMutableArray *rankObjects = [QSDefaultObjectRanker rankedObjectsForAbbreviation:searchString inSet:set inContext:searchString mnemonicsOnly:mnemonicsOnly];
 #ifdef DEBUG
 	NSDate *date = [NSDate date];

--- a/Quicksilver/Code-QuickStepCore/QSObjectRanker.m
+++ b/Quicksilver/Code-QuickStepCore/QSObjectRanker.m
@@ -71,7 +71,6 @@ QSScoreForAbbrevIMP scoreForAbbrevIMP;
 		(QSScoreForObjectIMP) [self instanceMethodForSelector:@selector(rankedObject:forAbbreviation:inContext:withMnemonics:mnemonicsOnly:)];
 
 	for (thisObject in set) {
-    if ([[QSLibrarian sharedInstance] itemIsOmitted:thisObject]) continue;
 		id ranker = [thisObject ranker];
 
         QSRankedObject *rankedObject;

--- a/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
@@ -813,8 +813,21 @@ NSMutableDictionary *bindingsDict = nil;
     // ***Quicksilver's search algorithm is case insensitive
     string = [string lowercaseString];
     
+    NSArray *tempSearchArray;
+    if (!searchArray) {
+        tempSearchArray = [[QSLib defaultSearchSet] allObjects];
+        if (searchMode == SearchFilterAll) {
+            NSIndexSet *validSearchArrayIndexes = [tempSearchArray indexesOfObjectsWithOptions:NSEnumerationConcurrent passingTest:^(id obj, NSUInteger idx, BOOL *stop){
+                return (BOOL) ![[QSLibrarian sharedInstance] itemIsOmitted:obj];
+            }];
+            tempSearchArray = [tempSearchArray objectsAtIndexes:validSearchArrayIndexes];
+        }
+    } else {
+        tempSearchArray = searchArray;
+    }
+    
 	//	NSData *scores;
-	NSMutableArray *newResultArray = [[QSLibrarian sharedInstance] scoredArrayForString:string inSet:searchArray];
+	NSMutableArray *newResultArray = [[QSLibrarian sharedInstance] scoredArrayForString:string inSet:tempSearchArray];
 	//t NSLog(@"scores %@", scores);
 	
 #ifdef DEBUG


### PR DESCRIPTION
This is an improvement on #1197, without the need to go delving around views and things. It requires an extra loop over an array when compared to the original code, but does so with `NSEnumerationConcurrent` so hopefully there won't be any performance loss.

See #1197 for a little more info
