### PR TITLE
Move focus to the 2nd pane when ⇧ is pressed in the 1st pane. Fixes #1030

### DIFF
--- a/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.h
+++ b/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.h
@@ -72,6 +72,7 @@ typedef enum QSSearchMode {
     // Indicates if extras (such as indirect objects) should be updated when the 'search object' is changed. Default is NO
     BOOL updatesSilently;
     QSAction *alternateActionCounterpart;
+    BOOL isFocusedFromShift;
 
 @public
 	QSResultController *resultController;
@@ -92,6 +93,7 @@ typedef enum QSSearchMode {
 
 }
 
+@property (assign) BOOL isFocusedFromShift;
 @property (assign) BOOL updatesSilently;
 @property (retain) QSResultController *resultController;
 @property (retain) QSAction *alternateActionCounterpart;

--- a/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
@@ -37,7 +37,7 @@ NSMutableDictionary *bindingsDict = nil;
 
 @implementation QSSearchObjectView
 
-@synthesize textModeEditor, alternateActionCounterpart, resultController, updatesSilently;
+@synthesize textModeEditor, alternateActionCounterpart, resultController, updatesSilently, isFocusedFromShift;
 
 + (void)initialize {
     if( bindingsDict == nil ) {
@@ -959,10 +959,6 @@ NSMutableDictionary *bindingsDict = nil;
 #pragma mark -
 #pragma mark NSResponder
 - (BOOL)acceptsFirstResponder {
-    if (self != [self directSelector] && [[self directSelector] objectValue] == nil) {
-        // Don't let the aSelctor or iSelector gain focus if the dSelector is empty
-        return NO;
-    }
     return YES;
 }
 
@@ -988,7 +984,12 @@ NSMutableDictionary *bindingsDict = nil;
 - (BOOL)resignFirstResponder {  
     
     if ([self isEqual:[self directSelector]]) {
+        if ([self objectValue] == nil) {
+            return NO;
+        }
         [self updateHistory];
+    } else if(self == [self actionSelector]) {
+        isFocusedFromShift = NO;
     }
 	[resultTimer invalidate];
 	[self hideResultView:self];
@@ -1003,7 +1004,7 @@ NSMutableDictionary *bindingsDict = nil;
     [aSelector setUpdatesSilently:YES];
     NSUInteger flags = [theEvent modifierFlags] & NSDeviceIndependentModifierFlagsMask;
     // if only the command key is pressed
-	if (flags == NSCommandKeyMask) {
+	if (flags == NSCommandKeyMask || flags == (NSCommandKeyMask | NSAlphaShiftKeyMask)) {
 		// change the image
 		QSAction *theAction = [aSelector objectValue];
 		if (theAction && [theAction alternate]) {
@@ -1020,8 +1021,15 @@ NSMutableDictionary *bindingsDict = nil;
             [aSelector setNeedsDisplay:YES];
 			[aSelector setAlternateActionCounterpart:theAction];
 		}
-	}
-	else if ([aSelector alternateActionCounterpart]) {
+	} else if (flags == NSShiftKeyMask || flags == (NSShiftKeyMask | NSAlphaShiftKeyMask)) {
+        if (self == [self directSelector]) {
+            [[self actionSelector] setIsFocusedFromShift:YES];
+            [[self window] makeFirstResponder:[self actionSelector]];
+        }
+    } else if (self == aSelector && isFocusedFromShift) {
+        isFocusedFromShift = NO;
+        [[self window] makeFirstResponder:[self directSelector]];
+    } else if ([aSelector alternateActionCounterpart]) {
         QSAction *theAction = [aSelector objectValue];
         NSMutableArray *currentResultArray = [aSelector resultArray];
         if ([currentResultArray containsObject:[aSelector alternateActionCounterpart]]) {


### PR DESCRIPTION
This fixes a bug by Apple, but also makes the feature more obvious. (see #1030)

Other fixes:
- Allow ⌘ (and ⇧) to show alternate actions (focus the 2nd pane) if the capslock key is on as well.
- Don't let the 1st pane resign first responder if it's empty (more reliable than only letting the 2nd pane accept first responder if the 1st pane isn't empty  (done in `acceptsFirstResponder`))

Rob - now I see why you were happy for me to get a new Mac… it was so that I could get annoyed by this and fix it for you ;-)
