### PR TITLE
Speedups

### DIFF
--- a/Quicksilver/Code-QuickStepFoundation/NSArray_BLTRExtensions.h
+++ b/Quicksilver/Code-QuickStepFoundation/NSArray_BLTRExtensions.h
@@ -8,10 +8,6 @@
 
 #import <Foundation/Foundation.h>
 
-@interface NSArray (IndexSet)
-- (NSArray *)objectsAtIndexes:(NSIndexSet *)indexes;
-@end
-
 @interface NSObject (BLTRArrayPerform)
 + (NSMutableArray *)performSelector:(SEL)aSelector onObjectsInArray:(id)array returnValues:(BOOL)flag;
 - (NSMutableArray *)performSelector:(SEL)aSelector onObjectsInArray:(id)array returnValues:(BOOL)flag;

--- a/Quicksilver/Code-QuickStepFoundation/NSArray_BLTRExtensions.m
+++ b/Quicksilver/Code-QuickStepFoundation/NSArray_BLTRExtensions.m
@@ -25,16 +25,6 @@
 
 @end
 
-@implementation NSArray (IndexSet)
-- (NSArray *)objectsAtIndexes:(NSIndexSet *)indexes {
-	NSMutableArray *array = [NSMutableArray array];
-	NSUInteger index;
-	for (index = [indexes firstIndex]; index != NSNotFound; index = [indexes indexGreaterThanIndex:index])
-		[array addObject:[self objectAtIndex:index]];
-	return array;
-}
-@end
-
 @implementation NSArray (Transformation)
 
 - (BOOL)hasPrefix:(NSArray *)prefixArray { return NO; }


### PR DESCRIPTION
I meant to mention this on #1180 but forgot… so I've done it myself.

I wasn't too fond of the `mutableCopy` that was done when populating the 3rd pane for 'open with…', just because mustableCopies are wasteful.

In this commit I've avoided it like the plague and done what I think is a little neater.

Here's the stats:

Rob's way:

```2012-11-13 09:30:52.594 Quicksilver[17859:303] Time: 3.196290
2012-11-13 09:31:00.470 Quicksilver[17859:303] Time: 3.082813
2012-11-13 09:31:06.725 Quicksilver[17859:303] Time: 3.066322
2012-11-13 09:31:12.398 Quicksilver[17859:303] Time: 3.067382
2012-11-13 09:31:17.980 Quicksilver[17859:303] Time: 3.105199
2012-11-13 09:31:23.366 Quicksilver[17859:303] Time: 3.051625
Sum = 18.5696
Avg = 3.0949

My way:

2012-11-13 09:31:46.183 Quicksilver[18048:303] Time: 2.888232
2012-11-13 09:31:52.231 Quicksilver[18048:303] Time: 2.790452
2012-11-13 09:31:57.658 Quicksilver[18048:303] Time: 2.745043
2012-11-13 09:32:03.093 Quicksilver[18048:303] Time: 2.796696
2012-11-13 09:32:08.252 Quicksilver[18048:303] Time: 2.771102
2012-11-13 09:32:13.054 Quicksilver[18048:303] Time: 2.741780
2012-11-13 09:32:18.048 Quicksilver[18048:303] Time: 2.751693
2012-11-13 09:32:22.767 Quicksilver[18048:303] Time: 2.742932
2012-11-13 09:32:28.189 Quicksilver[18048:303] Time: 2.981644
Sum = 25.2096
Avg = 2.8011

Diff = 9.5% improvement ```

If everyone (mainly @skurfer) is happy with this, I'll squash these two commits and then do the same for the copy to.../move to… actions.
I've left the profiling code in in the 1st commit incase anybody wants to test it on their machine :)
