### PR TITLE
show release notes when running a new version by default

### DIFF
--- a/Quicksilver/Resources/QSDefaults.plist
+++ b/Quicksilver/Resources/QSDefaults.plist
@@ -70,7 +70,7 @@
 	<key>Search Delay</key>
 	<real>0.05</real>
 	<key>Show Release Notes on Upgrade</key>
-	<false/>
+	<true/>
 	<key>Use Effects</key>
 	<true/>
 	<key>QSFilePreviewTypes</key>


### PR DESCRIPTION
There are _a lot_ of changes coming in B71. We should make them more obvious.
