### PR TITLE
prevent the current search from being applied to objects in history

### DIFF
--- a/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
@@ -1605,7 +1605,7 @@ NSMutableDictionary *bindingsDict = nil;
 #ifdef DEBUG
 	if (VERBOSE) NSLog(@"select in history %ld %@", (long)i, [historyArray valueForKeyPath:@"selection.displayName"]);
 #endif
-	//
+	[self setMatchedString:@""];
 	if (i<(NSInteger)[(NSArray *)historyArray count])
 		[self setHistoryState:[historyArray objectAtIndex:i]];
 }


### PR DESCRIPTION
This fixes two visual oddities:
1. If you search for `s`, then start going back through your history, any object with `s` in the name or label would have that character underlined.
2. Some objects, like Safari, would always appear in the history with both name and label visible, as in “Safari ⟷ Safari.app”. This would happen unconditionally (not just when the active search string matched something in the name).

There seem to be 5 different methods to “reset” the search string in this class, but I think I’ve selected the correct one.

Note that this is a pull against the release branch. It should be merged it to master too, when the time comes.
