### PR TITLE
Fall back to the English defaultsMap file if no localisation file can be found. Fixes #1233

### DIFF
--- a/Quicksilver/Code-App/QSAdvancedPrefPane.m
+++ b/Quicksilver/Code-App/QSAdvancedPrefPane.m
@@ -42,7 +42,12 @@
 #endif
 
 - (NSArray *)prefSets {
-	return [NSArray arrayWithContentsOfFile:[[NSBundle mainBundle] pathForResource:@"DefaultsMap" ofType:@"plist"]];
+    NSString *defaultsMapPath = [[NSBundle mainBundle] pathForResource:@"DefaultsMap" ofType:@"plist"];
+    // fall back to the English file if no localisation can be found
+    if (!defaultsMapPath) {
+        defaultsMapPath = [[NSBundle mainBundle] pathForResource:@"DefaultsMap" ofType:@"plist" inDirectory:nil forLocalization:@"en"];
+    }
+	return [NSArray arrayWithContentsOfFile:defaultsMapPath];
 }
 
 - (CGFloat) tableView:(NSTableView *)tableView heightOfRow:(NSInteger)row {


### PR DESCRIPTION
I localised this file recently., but of course didn't think of the situation where a user might not even have English as an option in their language system prefs. This ensures the English file is used if no localisation can be found.

Based against the release branch. Should be merged into master once done.
