### PR TITLE
make sure docking windows close when the 'x' button is pressed

### DIFF
--- a/Quicksilver/Code-QuickStepInterface/QSDockingWindow.m
+++ b/Quicksilver/Code-QuickStepInterface/QSDockingWindow.m
@@ -131,7 +131,7 @@
 }
 
 - (BOOL)canBecomeKeyWindow {
-    return YES;
+    return !hidden && ![[(QSController *)[NSApp delegate] interfaceController] hiding];
 }
 
 - (BOOL)hidden {return hidden;}


### PR DESCRIPTION
This fixes a strange bug @skurfer picked up about docking windows. Clicking 'x' (close) in a docking window wouldn't necessarily close the right window!

Simple fix, and a bit of tidying up.

P.S. Here's your thanksgiving preset Rob. Who's to say we don't celebrate it?!
