### PR TITLE
localized files

### DIFF
--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Code/QSFileSystemObjectSource.m
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Code/QSFileSystemObjectSource.m
@@ -344,14 +344,6 @@
 
 	if (!parser || ![[settings objectForKey:kItemSkipItem] boolValue]) {
 		QSObject *mainObject = [QSObject fileObjectWithPath:path];
-		NSString *name = [theEntry objectForKey:kItemName];
-		if (!QSGetLocalizationStatus() && !name) {
-			NSString *theID = [theEntry objectForKey:kItemID];
-			if ([theID hasPrefix:@"QSPreset"])
-				name = [[NSBundle mainBundle] safeLocalizedStringForKey:theID value:theID table:@"QSCatalogPreset.name"];
-		}
-		if (name) [mainObject setLabel:name];
-
 		[containedItems addObject:mainObject];
 	}
 	return containedItems;


### PR DESCRIPTION
If a file object also happens to be the root of a catalog entry, use the catalog entry's name instead of the file's name? Ummm… How about "no". :-)

This was causing things like `~/Desktop` and `~/Downloads` to appear in English no matter what.
