### PR TITLE
make sure docking windows close when the x button is pressed

### DIFF
--- a/Quicksilver/Code-QuickStepInterface/QSDockingWindow.m
+++ b/Quicksilver/Code-QuickStepInterface/QSDockingWindow.m
@@ -19,17 +19,17 @@
 		[self setSticky:YES];
 		hidden = YES;
 		
-		NSMutableArray *types = [standardPasteboardTypes mutableCopy];
-		[types addObjectsFromArray:[[QSReg objectHandlers] allKeys]];
-		[self registerForDraggedTypes:types];
-		[types release];
+        [self registerForDraggedTypes:[standardPasteboardTypes arrayByAddingObjectsFromArray:[[QSReg objectHandlers] allKeys]]];
 	}
 	return self;
 }
 
-#if 0
-- (void)sendEvent:(NSEvent *)theEvent { /*NSLog(@"Event: %@", theEvent);*/ [super sendEvent:theEvent]; }
-#endif
+- (void)sendEvent:(NSEvent *)theEvent {
+    // when events (such as a mouse click) are sent to the window, allow it to become key
+    allowKey = YES;
+    [super sendEvent:theEvent];
+    allowKey = NO;
+}
 
 - (void)awakeFromNib {
 	[self center];


### PR DESCRIPTION
A rework of #1237. See there for details.

We need the window to become key when events are sent to it so that things like clicking the 'x' button works.
Are we working round an OS X bug? I think that's normal now :)
