### PR TITLE
Remove two dangling actions

### DIFF
--- a/Quicksilver/PlugIns-Main/Finder/Info.plist
+++ b/Quicksilver/PlugIns-Main/Finder/Info.plist
@@ -25,12 +25,7 @@
 	<key>QSActions</key>
 	<dict>
 		<key>FinderEmptyTrashAction</key>
-		<dict>
-			<key>actionProvider</key>
-			<string>QSFinderProxy</string>
-			<key>actionSelector</key>
-			<string>emptyTrash:</string>
-		</dict>
+		<dict/>
 		<key>FinderOpenTrashAction</key>
 		<dict>
 			<key>actionProvider</key>


### PR DESCRIPTION
These actions have caused confusion for lots of users, especially as the 'FinderOpenTrashAction' has the name 'Open' and works on all objects.
