### PR TITLE
Remove two dangling actions. Fixes #1242

### DIFF
--- a/Quicksilver/PlugIns-Main/Finder/Info.plist
+++ b/Quicksilver/PlugIns-Main/Finder/Info.plist
@@ -22,27 +22,6 @@
 	<string>17A5</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2004, Blacktree, Inc.</string>
-	<key>QSActions</key>
-	<dict>
-		<key>FinderEmptyTrashAction</key>
-		<dict>
-			<key>actionProvider</key>
-			<string>QSFinderProxy</string>
-			<key>actionSelector</key>
-			<string>emptyTrash:</string>
-			<key>enabled</key>
-			<false/>
-		</dict>
-		<key>FinderOpenTrashAction</key>
-		<dict>
-			<key>actionProvider</key>
-			<string>QSFinderProxy</string>
-			<key>actionSelector</key>
-			<string>openTrash:</string>
-			<key>enabled</key>
-			<false/>
-		</dict>
-	</dict>
 	<key>QSPlugIn</key>
 	<dict>
 		<key>author</key>


### PR DESCRIPTION
These actions have caused confusion for lots of users, especially as the 'FinderOpenTrashAction' has the name 'Open' and works on all objects.

This is based against release, since quite a few users have reported problems with the 'open' action in ß71. Most likely due to the _real_ Open action being localised, but this one not.
