### PR TITLE
move Handlers preferences above the separator

### DIFF
--- a/Quicksilver/PropertyLists/QSRegistration.plist
+++ b/Quicksilver/PropertyLists/QSRegistration.plist
@@ -275,6 +275,8 @@
 			<string>Quicksilver</string>
 			<key>name</key>
 			<string>Handlers</string>
+			<key>type</key>
+			<string>Main</string>
 		</dict>
 		<key>QSMainMenuPrefPane</key>
 		<dict>


### PR DESCRIPTION
As mentioned in #1182. With this change, all of the preferences related to the core application appear above the line. Preferences for additional plug-ins appear below it.
