### PR TITLE
ß71: Set `savedKeyboard` to `nil` after releasing it. Fixes #1254

### DIFF
--- a/Quicksilver/Code-QuickStepInterface/QSInterfaceController.m
+++ b/Quicksilver/Code-QuickStepInterface/QSInterfaceController.m
@@ -202,6 +202,7 @@
     if ([[NSUserDefaults standardUserDefaults] boolForKey:@"QSSwitchKeyboardOnActivation"] && savedKeyboard) {
         TISSelectInputSource(savedKeyboard);
         CFRelease(savedKeyboard);
+        savedKeyboard = nil;
     }
 }
 


### PR DESCRIPTION
I _think_ this is all that's needed to fix #1254

Since @tiennou has played more with input sources, could you have a quick look over it?

Seems to me like exactly the same crash and fix as [this one](https://github.com/blakewatters/AFNetworking/commit/3589d25652034b71ca408eadb60de4ff903a44e4) so I'd have thought it's right :)

Correctly based against the release branch. Sorry for the incorrect first pull.
