### PR TITLE
ß71: Don't set the label as an empty string

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSObject_FileHandling.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject_FileHandling.m
@@ -797,7 +797,7 @@ NSArray *recentDocumentsForBundle(NSString *bundleIdentifier) {
 			if (mdItem) {
 				newLabel = [(NSString *)MDItemCopyAttribute(mdItem, kMDItemDisplayName) autorelease];
 			}
-			if (!newLabel) {
+			if (!newLabel || ![newLabel length]) {
 				newLabel = [[NSFileManager defaultManager] displayNameAtPath:path];
 			}
 		}
@@ -805,6 +805,7 @@ NSArray *recentDocumentsForBundle(NSString *bundleIdentifier) {
 		if ([newLabel isEqualToString:newName]) newLabel = nil;
 	}
 	[self setName:newName];
+
 	[self setLabel:newLabel];
 }
 


### PR DESCRIPTION
I think when the OS doesn't have a localisation for a file (such as when the language is set to Welsh), `mdls` gives the `kMDItemDisplayName` as an empty string. Check for this before blindly using it as the label

This was only really causing problems for .prefPane files, but I think there were a few others. It means that an empty label `@""` was being set and nothing was showing in the interface

http://cl.ly/image/0g3N1e3z4719

Here's what `mdls` gives for the Localization.prefPane file:

```
PaddyMBP:PreferencePanes patrick$ mdls Localization.prefPane
kMDItemAlternateNames          = (
    "Localization.prefPane"
)
kMDItemCFBundleIdentifier      = "com.apple.Localization"
kMDItemContentCreationDate     = 2012-06-20 22:08:38 +0000
kMDItemContentModificationDate = 2012-06-20 22:08:38 +0000
kMDItemContentType             = "com.apple.systempreference.prefpane"
kMDItemContentTypeTree         = (
    "com.apple.systempreference.prefpane",
    "com.apple.package",
    "public.directory",
    "public.item",
    "com.apple.bundle"
)
kMDItemDateAdded               = 2012-07-22 02:21:55 +0000
kMDItemDisplayName             = ""
```

Note `kMDItemDisplayName             = ""`
