### PR TITLE
Don't add multiple actions with the same ID. Fixes #1259

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSExecutor.m
+++ b/Quicksilver/Code-QuickStepCore/QSExecutor.m
@@ -169,16 +169,18 @@ QSExecutor *QSExec = nil;
 
 - (void)addAction:(QSAction *)action {
 	NSString *ident = [action identifier];
-	if (!ident)
+	if (!ident) {
 		return;
-	NSString *altName = [actionNames objectForKey:ident];
-	if (altName) [action setLabel:altName];
+    }
+    
 	QSAction *dupAction = [actionIdentifiers objectForKey:ident];
 	if (dupAction) {
-		[[directObjectTypes allValues] makeObjectsPerformSelector:@selector(removeObject:) withObject:dupAction];
-		[[directObjectFileTypes allValues] makeObjectsPerformSelector:@selector(removeObject:) withObject:dupAction];
+        return;
 	}
 
+    NSString *altName = [actionNames objectForKey:ident];
+	if (altName) [action setLabel:altName];
+    
 	[actionIdentifiers setObject:action forKey:ident];
 
     


### PR DESCRIPTION
The code for dealing with duplicates was already in the code, but for some strange reason it just removed the `directTypes` and `directFileTypes` for the _old_ action, before adding the new action as well.

This kind of make the old action (the one that was added first) pointless as it's direct types weren't set properly.

I've gone with the view that IDs should be unique. If there's already an action with the same ID that exists, then do nothing. Don't replace it, don't try and do anything fancy :)

I could have fixed #1259 in the services plugin but thought it was better to get it right from the start :)
