### PR TITLE
Notification Fix

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSNotifyMediator.m
+++ b/Quicksilver/Code-QuickStepCore/QSNotifyMediator.m
@@ -16,11 +16,12 @@ BOOL QSShowNotifierWithAttributes(NSDictionary *attributes) {
 - (id <QSNotifier>) preferredNotifier {
 	id <QSNotifier> mediator = [prefInstances objectForKey:kQSNotifiers];
 	if (!mediator) {
-        if ([NSApplication isMountainLion]) {
-            mediator = [self instanceForKey:[[NSUserDefaults standardUserDefaults] stringForKey:kQSNotifiers] inTable:kQSNotifiers];
-        } else {
+        NSString *userPref = [[NSUserDefaults standardUserDefaults] stringForKey:kQSNotifiers];
+        if (![NSApplication isMountainLion] && [userPref isEqualToString:@"com.apple.NotificationCenter"]) {
             // drop10.7: ugly hack - when Notification Center becomes the default, remove this
             mediator = [self instanceForKey:@"com.blacktree.Quicksilver" inTable:kQSNotifiers];
+        } else {
+            mediator = [self instanceForKey:userPref inTable:kQSNotifiers];
         }
 		if (mediator)
 			[prefInstances setObject:mediator forKey:kQSNotifiers];


### PR DESCRIPTION
Last time I looked at this, I misunderstood `prefInstances`. When the application launches, `mediator` will _always_ be `nil` the first time. After that it gets set according to the logic I changed here.

It was set so it would only look at the user's preferred notifier if they were using 10.8.
