### PR TITLE
Always show release notes in a browser. Fixes #1280

### DIFF
--- a/Quicksilver/Code-App/QSController.m
+++ b/Quicksilver/Code-App/QSController.m
@@ -771,7 +771,13 @@ static QSController *defaultController = nil;
     [fm release];
 }
 
-- (IBAction)showReleaseNotes:(id)sender { [[NSWorkspace sharedWorkspace] openFile:[[[NSBundle mainBundle] bundlePath] stringByAppendingPathComponent:@"Contents/SharedSupport/Changes.html"]];  }
+- (IBAction)showReleaseNotes:(id)sender {
+    
+    NSURL *appURL = nil;
+    LSGetApplicationForURL((CFURLRef)[NSURL URLWithString:@"http://"], kLSRolesAll, NULL, (CFURLRef *)&appURL);
+    [[NSWorkspace sharedWorkspace] openFile:[[[NSBundle mainBundle] bundlePath] stringByAppendingPathComponent:@"Contents/SharedSupport/Changes.html"] withApplication:[appURL path]];
+    [appURL release];
+}
 
 - (QSInterfaceController *)interfaceController { return [QSReg preferredCommandInterface];  }
 


### PR DESCRIPTION
Regardless of what the user's preferences are for opening .html files, always open the release notes in the default browser

Simple really :)

Well, it would be if I didn't forget to set it against the release branch **every time**! Sorry guys :(
