### PR TITLE
file preview efficiency

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSObject_FileHandling.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject_FileHandling.m
@@ -221,14 +221,11 @@ NSArray *recentDocumentsForBundle(NSString *bundleIdentifier) {
             }
         }
     }
-	// if no of the other methods worked or previews are disabled: just use icon for filetype
-	if (!theImage) {
-		theImage = [[NSWorkspace sharedWorkspace] iconForFile:path];
-	}
-
-	theImage = [self prepareImageforIcon:theImage];
-	
-	[object updateIcon:theImage];
+    if (theImage) {
+        // update the UI with the new icon
+        theImage = [self prepareImageforIcon:theImage];
+        [object updateIcon:theImage];
+    }
 }
 
 - (NSImage *)prepareImageforIcon:(NSImage *)theImage {


### PR DESCRIPTION
The fallback value when no preview image is available for a file object was the "regular" icon from `NSWorkspace`. But it occurred to me that the regular icon is what gets used as the initial value while the background thread goes and looks for something better. If nothing better is found, there's no sense falling back to the icon that's already set and forcing the UI to redraw.

This should cut down on **a ton** of `QSObjectIconModified` notifications.
