### PR TITLE
remove unused methods

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSProcessMonitor.m
+++ b/Quicksilver/Code-QuickStepCore/QSProcessMonitor.m
@@ -373,14 +373,6 @@ OSStatus appTerminated(EventHandlerCallRef nextHandler, EventRef theEvent, void 
 #pragma mark -
 #pragma mark Utilities
 
-- (void)addObserverForEvent:(NSString *)event trigger:(NSDictionary *)trigger {
-	NSLog(@"Add %@", event);
-}
-
-- (void)removeObserverForEvent:(NSString *)event trigger:(NSDictionary *)trigger {
-	NSLog(@"Remove %@", event);
-}
-
 - (NSArray *)processesWithHiddenState:(BOOL)hidden {
 	NSMutableArray *objects = [NSMutableArray arrayWithCapacity:1];
 


### PR DESCRIPTION
These are called by the Event Triggers plug-in so individual handlers can be told which specific notifications they need to watch for. In this case, the application launched/quit notifications are already handled by the Event Triggers plug-in itself. All these are doing is sending noise to the console.
