### PR TITLE
treat current selection as a string when type is unknown

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSGlobalSelectionProvider.m
+++ b/Quicksilver/Code-QuickStepCore/QSGlobalSelectionProvider.m
@@ -168,7 +168,7 @@ NSTimeInterval failDate = 0;
 	}
 	NSDictionary *info = [[QSReg tableNamed:@"QSProxies"] objectForKey:identifier];
 	NSArray *array = [info objectForKey:kQSProxyTypes];
-	if (!info) return [NSArray arrayWithObjects:NSStringPboardType, NSFilenamesPboardType, nil];
+	if (!info) return [NSArray arrayWithObjects:NSStringPboardType, nil];
 	if (array) return array;
 	
 	id provider = [QSReg getClassInstance:[info objectForKey:kQSProxyProviderClass]];


### PR DESCRIPTION
I'm not sure what the thinking was behind these defaults. The history credits it to the "Code cleanup" commit. :-(

Anyway, I see no reason to include the file type. The value for it is empty anyway, and in situations where the Current Selection proxy _should_ have a file type, it does without this default (tested in Finder and Path Finder).

The reason for this change is that the "Find With…" action [wouldn't appear](https://groups.google.com/d/topic/blacktree-quicksilver/T4-8tN8G9gE/discussion) for Current Selection. The Web Search plug-in only allows that action for objects with the text type, but no file type.

If anyone is uncomfortable with this change, there are at least two other ways to fix it in the plug-in instead:
1. Instead of just checking for the presence of the file type, maybe test `validSingleFilePath` instead. So if it's just a blank dummy type, it won't prevent the action from appearing.
2. Allow the "Find With…" action for files. Hey, maybe someone has a need to search the web for the string "~/Library/Application Support". :-)
