### PR TITLE
Perform indexIsValid on the scanQueue

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSProcessMonitor.m
+++ b/Quicksilver/Code-QuickStepCore/QSProcessMonitor.m
@@ -441,7 +441,11 @@ OSStatus appTerminated(EventHandlerCallRef nextHandler, EventRef theEvent, void 
 - (NSMutableDictionary *)processesDict {
 	if (!processes) {
 		processes = [[NSMutableDictionary dictionaryWithCapacity:1] retain];
-		[self reloadProcesses];
+        isReloading = YES;
+        for (id thisProcess in [NDProcess everyProcess]) {
+            [self addProcessWithPSN:[thisProcess processSerialNumber]];
+        }
+        isReloading = NO;
 	}
 	return processes;
 }

--- a/Quicksilver/Code-QuickStepFoundation/NSFileManager_BLTRExtensions.m
+++ b/Quicksilver/Code-QuickStepFoundation/NSFileManager_BLTRExtensions.m
@@ -239,9 +239,7 @@
 
 - (BOOL)touchPath:(NSString *)path {
 	return [self setAttributes:[NSDictionary dictionaryWithObject:[NSDate date] forKey:NSFileModificationDate] ofItemAtPath:path error:nil];
-
 }
-
 
 - (NSDate *)path:(NSString *)path wasModifiedAfter:(NSDate *)date depth:(NSInteger)depth {
 	NSWorkspace *workspace = [NSWorkspace sharedWorkspace];
@@ -250,8 +248,14 @@
 
 	if (depth) depth--;
 
-	NSDate *moddate = [[self attributesOfItemAtPath:path error:NULL] fileModificationDate];
-
+    NSError *err = nil;
+	NSDate *moddate = [[self attributesOfItemAtPath:path error:&err] fileModificationDate];
+    if (err) {
+        NSLog(@"Error: %@",err);
+    }
+    if (!moddate) {
+        return date;
+    }
 	if ([date compare:moddate] == NSOrderedAscending && [moddate timeIntervalSinceNow] <0) {
 		return moddate;
 	}


### PR DESCRIPTION
Avoids cases where indexDate is modified by saveIndex when being accessed by indexIsValid

Performing indexIsValid on the scan queue could quite likely cause a lock up of QS. This was the case for the QSProcessSource, and is fixed in this commit.
This is not great, and could potentially cause a lot of lock ups in QS, but my reasoning is that we never object sources to recursively rescan themselves, and this will bring them to light (albeit in an annoying way to the user).

e.g. The first time QSProcessSource.m was sent `objectsForEntry:`, it loaded all the processes into a mutable dict (`processes`) and subsequently sent an `invalidateSelf` message, causing it to be rescanned _again_ whilst it's being scanned for the 1st time. Not something we want to do.

If you're completely unhappy with this, we should keep the QSProcessSource changes in, but use some kind of BOOL (say `isSavingIndex`) that would be set on `saveIndex` to `YES`.

Really, the fundamental problem is that `indexIsValid` is being called whilst the catalog is being saved (i.e. the catalog is being scanned whilst it is being saved) so we should fix that. 
I'm throwing this out there to get a discussion going.

View the crash log [here](https://gist.github.com/4503804)
