### PR TITLE
Show omitted catalog items if in "browsing" in Quicksilver, Fixes #1195

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSLibrarian.m
+++ b/Quicksilver/Code-QuickStepCore/QSLibrarian.m
@@ -651,13 +651,19 @@ static CGFloat searchSpeed = 0.0;
 }
 
 - (NSMutableArray *)scoredArrayForString:(NSString *)searchString inSet:(NSArray *)set mnemonicsOnly:(BOOL)mnemonicsOnly {
-	if (!set) set = [defaultSearchSet allObjects];
+    BOOL includeOmitted = NO;
+    if (!set) {
+        set = [defaultSearchSet allObjects];
+    } else {
+        includeOmitted = YES;
+    }
+    
     if (!searchString) searchString = @"";
-
     BOOL usePureStringRanking = [[NSUserDefaults standardUserDefaults] boolForKey:@"QSUsePureStringRanking"];
     NSDictionary *options = [NSDictionary dictionaryWithObjectsAndKeys:
                              searchString, QSRankingContext,
                              set, QSRankingObjectsInSet,
+                             [NSNumber numberWithBool:includeOmitted], QSRankingIncludeOmitted,
                              [NSNumber numberWithBool:mnemonicsOnly], QSRankingMnemonicsOnly,
                              [NSNumber numberWithBool:usePureStringRanking], QSRankingUsePureString,
                              nil];

--- a/Quicksilver/Code-QuickStepCore/QSObjectRanker.h
+++ b/Quicksilver/Code-QuickStepCore/QSObjectRanker.h
@@ -16,6 +16,7 @@ extern NSString *QSRankingMnemonicsOnly;    // BOOL
 extern NSString *QSRankingObjectsInSet;     // NSArray
 extern NSString *QSRankingContext;          // NSString, unused ?
 extern NSString *QSRankingUsePureString;    // BOOL
+extern NSString *QSRankingIncludeOmitted;   // BOOL. Specifies whether the ranker should include omitted catalog items or not
 
 @protocol QSObjectRanker
 - (id)initWithObject:(QSBasicObject *)object;

--- a/Quicksilver/PropertyLists/QSRegistration.plist
+++ b/Quicksilver/PropertyLists/QSRegistration.plist
@@ -428,7 +428,7 @@
 			<key>name</key>
 			<string>String Ranker</string>
 			<key>requiresRelaunch</key>
-			<true/>
+			<false/>
 			<key>type</key>
 			<string>mediator</string>
 		</dict>


### PR DESCRIPTION
This uses the new ranker options created in #1212.
It's a better workaround to #1198 
