### PR TITLE
recreate objects that aren't in the catalog (demo)

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSCommand.m
+++ b/Quicksilver/Code-QuickStepCore/QSCommand.m
@@ -243,9 +243,10 @@ NSTimeInterval QSTimeIntervalForString(NSString *intervalString) {
         dObject = [newObject retain];
         
         id rep = [dObject identifier];
-        if(rep != nil)
+        if(rep != nil) {
             [[self commandDict] setObject:rep forKey:@"directID"];
-        else {
+            [[self commandDict] setObject:[dObject primaryType] forKey:@"directType"];
+        } else {
             rep = [dObject dictionaryRepresentation];
             if(rep)
                 [[self commandDict] setObject:rep forKey:@"directArchive"];
@@ -276,9 +277,10 @@ NSTimeInterval QSTimeIntervalForString(NSString *intervalString) {
         iObject = [newObject retain];
     
         id rep = [iObject identifier];
-        if(rep != nil)
+        if(rep != nil) {
             [[self commandDict] setObject:rep forKey:@"indirectID"];
-        else {
+            [[self commandDict] setObject:[iObject primaryType] forKey:@"indirectType"];
+        } else {
             rep = [iObject dictionaryRepresentation];
             if(rep)
                 [[self commandDict] setObject:rep forKey:@"indirectArchive"];
@@ -321,7 +323,8 @@ NSTimeInterval QSTimeIntervalForString(NSString *intervalString) {
 	NSString *directID = [cmdDict objectForKey:@"directID"];
 
 	if (directID) {
-        object = [QSObject objectWithIdentifier:directID];
+        NSString *directType = [cmdDict objectForKey:@"directType"];
+        object = [QSObject recreateObjectOfType:directType withIdentifier:directID];
 	}
 	
 	if (!object) {
@@ -361,7 +364,8 @@ NSTimeInterval QSTimeIntervalForString(NSString *intervalString) {
 	NSString *indirectID = [cmdDict objectForKey:@"indirectID"];
 	
     if (indirectID) {
-        object = [QSObject objectWithIdentifier:indirectID];
+        NSString *indirectType = [cmdDict objectForKey:@"indirectType"];
+        object = [QSObject recreateObjectOfType:indirectType withIdentifier:indirectID];
 	}
 	
 	if (!object) {

--- a/Quicksilver/Code-QuickStepCore/QSObject.h
+++ b/Quicksilver/Code-QuickStepCore/QSObject.h
@@ -105,6 +105,7 @@ extern NSSize QSMaxIconSize;
 
 + (id)objectWithName:(NSString *)aName;
 + (id)objectWithIdentifier:(NSString *)anIdentifier;
++ (id)recreateObjectOfType:(NSString *)aType withIdentifier:(NSString *)anIdentifier;
 + (id)makeObjectWithIdentifier:(NSString *)anIdentifier;
 + (id)objectByMergingObjects:(NSArray *)objects;
 + (id)objectByMergingObjects:(NSArray *)objects withObject:(QSObject *)object;

--- a/Quicksilver/Code-QuickStepCore/QSObject.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject.m
@@ -206,6 +206,24 @@ NSSize QSMaxIconSize;
 	return [objectDictionary objectForKey:anIdentifier];
 }
 
++ (id)recreateObjectOfType:(NSString *)aType withIdentifier:(NSString *)anIdentifier
+{
+    if (!anIdentifier) {
+        return nil;
+    }
+    if ([QSObject objectWithIdentifier:anIdentifier]) {
+        return [QSObject objectWithIdentifier:anIdentifier];
+    }
+    if (!aType) {
+        return nil;
+    }
+    id handler = [[QSReg objectHandlers] objectForKey:aType];
+    if (handler && [handler respondsToSelector:@selector(recreateObjectOfType:withIdentifier:)]) {
+        return [handler recreateObjectOfType:aType withIdentifier:anIdentifier];
+    }
+    return nil;
+}
+
 + (id)objectByMergingObjects:(NSArray *)objects withObject:(QSObject *)object {
 	if ([objects containsObject:object] || !object)
 		return [self objectByMergingObjects:objects];

--- a/Quicksilver/Code-QuickStepCore/QSObjectSource.h
+++ b/Quicksilver/Code-QuickStepCore/QSObjectSource.h
@@ -26,6 +26,7 @@
 //- (NSString *)nameForEntry:(NSDictionary *)theEntry;
 - (NSArray *)objectsForEntry:(NSDictionary *)theEntry;
 - (BOOL)indexIsValidFromDate:(NSDate *)indexDate forEntry:(NSDictionary *)theEntry;
+- (QSObject *)recreateObjectOfType:(NSString *)aType withIdentifier:(NSString *)anIdentifier;
 - (void)populateFields;
 
 - (void)updateCurrentEntryModificationDate;

--- a/Quicksilver/Code-QuickStepCore/QSObjectSource.m
+++ b/Quicksilver/Code-QuickStepCore/QSObjectSource.m
@@ -23,6 +23,7 @@
 - (NSImage *)iconForEntry:(NSDictionary *)theEntry {return nil;}
 - (NSString *)nameForEntry:(NSDictionary *)theEntry {return nil;}
 - (NSArray *)objectsForEntry:(NSDictionary *)theEntry {return nil;}
+- (QSObject *)recreateObjectOfType:(NSString *)aType withIdentifier:(NSString *)anIdentifier {return nil;}
 - (void)invalidateSelf {
 	//  NSLog(@"invalidated %@", self);
 	[[NSNotificationCenter defaultCenter] postNotificationName:QSCatalogSourceInvalidated object:NSStringFromClass([self class])];

--- a/Quicksilver/Code-QuickStepCore/QSObject_FileHandling.h
+++ b/Quicksilver/Code-QuickStepCore/QSObject_FileHandling.h
@@ -15,6 +15,7 @@
 // Added by Patrick Robertson 30/06/11 in Pull #388. QSObject_FileHandling.h/.m are a mess and it's unclear as to wether
 // this is required. Any developers working on tidying these files should check the necessity/requirement of this definition
 - (NSArray *)actionsForDirectObject:(QSObject *)dObject indirectObject:(QSObject *)iObject;
+- (QSObject *)recreateObjectOfType:(NSString *)aType withIdentifier:(NSString *)anIdentifier;
 @end
 
 @interface QSBasicObject (FileHandling)

--- a/Quicksilver/Code-QuickStepCore/QSObject_FileHandling.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject_FileHandling.m
@@ -501,6 +501,11 @@ NSArray *recentDocumentsForBundle(NSString *bundleIdentifier) {
     return nil;
 }
 
+- (QSObject *)recreateObjectOfType:(NSString *)aType withIdentifier:(NSString *)anIdentifier
+{
+    return [QSObject fileObjectWithPath:anIdentifier];
+}
+
 @end
 
 @implementation QSBasicObject (FileHandling)

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Code/QSUserDefinedProxySource.m
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Code/QSUserDefinedProxySource.m
@@ -25,6 +25,13 @@
     [super dealloc];
 }
 
+- (QSObject *)getTargetFromProxy:(QSObject *)proxy
+{
+    NSString *targetID = [proxy objectForMeta:@"target"];
+    NSString *targetType = [proxy objectForMeta:@"targetType"];
+    return [QSObject recreateObjectOfType:targetType withIdentifier:targetID];
+}
+
 #pragma mark Catalog Entry
 
 - (BOOL)indexIsValidFromDate:(NSDate *)indexDate forEntry:(NSDictionary *)theEntry
@@ -48,10 +55,12 @@
     // assign values to the proxy object
     NSDictionary *settings = [theEntry objectForKey:kItemSettings];
     NSString *targetID = [settings objectForKey:@"target"];
+    NSString *targetType = [settings objectForKey:@"targetType"];
     NSString *name = [settings objectForKey:@"name"];
     [proxy setIdentifier:[NSString stringWithFormat:@"QSUserDefinedProxy:%@", name]];
     [proxy setName:name];
     [proxy setObject:targetID forMeta:@"target"];
+    [proxy setObject:targetType forMeta:@"targetType"];
     return [NSArray arrayWithObject:proxy];
 }
 
@@ -59,7 +68,8 @@
 {
     NSDictionary *settings = [theEntry objectForKey:kItemSettings];
     NSString *targetID = [settings objectForKey:@"target"];
-    QSObject *target = [QSObject objectWithIdentifier:targetID];
+    NSString *targetType = [settings objectForKey:@"targetType"];
+    QSObject *target = [QSObject recreateObjectOfType:targetType withIdentifier:targetID];
     if (target) {
         [target loadIcon];
         return [target icon];
@@ -72,7 +82,7 @@
 - (QSObject *)resolveProxyObject:(QSProxyObject *)proxy
 {
     NSString *targetID = [proxy objectForMeta:@"target"];
-    QSObject *target = [QSObject objectWithIdentifier:targetID];
+    QSObject *target = [self getTargetFromProxy:proxy];
     if (target) {
         return target;
     } else {
@@ -89,8 +99,7 @@
 
 - (NSArray *)typesForProxyObject:(QSProxyObject *)proxy
 {
-    NSString *targetID = [proxy objectForMeta:@"target"];
-    QSObject *target = [QSObject objectWithIdentifier:targetID];
+    QSObject *target = [self getTargetFromProxy:proxy];
     if (target) {
         return [target types];
     }
@@ -99,8 +108,7 @@
 
 - (NSString *)detailsOfObject:(QSObject *)object
 {
-    NSString *targetID = [object objectForMeta:@"target"];
-    QSObject *target = [QSObject objectWithIdentifier:targetID];
+    QSObject *target = [self getTargetFromProxy:object];
     if (target) {
         NSString *localizedDetails = NSLocalizedStringFromTableInBundle(@"Synonym for %@", nil, [NSBundle bundleForClass:[self class]], nil);
         return [NSString stringWithFormat:localizedDetails, [target displayName]];
@@ -114,8 +122,7 @@
 {
     // make this object act as much like the target as possible
     // (show the target's children instead of the target)
-    NSString *targetID = [proxy objectForMeta:@"target"];
-    QSObject *target = [QSObject objectWithIdentifier:targetID];
+    QSObject *target = [self getTargetFromProxy:proxy];
     if (target) {
         [proxy setChildren:[target children]];
         [proxy setAltChildren:[target altChildren]];


### PR DESCRIPTION
Here's a proof-of-concept for what I was proposing in #1277. Rather than try to preserve objects in dictionary form, we just ask the class that created them in the first place to create them again.
## Notes
- I don't really like that there's a class method on `QSObject` and an instance method on `QSObjectSource` with nearly identical signatures. They aren't exactly the same thing, but then again, the name makes sense for both. Suggestions welcome.
- I don't know of a specific style rule on this, but you'll see that the type is optional for `+[QSObject recreateObjectOfType:withIdentifier:]`. I can't think of another method where the first argument is optional, while later ones are required. So maybe it should change, but to my English speaking ears, it sounded better the way it is.
- We pass the object source both identifier _and_ type to make things easier on the object source. Some of them provide multiple types of objects and while you could probably sniff the identifier to figure out which you have, this is much cleaner.
- By not storing dictionaries, we don't have to worry about non-plist objects being present. This also means that if plug-ins change the metadata they store in objects, we don't care because they will always be freshly created, not pulled from an archive.
- Because this is implemented at the command level, it also allows you to use non-catalog objects in saved commands, droplets, etc. in addition to triggers.

I've implemented the "recreate" method in the filesystem object source and in the iTunes plug-in (see the [diff for the "resurrection" branch](https://github.com/quicksilver/iTunes-qsplugin/compare/resurrection)) for demonstration purposes.

(FYI, through some mysterious magic, triggers would already work for files not in the catalog. That is, `objectWithIdentier:` would always find it. But the same method in the synonyms code would come up empty. It was driving me crazy, but I quit trying to figure it out since my goal was to fix the situation across the board.)
## Things to try

Or things I tried anyway. All of the following used to stop working after a restart.
- Create a synonym for a file that isn't in the catalog.
- Create a trigger that sets an EQ preset for iTunes, then disable the EQ presets catalog entry.
- Create a trigger that uses an Album, Artist, or Track. (I just used "Select in Command Window" to keep it quiet.)
