### PR TITLE
Attempt to add internal objs/messages to QS permanently

### DIFF
--- a/Quicksilver/Code-App/QSController.m
+++ b/Quicksilver/Code-App/QSController.m
@@ -899,8 +899,9 @@ static QSController *defaultController = nil;
 	if (DEBUG_STARTUP)
 		NSLog(@"Catalog loaded");
 #endif
-
+    
 	[QSObject purgeIdentifiers];
+    [QSObject addInternalObjectsToObjectDictionary];
 
 #ifndef DEBUG
 	if (newVersion) {

--- a/Quicksilver/Code-QuickStepCore/QSObject.h
+++ b/Quicksilver/Code-QuickStepCore/QSObject.h
@@ -94,7 +94,11 @@ extern NSSize QSMaxIconSize;
 	QSObjectFlags			flags;
 	NSTimeInterval			lastAccess;
 }
+
+@property (assign) NSTimeInterval lastAccess;
+
 + (void)initialize;
++ (void)addInternalObjectsToObjectDictionary;
 + (void)cleanObjectDictionary;
 + (void)purgeOldImagesAndChildren;
 + (void)purgeAllImagesAndChildren;
@@ -139,6 +143,7 @@ extern NSSize QSMaxIconSize;
 - (void)setCache:(NSMutableDictionary *)aCache;
 - (BOOL)isProxyObject;
 - (QSObject *)resolvedObject;
+
 
 @end
 

--- a/Quicksilver/Code-QuickStepInterface/QSInterfaceController.m
+++ b/Quicksilver/Code-QuickStepInterface/QSInterfaceController.m
@@ -471,9 +471,9 @@
 	// We want to stop getting updates at that point, so we compare to the resultArray instead.
 	if ([[dSelector resultArray] isEqual:[[notif userInfo] objectForKey:kQSResultArrayKey]]) {
 		//NSLog(@"arraychanged");
-		if ([[dSelector->resultController window] isVisible]) {
+		if ([[dSelector.resultController window] isVisible]) {
 			[dSelector reloadResultTable];
-			[dSelector->resultController updateSelectionInfo];
+			[dSelector.resultController updateSelectionInfo];
 		}
 		if (![[dSelector resultArray] containsObject:[dSelector selectedObject]]) {
 			if ([[dSelector resultArray] count]) {


### PR DESCRIPTION
Internal Objs/messages currently only work if the catalog entries are enabled. Otherwise triggers etc. that use them just fail miserably.

This is an attempt to fix that, although it may not be the best. Open on the quicksilver repo for collab :)

`+[QSObject cleanObjectDictionary]` may well clear the items straight away, but testing seems to show that adding them to the catalog gives triggers etc. enough time to use the objects and hold on to them.