### PR TITLE
set an abbreviation when running the "Assign Abbreviation" action

### DIFF
--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Code/QSObjectActions.m
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Code/QSObjectActions.m
@@ -69,6 +69,7 @@
 
 - (QSObject *)setObjectMnemonic:(QSObject *)dObject string:(QSObject *)iObject {
 	[[QSMnemonics sharedInstance] addObjectMnemonic:[iObject stringValue] forID:[dObject identifier]];
+    [[QSMnemonics sharedInstance] addAbbrevMnemonic:[iObject stringValue] forID:[dObject identifier] relativeToID:nil immediately:NO];
 	[dObject updateMnemonics];
 	return nil;
 }


### PR DESCRIPTION
Seems pretty obvious, but it wasn't happening. See [my previous comment](/quicksilver/Quicksilver/pull/1343#issuecomment-12603961) for a description of what this fixes.
