### PR TITLE
recognize javascript: strings

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSObject_StringHandling.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject_StringHandling.m
@@ -127,6 +127,11 @@
 		[self assignURLTypesWithURL:stringValue];
 		return;
 	}
+    // JavaScript
+	if ([stringValue hasPrefix:@"javascript:"]) {
+		[self assignURLTypesWithURL:stringValue];
+		return;
+	}
     // returns YES if a valid URL is assigned to the object
     if ([self sniffURL:stringValue]) {
         return;

--- a/Quicksilver/Code-QuickStepCore/QSObject_URLHandling.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject_URLHandling.m
@@ -246,7 +246,7 @@
 {
     [[self dataDictionary] setObject:urlString forKey:QSURLType];
     // Apple's 'URLWithString' method incorrectly deals with IP addresses, check for "://" and "mailto:" in the string as well
-    if (([urlString rangeOfString:@"://"].location != NSNotFound || [urlString hasPrefix:@"mailto:"]) && [[NSURL URLWithString:[urlString URLEncoding]] scheme])
+    if (([urlString rangeOfString:@"://"].location != NSNotFound || [urlString hasPrefix:@"mailto:"] || [urlString hasPrefix:@"javascript:"]) && [[NSURL URLWithString:[urlString URLEncoding]] scheme])
     {
         [self setObject:urlString forType:QSURLType];
     } else {


### PR DESCRIPTION
Just a quick fix up before the next release. Another hack like the `mailto:` thing, but it gets the job done.

Long term, we need to be less specific about various protocols. We should find a way to get this information out of launch services via Objective-C:

```
/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/Support/lsregister -dump | grep 'bindings:.*:'
```

Then, instead of checking specific prefixes, we can just split on `:` and see if the first component is on the list.
