### PR TITLE
set a default value for the ranker preference

### DIFF
--- a/Quicksilver/Resources/QSDefaults.plist
+++ b/Quicksilver/Resources/QSDefaults.plist
@@ -77,5 +77,7 @@
 	<array>
 		<string>public.item</string>
 	</array>
+	<key>QSStringRankers</key>
+	<string>QSDefaultStringRanker</string>
 </dict>
 </plist>


### PR DESCRIPTION
Prevents a notification that implies the ranker couldn't be loaded.
