### PR TITLE
Unbind all bindings when deallocing

### DIFF
--- a/Quicksilver/Code-QuickStepInterface/QSResultController.m
+++ b/Quicksilver/Code-QuickStepInterface/QSResultController.m
@@ -161,6 +161,7 @@ NSMutableDictionary *kindDescriptions = nil;
 	[[[resultTable tableColumnWithIdentifier:@"NameColumn"] dataCell] unbind:@"textColor"];
 	[resultTable unbind:@"backgroundColor"];
 	[resultTable unbind:@"highlightColor"];
+    [resultTable unbind:@"rowHeight"];
 	[resultChildTable unbind:@"backgroundColor"];
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 


### PR DESCRIPTION
Avoids a crash when attempting to change the result view row height after an interface change, as discussed with @skurfer on #1378
