### PR TITLE
merge recent and iCloud documents correctly

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSObject_FileHandling.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject_FileHandling.m
@@ -449,7 +449,7 @@ NSArray *recentDocumentsForBundle(NSString *bundleIdentifier) {
                     NSIndexSet *ind = [iCloudDocuments indexesOfObjectsWithOptions:NSEnumerationConcurrent passingTest:^BOOL(QSObject *icdoc, NSUInteger i, BOOL *stop) {
                         return ![recentDocuments containsObject:[icdoc objectForType:QSFilePathType]];
                     }];
-					newChildren = [QSObject fileObjectsWithPathArray:[recentDocuments arrayByAddingObjectsFromArray:[iCloudDocuments objectsAtIndexes:ind]]];
+                    newChildren = [[QSObject fileObjectsWithPathArray:recentDocuments] arrayByAddingObjectsFromArray:[iCloudDocuments objectsAtIndexes:ind]];
 
 					for(QSObject * child in newChildren) {
 						[child setObject:bundleIdentifier forMeta:@"QSPreferredApplication"];


### PR DESCRIPTION
It was mixing file paths with QSObjects. Now it combines two arrays of QSObjects.
