### PR TITLE
small identifier bug

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSObject.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject.m
@@ -684,6 +684,7 @@ NSSize QSMaxIconSize;
             [identifier release];
             identifier = nil;
         } else if (identifier == nil) {
+            flags.noIdentifier = NO;
             [objectDictionary setObject:self forKey:newIdentifier];
             [meta setObject:newIdentifier forKey:kQSObjectObjectID];
             identifier = [newIdentifier retain];


### PR DESCRIPTION
This is for the release branch.

26f9250ac02343c00e29f2b5ccf04c8f16b881f2 had a small problem where objects that were created and assigned an identifier for the first time would never have the `noIdentifier` flag turned off, causing the `identifier` getter to always return `nil`.
