### PR TITLE
fix loading URL children

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSObject_URLHandling.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject_URLHandling.m
@@ -193,6 +193,11 @@
     
 	[QSTasks updateTask:@"DownloadPage" status:@"Downloading Page" progress:0];
     
+    if (![object objectForMeta:QSURLTypeParsersTableKey]) {
+        // it's possible `objectHasChildren:` was never called to populate this
+        [self objectHasChildren:object];
+    }
+    
     id <QSParser> parser = [QSReg instanceForKey:[object objectForMeta:QSURLTypeParsersTableKey] inTable:@"QSURLTypeParsers"];
     
 	NSArray *children = [parser objectsFromURL:[NSURL URLWithString:[object objectForType:QSURLType]] withSettings:nil];


### PR DESCRIPTION
This is why `Current Web Page ⇥ Search Contents` wouldn't work. If you just ask for a URL's children without ever calling `objectHasChildren:` first, the handler would always be `nil`.

Generally, I think we should discourage making changes to an object when simply asking if it has children, but I can see why it was done in this case. Since we can keep the work-around local to the class that creates the "problem", I think it's fine.
