### PR TITLE
Don't unload icons for objects who's icon never changes

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSAction.m
+++ b/Quicksilver/Code-QuickStepCore/QSAction.m
@@ -411,6 +411,7 @@ static BOOL gModifiersAreIgnored;
     }
 	if (icon) {
 		[object setIcon:icon];
+        [object setRetainsIcon:YES];
 		return YES;
 	} else
 		return NO;

--- a/Quicksilver/Code-QuickStepCore/QSCommand.m
+++ b/Quicksilver/Code-QuickStepCore/QSCommand.m
@@ -44,6 +44,7 @@
     id dObject = [(QSCommand*)object dObject];
 	[dObject loadIcon];
 	[object setIcon:[dObject icon]];
+    [object setRetainsIcon:YES];
 	return YES;
 }
 

--- a/Quicksilver/Code-QuickStepCore/QSObject.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject.m
@@ -97,7 +97,7 @@ NSSize QSMaxIconSize;
 
     @synchronized(iconLoadedSet) {
         NSSet *s = [iconLoadedSet objectsWithOptions:NSEnumerationConcurrent passingTest:^BOOL(QSObject *obj, BOOL *stop) {
-            return obj->lastAccess && obj->lastAccess < (globalLastAccess - interval) && ![obj isKindOfClass:[QSAction class]];
+            return obj->lastAccess && obj->lastAccess < (globalLastAccess - interval);
         }];
         for(QSObject *thisObject in s) {
             if ([thisObject unloadIcon]) {

--- a/Quicksilver/Code-QuickStepCore/QSObject_FileHandling.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject_FileHandling.m
@@ -205,6 +205,8 @@ NSArray *recentDocumentsForBundle(NSString *bundleIdentifier) {
         theImage = [self prepareImageforIcon:theImage];
         [object setIcon:theImage];
         return YES;
+    } else {
+        [object setRetainsIcon:YES];
     }
     return NO;
 }

--- a/Quicksilver/Code-QuickStepCore/QSObject_URLHandling.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject_URLHandling.m
@@ -101,6 +101,7 @@
     [webSearchImage setName:@"Web Search Icon"];
 
     [object setIcon:webSearchImage];
+    [object setRetainsIcon:YES];
 }
 
 #pragma mark image handling
@@ -151,6 +152,7 @@
 			return YES;
 		}
 	}
+    [object setRetainsIcon:YES];
 	return NO;
 }
 

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Code/QSCatalogEntrySource.m
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Code/QSCatalogEntrySource.m
@@ -87,6 +87,7 @@ static NSImage *prefsCatalogImage = nil;
 
 - (BOOL)loadIconForObject:(QSObject *)object {
 	[object setIcon:[[[QSLibrarian sharedInstance] entryForID:[object objectForType:QSCatalogEntryPboardType]] icon]];
+    [object setRetainsIcon:YES];
 	return YES;
 }
 

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Code/QSObject+ColorHandling.m
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Code/QSObject+ColorHandling.m
@@ -28,6 +28,7 @@
 	[roundRect fill];
 	[image unlockFocus];
 	[object setIcon:image];
+    [object setRetainsIcon:YES];
 	[image release];
 	return YES;
 }


### PR DESCRIPTION
Being on a slow internet connection I realised web search icons were re-loading ever time the interface was opened/closed.

I noticed that these types of objects (and others after thinking about it) never need to reload their icons, so I've changed the code in a few places to set `retainsIcon` to `YES`.
Incase you're wondering, the flag is slighty misleading, it doesn't mean the icon is retained (retain count goes up by 1) but just that it's not released. When the object is dealloced the icon is of course still released.
