### PR TITLE
Respect the 'run tasks in background' setting for triggers as well

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSTrigger.m
+++ b/Quicksilver/Code-QuickStepCore/QSTrigger.m
@@ -144,12 +144,21 @@
 }
 
 - (BOOL)execute {
-    if(!activated)
+    if(!activated) {
         return NO;
-	[[self command] executeIgnoringModifiers];
-	if ([info objectForKey:@"oneshot"]) {
-		[self setEnabled:NO];
-	}
+    }
+    void (^block)(void) =  ^{
+        [[self command] executeIgnoringModifiers];
+        if ([info objectForKey:@"oneshot"]) {
+            [self setEnabled:NO];
+        }
+    };
+    if (defaultBool(kExecuteInThread)) {
+        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), block);
+    } else {
+        block();
+    }
+
 	return YES;
 }
 


### PR DESCRIPTION
From #1477 I realised QS doesn't currently run triggers in the background, ever. That's not so good :/

I've fixed this now. It would have been nicer to tie it into the existing code that checks for this setting, but that's related to the interface, and this is related to triggers (which don't use the interface, so they'll have to be independent
