### PR TITLE
Remove duplicate commands from the command history

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSCommand.m
+++ b/Quicksilver/Code-QuickStepCore/QSCommand.m
@@ -433,6 +433,16 @@ NSTimeInterval QSTimeIntervalForString(NSString *intervalString) {
 	return [self execute];
 }
 
+- (BOOL)isEqual:(id)anObject {
+    if (![anObject isKindOfClass:[QSCommand class]]) {
+        return NO;
+    }
+    if ([anObject dObject] == [self dObject] && [anObject aObject] == [self aObject] && [anObject iObject] == [self iObject]) {
+        return YES;
+    }
+    return NO;
+}
+
 - (QSObject *)execute {
 	QSAction *actionObject = [self aObject];
 	QSObject *directObject = [self dObject];

--- a/Quicksilver/Code-QuickStepCore/QSHistoryController.m
+++ b/Quicksilver/Code-QuickStepCore/QSHistoryController.m
@@ -42,15 +42,26 @@ id QSHist;
 		[actionHistory removeLastObject];
 }
 - (void)addCommand:(QSCommand *)command {
-	if ([[[command dObject] identifier] isEqualToString:@"QSLastCommandProxy"]) {
+	if ([[[command dObject] identifier] isEqualToString:@"QSLastCommandProxy"] || !command) {
         // If we're re-running the last command, don't change anything
         return;
 	}
-	if (command)
-		[commandHistory insertObject:command atIndex:0];
-	while ([commandHistory count] > MAXHIST)
-		[commandHistory removeLastObject];
-	[[NSNotificationCenter defaultCenter] postNotificationName:QSCatalogEntryInvalidated object:@"QSPresetCommandHistory"];
+    
+    NSUInteger existingCommandIndex = [commandHistory indexOfObject:command];
+    if (existingCommandIndex != NSNotFound) {
+        if (existingCommandIndex == 0) {
+            // command is already the first item in the history, no need to remove and re-add it
+            return;
+        }
+        [commandHistory removeObjectAtIndex:existingCommandIndex];
+    }
+    [commandHistory insertObject:command atIndex:0];
+    if (existingCommandIndex == NSNotFound) {
+        while ([commandHistory count] > MAXHIST) {
+            [commandHistory removeLastObject];
+        }
+    }
+    [[NSNotificationCenter defaultCenter] postNotificationName:QSCatalogEntryInvalidated object:@"QSPresetCommandHistory"];
 }
 
 - (void)addObject:(id)object {


### PR DESCRIPTION
This got on my nerves today.

If you run the same command say 5 times from QS, you'll notice in Prefs > Catalog > Quicksilver > Recent Commands has the same command 5 times.

I just needed to implement an `isEqual:` method for QSCommands (I guessed that testing the `d/a/iObjects` for equality was enough, but correct me if I'm wrong). I used pointer comparison as opposed to `isEqual:` for the objects, since isEqual doesn't work nicely with `nil` (typically what the `iObject is).
