### PR TITLE
prevent a crash with Command Window in Text Mode

### DIFF
--- a/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
@@ -752,7 +752,7 @@ NSMutableDictionary *bindingsDict = nil;
             NSString *text;
             NSUInteger currentEventMask = NSEventMaskFromType([[NSApp currentEvent] type]);
             // getting characters raises an exception if this wasn't a key event
-            if (currentEventMask & (NSKeyUpMask | NSKeyDownMask)) {
+            if (currentEventMask & (NSKeyUpMask | NSKeyDownMask | NSFlagsChangedMask)) {
                 text = [partialString stringByAppendingString:[[NSApp currentEvent] charactersIgnoringModifiers]];
             } else {
                 text = partialString;


### PR DESCRIPTION
I can't fathom a reason for getting the characters from the event, so I just removed that code. Say your trigger for this is `⌃T`. Does that mean searching for "xyz", then at some later point hitting the trigger, you should expect to see "xyzt"? Doesn't make sense. I must be missing something, but I can't find anything that doesn't work with these changes.

I also simplified the way `length` was gotten for the calls to `NSMakeRange()`.
