### PR TITLE
Default the third pane for "Assign Abbreviation" to the matched string.

### DIFF
--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Code/QSObjectActions.m
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Code/QSObjectActions.m
@@ -190,6 +190,10 @@
 - (NSArray *)validIndirectObjectsForAction:(NSString *)action directObject:(QSObject *)dObject {
 	if ([action isEqualToString:@"QSCreateFileAction"]) {
 		return nil;
+	} else if ([action isEqualToString:@"QSObjectAssignMnemonic"]) {
+        NSString *suggestion = [[[[NSApp delegate] interfaceController] dSelector] matchedString];
+        QSObject *textObject = [QSObject textProxyObjectWithDefaultValue:suggestion];
+        return [NSArray arrayWithObject:textObject];
 	} else {
 	QSObject *textObject = [QSObject textProxyObjectWithDefaultValue:@""];
 	return [NSArray arrayWithObject:textObject]; //[[QSLibrarian sharedInstance]arrayForType:NSFilenamesPboardType];


### PR DESCRIPTION
I've always thought that a blank third pane is not very useful.

Often I want to fix the ranking of an object after I've arrowed down to it. This diff makes it easy to fix such a problem:
- Run "Assign Abbreviation" on the item, which will default to using what you searched.
- Invoke QS again, and run the intended action.

![screenshot 2013-07-31 16 45 30](https://f.cloud.github.com/assets/248078/890698/56ad8502-fa3b-11e2-8baf-179695c2eeae.png)

`matchedString` appears to be the proper accessor exposed by `QSSearchObjectView`, although I don't know if it might have issues with e.g. special keyboards/characters.
However, this does work if you use the action with a dismissed-and-re-invoked QS direct object selected via text. (A hackier approach using `partialString` didn't work.)

Note that selections sent to Quicksilver don't have a `matchedString`, so there's no sensible suggestion (although you _could_ make an argument for either the entire string version of the direct object, or for a string of the first letter of every alphabetic substring).
