### PR TITLE
Prevent aliases from overwriting the original file

### DIFF
--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Code/QSActionProvider_EmbeddedProviders.m
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Code/QSActionProvider_EmbeddedProviders.m
@@ -686,6 +686,12 @@
 	NSString *destinationFile;
 	for(NSString *thisFile in [dObject arrayForType:QSFilePathType]) {
 		destinationFile = [destination stringByAppendingPathComponent:[thisFile lastPathComponent]];
+        if ([destinationFile isEqualToString:thisFile]) {
+            // change the name if the alias will be in the same directory
+            NSString *aliasSuffix = NSLocalizedString(@"alias", @"alias");
+            NSArray *pathAndSuffix = @[destinationFile, aliasSuffix];
+            destinationFile = [pathAndSuffix componentsJoinedByString:@" "];
+        }
 		if ([(NDAlias *)[NDAlias aliasWithPath:thisFile] writeToFile:destinationFile])
 			[[NSWorkspace sharedWorkspace] noteFileSystemChanged:destination];
 	}
@@ -694,8 +700,18 @@
 
 - (QSObject *)makeLinkTo:(QSObject *)dObject inFolder:(QSObject *)iObject {
 	NSString *destination = [iObject singleFilePath];
+    NSString *linkPath;
 	for(NSString *thisFile in [dObject arrayForType:QSFilePathType]) {
-		if ([[NSFileManager defaultManager] createSymbolicLinkAtPath:[destination stringByAppendingPathComponent:[thisFile lastPathComponent]] withDestinationPath:thisFile error:nil])
+        linkPath = [destination stringByAppendingPathComponent:[thisFile lastPathComponent]];
+        if ([linkPath isEqualToString:thisFile]) {
+            // change the name if the link will be in the same directory
+            NSString *linkSuffix = NSLocalizedString(@"link", @"link");
+            NSArray *pathAndSuffix = @[linkPath, linkSuffix];
+            linkPath = [pathAndSuffix componentsJoinedByString:@" "];
+            // don't use the absolute path, since we know the relative locations
+            thisFile = [thisFile lastPathComponent];
+        }
+		if ([[NSFileManager defaultManager] createSymbolicLinkAtPath:linkPath withDestinationPath:thisFile error:nil])
 			[[NSWorkspace sharedWorkspace] noteFileSystemChanged:destination];
 	}
 	return nil;


### PR DESCRIPTION
See #1547

I also changed the behavior for symlinks so a link will get created and be relative.
