### PR TITLE
Update user agent

### DIFF
--- a/Quicksilver/Code-App/QSUpdateController.m
+++ b/Quicksilver/Code-App/QSUpdateController.m
@@ -115,6 +115,7 @@ typedef enum {
 	NSString *checkVersionString = nil;
 
     NSMutableURLRequest *theRequest = [NSMutableURLRequest requestWithURL:[self buildUpdateCheckURL] cachePolicy:NSURLRequestUseProtocolCachePolicy timeoutInterval:20.0];
+    [theRequest setValue:kQSUserAgent forHTTPHeaderField:@"User-Agent"];
 
     NSData *data = [NSURLConnection sendSynchronousRequest:theRequest returningResponse:nil error:nil];
     checkVersionString = [[[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding] autorelease];


### PR DESCRIPTION
For calls to the check.php URL (for checking if a QS update is available) we were never setting the User agent.
I've changed this now, but we still have to deal with previous QS versions. See the dev discussions for what I've done
