### PR TITLE
display file icons before attempting to load Quick Look previews

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSObject_FileHandling.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject_FileHandling.m
@@ -189,6 +189,7 @@ NSArray *recentDocumentsForBundle(NSString *bundleIdentifier) {
 
 - (BOOL)loadIconForObject:(QSObject *)object {
 	NSImage *theImage = nil;
+    NSImage *previewImage = nil;
 	NSString *path = [[object arrayForType:QSFilePathType] lastObject];
 	NSFileManager *manager = [NSFileManager defaultManager];
     
@@ -196,6 +197,12 @@ NSArray *recentDocumentsForBundle(NSString *bundleIdentifier) {
 	if (![manager fileExistsAtPath:path]) {
 		return NO;
 	}
+    
+    // try to use the file's actual icon immediately
+    theImage = [[NSWorkspace sharedWorkspace] iconForFiles:[object arrayForType:QSFilePathType]];
+    if (theImage) {
+        [object setIcon:theImage];
+    }
     
     if ([[NSUserDefaults standardUserDefaults] boolForKey:@"QSLoadImagePreviews"]) {
         // try to create a preview icon
@@ -207,25 +214,23 @@ NSArray *recentDocumentsForBundle(NSString *bundleIdentifier) {
                 id provider = [QSReg instanceForKey:type inTable:@"QSFSFileTypePreviewers"];
                 if (provider) {
                     //NSLog(@"provider %@", [QSReg tableNamed:@"QSFSFileTypePreviewers"]);
-                    theImage = [provider iconForFile:path ofType:type];
+                    previewImage = [provider iconForFile:path ofType:type];
                     break;
                 }
             }
         }
-        if (!theImage) {
+        if (!previewImage) {
             NSArray *previewTypes = [[NSUserDefaults standardUserDefaults] objectForKey:@"QSFilePreviewTypes"];
             for (NSString *type in previewTypes) {
                 if (UTTypeConformsTo((CFStringRef)uti, (CFStringRef)type)) {
-                    theImage = [NSImage imageWithPreviewOfFileAtPath:path ofSize:QSSizeMax asIcon:YES];
+                    previewImage = [NSImage imageWithPreviewOfFileAtPath:path ofSize:QSSizeMax asIcon:YES];
                     break;
                 }
             }
         }
-    }
-    if (!theImage) {
-        // previews are disabled or couldn't be loaded
-        // use the file's actual icon
-        theImage = [[NSWorkspace sharedWorkspace] iconForFiles:[object arrayForType:QSFilePathType]];
+        if (previewImage) {
+            theImage = previewImage;
+        }
     }
     if (theImage) {
         // update the UI with the new icon


### PR DESCRIPTION
As discussed in #1552, attempting to load Quick Look previews before giving up and showing the file's icon instead introduced a noticeable delay. I changed it to show the file's icon (if it exists) first. The obvious downsides are the extra work of loading two icons, and sending two notifications. But loading the file's icon is usually lightning quick. (Almost no one complained about it when it was done on the main thread.) And if there is no Quick Look preview, the second notification never happens.
