### PR TITLE
Copy the text editor string (when creating new objects) don't reference it

### DIFF
--- a/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
@@ -767,7 +767,7 @@ NSMutableDictionary *bindingsDict = nil;
             }
 		}
 		// Set the underlying object of the pane to be a text object
-		[self setObjectValue:[QSObject objectWithString:[[self textModeEditor] string]]];
+		[self setObjectValue:[QSObject objectWithString:[[[[self textModeEditor] string] copy] autorelease]]];
 		
 		NSRect titleFrame = [self frame];
 		NSRect editorFrame = NSInsetRect(titleFrame, NSHeight(titleFrame) /16, NSHeight(titleFrame)/16);
@@ -1529,7 +1529,7 @@ NSMutableDictionary *bindingsDict = nil;
 }
 
 - (void)textDidEndEditing:(NSNotification *)aNotification {
-    NSString *string = [[aNotification object] string];
+    NSString *string = [[[[aNotification object] string] copy] autorelease];
     if (![string isEqualToString:@" "]) {
         // only set the object value if it's not a 'short circuit'
         [self setObjectValue:[QSObject objectWithString:string]];


### PR DESCRIPTION
For an example of the bug see https://github.com/quicksilver/Quicksilver/pull/1532#issuecomment-22485744

This is the weirdest bug I've ever worked on, and it intrigues me how:

a) nobody has ever picked up this bug before (it's been around since for ever I think)
b) it hasn't affected QS that much in the past

But anyway, if you see the teeny tiny disclaimer in [the docs](https://developer.apple.com/library/mac/documentation/Cocoa/Reference/ApplicationKit/Classes/NSText_Class/Reference/Reference.html#//apple_ref/occ/instm/NSText/string) you'll see that 'for performance reasons' the _same_ NSString object is returned every time. We want to store it (in our new QSObject), so we have to make a copy of it. Turns out it seems the NSNotification that I've changed does the same thing

Based against release branch

Oh - and the other change is just a performance thing I saw when debugging. All the drawing code in QSObjectCell was being called **all the flippin' time** even when views were off screen. I thought that was silly
