### PR TITLE
don't modify identifiers for strings

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSObject_StringHandling.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject_StringHandling.m
@@ -51,8 +51,6 @@
 
 - (void)setQuickIconForObject:(QSObject *)object { [object setIcon:[[NSWorkspace sharedWorkspace] iconForFileType:@"'clpt'"]];  }
 - (BOOL)loadIconForObject:(QSObject *)object { return NO;  }
-- (NSString *)identifierForObject:(QSObject *)object { return [NSString stringWithFormat:@"%@-:-%@",QSTextType,[object objectForType:QSTextType]];
-}
 
  - (NSString *)detailsOfObject:(QSObject *)object { return nil;  }
 @end
@@ -61,10 +59,6 @@
 
     
 + (id)objectWithString:(NSString *)string {
-    NSString *stringIDPrefix = [NSString stringWithFormat:@"%@-:-",QSTextType];
-    if ([string hasPrefix:stringIDPrefix]) {
-        string = [string substringFromIndex:[stringIDPrefix length]];
-    }
     return [[(QSObject *)[QSObject alloc] initWithString:string] autorelease];
 }
 


### PR DESCRIPTION
I think the easiest fix is to just revert the changes that assign an identifier to strings, so that's what I've done.

Maybe we can look at a proper fix after the `ARC` and `release` branches are both in `master`.

I tried two different approaches, and neither worked.
## First
1. Change `-[QSObject identifier]` to just return the identifier
2. Create a new method, like `- (void)establishIdentifier` that does all the stuff currently in `-[QSObject identifier]`
3. Call `establishIdentifier` on any new object that gets created.

That last one is the tricky part. I don't think there are too many places it applies to. (Far fewer than the number of places that simply want to _read_ the identifier.) But I'd never feel confident that we got them all. I did it when calling `objectsForEntry`, when loading children, and when leaving text-entry mode, which seemed to get everything working, but there were frequent crashes when adding to the `objectDictionary`. Given that I wasn't thrilled with the approach in the first place, I didn't spend a lot of time on it.
## Second

I tried dropping `identifierForObject` from the string handling category and just setting an identifier in `objectWithString`. The idea there is that new strings would get a proper identifier, but existing identifiers would be left alone.

That still screws up triggers if you look at them in the prefs, though. To show the trigger in the prefs, it eventually asks for `dObject` and that causes the identifier to be looked up. If an object doesn't exist with that identifier, it treats it as a string and calls `objectWithString` which rewrites the identifier thanks to what I changed in that method.
