### PR TITLE
remove the focus ring around the search text field

### DIFF
--- a/Quicksilver/Code-QuickStepInterface/QSObjectCell.m
+++ b/Quicksilver/Code-QuickStepInterface/QSObjectCell.m
@@ -22,7 +22,7 @@
 
 
 + (NSFocusRingType) defaultFocusRingType {
-	return NSFocusRingTypeExterior;
+	return NSFocusRingTypeNone;
 }
 - (NSTextView *)fieldEditorForView:(NSView *)aControlView
 {


### PR DESCRIPTION
This is only noticeable (and obnoxious) under 10.9. I can't see any difference under 10.8, which makes me wonder why someone went out of their way to define that method.

I checked for the commit that added it. If you guessed “Code cleanup”, you get this :cake:.
