### PR TITLE
Bug fix switching to text mode when activating a trigger

### DIFF
--- a/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
@@ -566,7 +566,7 @@ NSMutableDictionary *bindingsDict = nil;
         currentObject = [(QSRankedObject *)currentObject object];
     }
     // if the two objects are not the same, send an 'object chagned' notif
-	if (newObject != currentObject) {
+	if (newObject != currentObject || [newObject isKindOfClass:[QSAction class]]) {
         [[NSNotificationCenter defaultCenter] removeObserver:self name:QSObjectIconModified object:currentObject];
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(objectIconModified:) name:QSObjectIconModified object:newObject];
 		[super setObjectValue:newObject];


### PR DESCRIPTION
See the [Google groups](https://groups.google.com/forum/?fromgroups#!topic/blacktree-quicksilver/S2x6ro3xdug)

Turns out the evil commit was 4919bcdb99ef0f7c01eeb7848f144f550fc64a01

@skurfer - do you know what that was meant to fix. If the answer is 'nothing', should we just revert that commit?
