### PR TITLE
Refresh the third pane when using triggers

### DIFF
--- a/Quicksilver/Code-QuickStepInterface/QSInterfaceController.m
+++ b/Quicksilver/Code-QuickStepInterface/QSInterfaceController.m
@@ -605,6 +605,8 @@
 		[aSelector setObjectValue:[array objectAtIndex:1]];
 		if ([array count] > 2) {
 			[iSelector setObjectValue:[array objectAtIndex:2]];
+		} else {
+			[self updateIndirectObjects];
 		}
 		[[self window] makeFirstResponder:iSelector];
 	}


### PR DESCRIPTION
This fixes the same bug as #1582, but I think it's a little cleaner than claiming the search object changed (when it didn't) just to trigger a known side-effect. I'm not convinced I've tested every use case, but it seems to fix the bug without adding any.
