### PR TITLE
String sniffing fixes for URLs

### DIFF
--- a/Quicksilver/Tests/Tests-QSCore/TestQSObject.m
+++ b/Quicksilver/Tests/Tests-QSCore/TestQSObject.m
@@ -59,7 +59,9 @@
         @"http://qsapp.com/",
         @"http://hostname",
         @"http://qsapp.com:8080/path/",
-        @"http://hostname.local/"
+        @"http://hostname.local/",
+        @"qsapp/",
+        @"qs-app/"
     ];
     for (NSString *url in shouldBeURL) {
         QSObject *object = [QSObject objectWithString:url];
@@ -89,7 +91,13 @@
         @".co.uk",
         @"abcdefg\nhttp://qsapp.com/",
         @"http://qsapp.com:string:123",
-        @"http://qsapp.com:2:colons"
+        @"http://qsapp.com:2:colons",
+        @"/qsapp/",
+        @"qsapp//",
+        @"qs.app/",
+        @"qs.app/",
+        @"qsapp-/",
+        @"qsapp:80/"
     ];
     for (NSString *text in shouldNotBeURL) {
         QSObject *object = [QSObject objectWithString:text];


### PR DESCRIPTION
In working with Howard on #1553, I ran across a bug with this search URL:

```
http://en.wikipedia.org/wiki/Special:Search?search=***
```

while adding a port would make it work as expected

```
http://en.wikipedia.org:80/wiki/Special:Search?search=***
```

You can test this by running ⌘⎋ on both of those and checking the default action.

So, I added some unit tests for various colon placement combinations, then changed the string sniffing code so the tests would pass.

In a nutshell, all I did was split on `/` first before splitting on `:`. That way, we only worry about colons in the `hostname:port` part of the URL. All other colons are ignored.
