### PR TITLE
Bash QSUpdateController out of the main thread.

### DIFF
--- a/Quicksilver/Code-App/QSController.m
+++ b/Quicksilver/Code-App/QSController.m
@@ -979,13 +979,6 @@ static QSController *defaultController = nil;
 	if ( ! (runningSetupAssistant || versionChanged) )
 		[self rescanItems:self];
 
-#ifndef DEBUG
-	if (versionChanged)
-		[[QSUpdateController sharedInstance] forceStartupCheck];
-#endif
-
-	[[QSUpdateController sharedInstance] setUpdateTimer];
-
 #if 0
 	[self recompositeIconImages];
 #endif

--- a/Quicksilver/Code-App/QSMainPreferencePanes.m
+++ b/Quicksilver/Code-App/QSMainPreferencePanes.m
@@ -282,7 +282,7 @@
 }
 
 - (IBAction)checkNow:(id)sender {
-	[[QSUpdateController sharedInstance] threadedRequestedCheckForUpdate:sender];
+	[[QSUpdateController sharedInstance] checkForUpdates:YES];
 }
 
 - (void)deleteSupportFiles {

--- a/Quicksilver/Code-App/QSUpdateController.h
+++ b/Quicksilver/Code-App/QSUpdateController.h
@@ -23,15 +23,6 @@
 + (id)sharedInstance;
 - (void)setUpdateTimer;
 - (IBAction)checkForUpdate:(id)sender;
-//- (BOOL)updatePlugIns:(NSArray *)bundles;
-//- (BOOL)installPlugInsForIdentifiers:(NSArray *)bundleIDs;
-//- (NSMutableArray *)updatedPlugIns;
-//- (NSMutableArray *)downloadsQueue;
-//- (BOOL)handleInstallURL:(NSURL *)url;
-//- (BOOL)installPlugInsFromFiles:(NSArray *)fileList;
-//- (NSString *)installPlugInFromFile:(NSString *)path;
-//- (NSArray *)installPlugInFromCompressedFile:(NSString *)path;
-//-(float) downloadProgress;
 - (void)forceStartupCheck;
 - (NSArray *)extractFilesFromQSPkg:(NSString *)path toPath:(NSString *)tempDirectory;
 - (IBAction)threadedRequestedCheckForUpdate:(id)sender;

--- a/Quicksilver/Code-App/QSUpdateController.h
+++ b/Quicksilver/Code-App/QSUpdateController.h
@@ -8,25 +8,11 @@
 
 #import <Cocoa/Cocoa.h>
 
-@class QSTask, QSURLDownload;
-
-@interface QSUpdateController : NSObject {
-	NSTimer *updateTimer;
-	BOOL doStartupCheck;
-	QSURLDownload *appDownload;
-	NSString *newVersion;
-	NSString *tempPath;
-	QSTask *updateTask;
-	BOOL shouldCancel;
-}
-
-+ (id)sharedInstance;
-- (void)setUpdateTimer;
+@interface QSUpdateController : NSObject
++ (instancetype)sharedInstance;
 - (IBAction)checkForUpdate:(id)sender;
-- (void)forceStartupCheck;
-- (NSArray *)extractFilesFromQSPkg:(NSString *)path toPath:(NSString *)tempDirectory;
 - (IBAction)threadedRequestedCheckForUpdate:(id)sender;
-- (void)finishAppInstall;
-- (BOOL)installAppFromDiskImage:(NSString *)path;
-- (IBAction)threadedCheckForUpdate:(id)sender;
+
+/* Needed by QSPlugInManager */
+- (NSArray *)extractFilesFromQSPkg:(NSString *)path toPath:(NSString *)tempDirectory;
 @end

--- a/Quicksilver/Code-App/QSUpdateController.h
+++ b/Quicksilver/Code-App/QSUpdateController.h
@@ -10,8 +10,7 @@
 
 @interface QSUpdateController : NSObject
 + (instancetype)sharedInstance;
-- (IBAction)checkForUpdate:(id)sender;
-- (IBAction)threadedRequestedCheckForUpdate:(id)sender;
+- (void)checkForUpdates:(BOOL)userInitiated;
 
 /* Needed by QSPlugInManager */
 - (NSArray *)extractFilesFromQSPkg:(NSString *)path toPath:(NSString *)tempDirectory;

--- a/Quicksilver/Code-App/QSUpdateController.m
+++ b/Quicksilver/Code-App/QSUpdateController.m
@@ -133,7 +133,8 @@ typedef enum {
 
 	[[NSUserDefaults standardUserDefaults] setObject:[NSDate date] forKey:kLastUpdateCheck];
 	if (![checkVersionString length] || [checkVersionString length] > 10) {
-		NSLog(@"Unable to check for new version.");
+		NSString *preview = [checkVersionString substringToIndex:([checkVersionString length] < 10 ? [checkVersionString length] : 9)];
+		NSLog(@"Strange reply from update server: %@", preview);
 		return kQSUpdateCheckError;
 	}
 

--- a/Quicksilver/Code-App/QSUpdateController.m
+++ b/Quicksilver/Code-App/QSUpdateController.m
@@ -503,7 +503,9 @@ typedef enum {
 	NSInteger status = [task terminationStatus];
 	if (status == 0) {
 		[manager removeItemAtPath:path error:nil];
-		[[NSWorkspace sharedWorkspace] noteFileSystemChanged:[path stringByDeletingLastPathComponent]];
+		QSGCDMainAsync(^{
+			[[NSWorkspace sharedWorkspace] noteFileSystemChanged:[path stringByDeletingLastPathComponent]];
+		});
 		return [manager contentsOfDirectoryAtPath:tempDirectory error:nil];
 	} else {
 		return nil;

--- a/Quicksilver/Code-App/QSUpdateController.m
+++ b/Quicksilver/Code-App/QSUpdateController.m
@@ -497,12 +497,9 @@ typedef enum {
 - (NSArray *)extractFilesFromQSPkg:(NSString *)path toPath:(NSString *)tempDirectory {
 	if (!path) return nil;
 	NSFileManager *manager = [NSFileManager defaultManager];
-	NSTask *task = [[NSTask alloc] init];
-	[task setLaunchPath:@"/usr/bin/ditto"];
-
-	[task setArguments:[NSArray arrayWithObjects:@"-x", @"-rsrc", path, tempDirectory, nil]];
-	[task launch];
+	NSTask *task = [NSTask launchedTaskWithLaunchPath:@"/usr/bin/ditto" arguments:@[@"-x", @"-rsrc", path, tempDirectory]];
 	[task waitUntilExit];
+
 	NSInteger status = [task terminationStatus];
 	if (status == 0) {
 		[manager removeItemAtPath:path error:nil];

--- a/Quicksilver/Code-App/QSUpdateController.m
+++ b/Quicksilver/Code-App/QSUpdateController.m
@@ -115,9 +115,9 @@ typedef enum {
 	kQSUpdateCheckUpdateAvailable = 1,
 } QSUpdateCheckResult;
 
-- (QSUpdateCheckResult)checkForUpdates:(BOOL)force {
+- (QSUpdateCheckResult)checkForUpdateStatus:(BOOL)userInitiated {
 	NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-	if ([defaults boolForKey:@"QSPreventAutomaticUpdate"] || (![defaults boolForKey:kCheckForUpdates] && !force)) {
+	if ([defaults boolForKey:@"QSPreventAutomaticUpdate"] || (![defaults boolForKey:kCheckForUpdates] && !userInitiated)) {
 		NSLog(@"Preventing update check.");
 		return kQSUpdateCheckSkip;
 	}
@@ -144,7 +144,7 @@ typedef enum {
 	newVersion = checkVersionString;
 #ifdef DEBUG
 	if (VERBOSE)
-		NSLog(@"Installed Version: %@, Available Version: %@, Valid: %@, Force update: %@", thisVersionString, checkVersionString, (newVersionAvailable ? @"YES" : @"NO"), (force ? @"YES" : @"NO"));
+		NSLog(@"Installed Version: %@, Available Version: %@, Valid: %@, User-initiated: %@", thisVersionString, checkVersionString, (newVersionAvailable ? @"YES" : @"NO"), (userInitiated ? @"YES" : @"NO"));
 #endif
 	return newVersionAvailable ? kQSUpdateCheckUpdateAvailable : kQSUpdateCheckNoUpdate;
 }
@@ -155,7 +155,7 @@ typedef enum {
 	[task start];
 	BOOL updated = NO;
 
-	NSInteger check = [self checkForUpdates:force];
+	NSInteger check = [self checkForUpdateStatus:force];
 	[task stop];
 
 	switch (check) {

--- a/Quicksilver/Code-App/QSUpdateController.m
+++ b/Quicksilver/Code-App/QSUpdateController.m
@@ -18,7 +18,10 @@
 
 + (id)sharedInstance {
 	static id _sharedInstance;
-	if (!_sharedInstance) _sharedInstance = [[[self class] alloc] init];
+	static dispatch_once_t onceToken;
+	dispatch_once(&onceToken, ^{
+		_sharedInstance = [[[self class] alloc] init];
+	});
 	return _sharedInstance;
 }
 

--- a/Quicksilver/Code-App/QSUpdateController.m
+++ b/Quicksilver/Code-App/QSUpdateController.m
@@ -36,7 +36,6 @@
 @interface QSUpdateController () {
 	NSTimer *updateTimer;
 	NSString *availableVersion;
-	NSString *tempPath;
 }
 @property (retain) QSURLDownload *appDownload;
 @property (retain) QSTask *downloadTask;

--- a/Quicksilver/Code-App/QSUpdateController.m
+++ b/Quicksilver/Code-App/QSUpdateController.m
@@ -14,6 +14,25 @@
 
 #import "QSUpdateController.h"
 
+/*
+ * As there's a bunch of settings that control updating, and you can't quickly
+ * tell them apart, here's a cheatsheet :
+ *
+ * - [defaults boolForKey:@"QSPreventAutomaticUpdate"]
+ *   "Paranoid" mode - Quicksilver will only update itself when the user explicitely asks for it.
+ *   It's a hidden pref setting, so developers can use this to stop those pesky update dialogs.
+ *
+ * - [defaults boolForKey:kCheckForUpdates]
+ *   The user-accessible preference setting.
+ *
+ * - [defaults boolForKey:@"QSDownloadUpdatesInBackground"]
+ *   QS won't ask before downloading an update.
+ *
+ * - [defaults boolForKey:@"QSUpdateWithoutAsking"]
+ *   QS will install the update silently and relaunch automatically.
+ *
+ */
+
 @interface QSUpdateController () {
 	NSTimer *updateTimer;
 	QSURLDownload *appDownload;

--- a/Quicksilver/Code-App/QSUpdateController.m
+++ b/Quicksilver/Code-App/QSUpdateController.m
@@ -118,10 +118,17 @@ typedef enum {
 	NSString *thisVersionString = [[NSBundle mainBundle] objectForInfoDictionaryKey:(NSString *)kCFBundleVersionKey];
 	NSString *checkVersionString = nil;
 
+	QSTask *task = [QSTask taskWithIdentifier:@"QSUpdateControllerTask"];
+	task.status = NSLocalizedString(@"Checking for Updates", @"QSUpdateController - task status");
+	task.progress = -1;
+	[task start];
+
 	NSMutableURLRequest *theRequest = [NSMutableURLRequest requestWithURL:[self buildUpdateCheckURL] cachePolicy:NSURLRequestUseProtocolCachePolicy timeoutInterval:20.0];
 	[theRequest setValue:kQSUserAgent forHTTPHeaderField:@"User-Agent"];
 
 	NSData *data = [NSURLConnection sendSynchronousRequest:theRequest returningResponse:nil error:nil];
+	[task stop];
+
 	checkVersionString = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
 
 	[[NSUserDefaults standardUserDefaults] setObject:[NSDate date] forKey:kLastUpdateCheck];
@@ -150,14 +157,9 @@ typedef enum {
 		NSLog(@"Preventing update check.");
 		return NO;
 	}
-
-	QSTask *task = [QSTask taskWithIdentifier:@"QSUpdateControllerTask"];
-	task.status = NSLocalizedString(@"Check for Update", @"");
-	[task start];
 	BOOL updated = NO;
 
 	NSInteger check = [self checkForUpdateStatus:userInitiated];
-	[task stop];
 
 	switch (check) {
 		case kQSUpdateCheckError:

--- a/Quicksilver/Code-App/QSUpdateController.m
+++ b/Quicksilver/Code-App/QSUpdateController.m
@@ -36,7 +36,7 @@
 @interface QSUpdateController () {
 	NSTimer *updateTimer;
 	QSURLDownload *appDownload;
-	NSString *newVersion;
+	NSString *availableVersion;
 	NSString *tempPath;
 	QSTask *updateTask;
 	BOOL shouldCancel;
@@ -161,7 +161,7 @@ typedef enum {
 	/* We have to get the current available version, because it will get displayed to the user,
 	 * so force happens only if there's a valid response from the server
 	 */
-	newVersion = checkVersionString;
+	availableVersion = checkVersionString;
 #ifdef DEBUG
 	if (VERBOSE)
 		NSLog(@"Installed Version: %@, Available Version: %@, Valid: %@, User-initiated: %@", thisVersionString, checkVersionString, (newVersionAvailable ? @"YES" : @"NO"), (userInitiated ? @"YES" : @"NO"));
@@ -195,7 +195,7 @@ typedef enum {
 				[self performSelectorOnMainThread:@selector(installAppUpdate) withObject:nil waitUntilDone:NO];
 #endif
 			} else {
-				NSInteger selection = NSRunInformationalAlertPanel([NSString stringWithFormat:@"New Version of Quicksilver Available", nil], @"A new version of Quicksilver is available, would you like to update now?\n\n(Update from %@ → %@)", @"Install Update", @"Later", nil, [[NSBundle mainBundle] objectForInfoDictionaryKey:(NSString *)kCFBundleVersionKey],newVersion); //, @"More Info");
+				NSInteger selection = NSRunInformationalAlertPanel([NSString stringWithFormat:@"New Version of Quicksilver Available", nil], @"A new version of Quicksilver is available, would you like to update now?\n\n(Update from %@ → %@)", @"Install Update", @"Later", nil, [[NSBundle mainBundle] objectForInfoDictionaryKey:(NSString *)kCFBundleVersionKey], availableVersion); //, @"More Info");
 				if (selection == 1) {
 					[self performSelectorOnMainThread:@selector(installAppUpdate) withObject:nil waitUntilDone:NO];
 				} else if (selection == -1) {  //Go to web site
@@ -288,7 +288,7 @@ typedef enum {
 	[updateTask setStatus:@"Download Complete"];
 	[updateTask setProgress:1.0];
 
-	BOOL plugInUpdates = [[QSPlugInManager sharedInstance] updatePlugInsForNewVersion:newVersion];
+	BOOL plugInUpdates = [[QSPlugInManager sharedInstance] updatePlugInsForNewVersion:availableVersion];
 
 	if (plugInUpdates) {
 		[[NSNotificationCenter defaultCenter] addObserver:self

--- a/Quicksilver/Code-App/QSUpdateController.m
+++ b/Quicksilver/Code-App/QSUpdateController.m
@@ -226,10 +226,6 @@ typedef enum {
 	[self checkForUpdates:NO];
 }
 
-- (IBAction)threadedRequestedCheckForUpdate:(id)sender {
-	[self checkForUpdates:YES];
-}
-
 - (void)installAppUpdate {
 	if (updateTask) return;
 

--- a/Quicksilver/Code-App/QSUpdateController.m
+++ b/Quicksilver/Code-App/QSUpdateController.m
@@ -33,177 +33,173 @@
 }
 
 - (void)setUpdateTimer {
-	// ***warning  * fix me
-	NSUserDefaults* defaults = [NSUserDefaults standardUserDefaults];
+	NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
 
 #ifdef DEBUG
-	if (![defaults boolForKey:@"QSPreventAutomaticUpdate"]) {
+	if ([defaults boolForKey:@"QSPreventAutomaticUpdate"]) return;
 #else
-    if ([defaults boolForKey:kCheckForUpdates]) {
+	if (![defaults boolForKey:kCheckForUpdates]) return;
 #endif
-		NSDate *lastCheck = [defaults objectForKey:kLastUpdateCheck];
-		// leaving this `nil` can cause Quicksilver to hang if it starts very soon after login
-		if (!lastCheck) {
-			lastCheck = [NSDate distantPast];
-		}
-		NSInteger frequency = [defaults integerForKey:kCheckForUpdateFrequency];
-#ifdef DEBUG
-        NSInteger versionType = [defaults integerForKey:@"QSUpdateReleaseLevel"];
-		if (versionType>0 && frequency>1)
-			frequency = 1;
-#endif
-		BOOL shouldRepeat = (frequency>0);
-		NSTimeInterval checkInterval = frequency*24*60*60;
-		//NSLog(@"Last Version Check at : %@", [lastCheck description]);
-		NSDate *nextCheck = [[NSDate alloc] initWithTimeInterval:checkInterval sinceDate:lastCheck];
-		//nextCheck = [NSDate distantPast];
-		//nextCheck = [NSDate dateWithTimeIntervalSinceNow: 20.0];
-		if (updateTimer) {
-			[updateTimer invalidate];
-		}
-		updateTimer = [NSTimer scheduledTimerWithTimeInterval:checkInterval target:self selector:@selector(threadedCheckForUpdate:) userInfo:nil repeats:shouldRepeat];
-		[updateTimer setFireDate:( doStartupCheck ? [NSDate dateWithTimeIntervalSinceNow:33.333f] : nextCheck )];
-#ifdef DEBUG
-		if (VERBOSE) NSLog(@"Next Version Check at : %@", [[updateTimer fireDate] description]);
-#endif
+
+	NSDate *lastCheck = [defaults objectForKey:kLastUpdateCheck];
+	// leaving this `nil` can cause Quicksilver to hang if it starts very soon after login
+	if (!lastCheck) {
+		lastCheck = [NSDate distantPast];
 	}
+	NSInteger frequency = [defaults integerForKey:kCheckForUpdateFrequency];
+#ifdef DEBUG
+	NSInteger versionType = [defaults integerForKey:@"QSUpdateReleaseLevel"];
+	if (versionType>0 && frequency>1)
+		frequency = 1;
+#endif
+	BOOL shouldRepeat = (frequency>0);
+	NSTimeInterval checkInterval = frequency*24*60*60;
+	NSDate *nextCheck = [[NSDate alloc] initWithTimeInterval:checkInterval sinceDate:lastCheck];
+	if (updateTimer) {
+		[updateTimer invalidate];
+	}
+	updateTimer = [NSTimer scheduledTimerWithTimeInterval:checkInterval target:self selector:@selector(threadedCheckForUpdate:) userInfo:nil repeats:shouldRepeat];
+	[updateTimer setFireDate:( doStartupCheck ? [NSDate dateWithTimeIntervalSinceNow:33.333f] : nextCheck )];
+#ifdef DEBUG
+	if (VERBOSE) NSLog(@"Next Version Check at : %@", [[updateTimer fireDate] description]);
+#endif
 }
 
 - (NSURL *)buildUpdateCheckURL {
 	NSString *checkURL = [[[NSProcessInfo processInfo] environment] objectForKey:@"QSCheckUpdateURL"];
-    if (!checkURL)
-        checkURL = kCheckUpdateURL;
-    NSString *thisVersionString = (__bridge NSString *)CFBundleGetValueForInfoDictionaryKey(CFBundleGetMainBundle(), kCFBundleVersionKey);
-    
-    NSString *versionType = nil;
-    switch ([[NSUserDefaults standardUserDefaults] integerForKey:@"QSUpdateReleaseLevel"]) {
-        case 2:
-            versionType = @"dev";
-            break;
-        case 1:
-            versionType = @"pre";
-            break;
-        default:
-            versionType = @"rel";
-            break;
-    }
-    
-    checkURL = [checkURL stringByAppendingFormat:@"?type=%@&current=%@", versionType, thisVersionString];
+	if (!checkURL)
+		checkURL = kCheckUpdateURL;
+	NSString *thisVersionString = (__bridge NSString *)CFBundleGetValueForInfoDictionaryKey(CFBundleGetMainBundle(), kCFBundleVersionKey);
+
+	NSString *versionType = nil;
+	switch ([[NSUserDefaults standardUserDefaults] integerForKey:@"QSUpdateReleaseLevel"]) {
+		case 2:
+			versionType = @"dev";
+			break;
+		case 1:
+			versionType = @"pre";
+			break;
+		default:
+			versionType = @"rel";
+			break;
+	}
+
+	checkURL = [checkURL stringByAppendingFormat:@"?type=%@&current=%@", versionType, thisVersionString];
 #ifdef DEBUG
 	if (VERBOSE) NSLog(@"Update Check URL: %@", checkURL);
 #endif
-    return [NSURL URLWithString:checkURL];
+	return [NSURL URLWithString:checkURL];
 }
 
 typedef enum {
-    kQSUpdateCheckSkip = -2,
-    kQSUpdateCheckError = -1,
-    kQSUpdateCheckNoUpdate = 0,
-    kQSUpdateCheckUpdateAvailable = 1,
+	kQSUpdateCheckSkip = -2,
+	kQSUpdateCheckError = -1,
+	kQSUpdateCheckNoUpdate = 0,
+	kQSUpdateCheckUpdateAvailable = 1,
 } QSUpdateCheckResult;
 
 - (QSUpdateCheckResult)checkForUpdates:(BOOL)force {
-    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-    if ([defaults boolForKey:@"QSPreventAutomaticUpdate"] || (![defaults boolForKey:kCheckForUpdates] && !force)) {
-        NSLog(@"Preventing update check.");
-        return kQSUpdateCheckSkip;
-    }
+	NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+	if ([defaults boolForKey:@"QSPreventAutomaticUpdate"] || (![defaults boolForKey:kCheckForUpdates] && !force)) {
+		NSLog(@"Preventing update check.");
+		return kQSUpdateCheckSkip;
+	}
 
-    NSString *thisVersionString = [[NSBundle mainBundle] objectForInfoDictionaryKey:(NSString *)kCFBundleVersionKey];
+	NSString *thisVersionString = [[NSBundle mainBundle] objectForInfoDictionaryKey:(NSString *)kCFBundleVersionKey];
 	NSString *checkVersionString = nil;
 
-    NSMutableURLRequest *theRequest = [NSMutableURLRequest requestWithURL:[self buildUpdateCheckURL] cachePolicy:NSURLRequestUseProtocolCachePolicy timeoutInterval:20.0];
-    [theRequest setValue:kQSUserAgent forHTTPHeaderField:@"User-Agent"];
+	NSMutableURLRequest *theRequest = [NSMutableURLRequest requestWithURL:[self buildUpdateCheckURL] cachePolicy:NSURLRequestUseProtocolCachePolicy timeoutInterval:20.0];
+	[theRequest setValue:kQSUserAgent forHTTPHeaderField:@"User-Agent"];
 
-    NSData *data = [NSURLConnection sendSynchronousRequest:theRequest returningResponse:nil error:nil];
-    checkVersionString = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+	NSData *data = [NSURLConnection sendSynchronousRequest:theRequest returningResponse:nil error:nil];
+	checkVersionString = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
 
-    [defaults setObject:[NSDate date] forKey:kLastUpdateCheck];
-    if (![checkVersionString length] || [checkVersionString length] > 10) {
-        NSLog(@"Unable to check for new version.");
-        return kQSUpdateCheckError;
-    }
+	[defaults setObject:[NSDate date] forKey:kLastUpdateCheck];
+	if (![checkVersionString length] || [checkVersionString length] > 10) {
+		NSLog(@"Unable to check for new version.");
+		return kQSUpdateCheckError;
+	}
 
-    BOOL newVersionAvailable = [checkVersionString hexIntValue] > [thisVersionString hexIntValue];
-    /* We have to get the current available version, because it will get displayed to the user,
-     * so force happens only if there's a valid response from the server
-     */
-    newVersion = checkVersionString;
+	BOOL newVersionAvailable = [checkVersionString hexIntValue] > [thisVersionString hexIntValue];
+	/* We have to get the current available version, because it will get displayed to the user,
+	 * so force happens only if there's a valid response from the server
+	 */
+	newVersion = checkVersionString;
 #ifdef DEBUG
-    if (VERBOSE)
-        NSLog(@"Installed Version: %@, Available Version: %@, Valid: %@, Force update: %@", thisVersionString, checkVersionString, (newVersionAvailable ? @"YES" : @"NO"), (force ? @"YES" : @"NO"));
+	if (VERBOSE)
+		NSLog(@"Installed Version: %@, Available Version: %@, Valid: %@, Force update: %@", thisVersionString, checkVersionString, (newVersionAvailable ? @"YES" : @"NO"), (force ? @"YES" : @"NO"));
 #endif
-    return newVersionAvailable ? kQSUpdateCheckUpdateAvailable : kQSUpdateCheckNoUpdate;
+	return newVersionAvailable ? kQSUpdateCheckUpdateAvailable : kQSUpdateCheckNoUpdate;
 }
 
 - (BOOL)checkForUpdatesInBackground:(BOOL)quiet force:(BOOL)force {
 	QSTask *task = [QSTask taskWithIdentifier:@"QSUpdateControllerTask"];
 	task.status = NSLocalizedString(@"Check for Update", @"");
 	[task start];
-    BOOL updated = NO;
-    
-    NSInteger check = [self checkForUpdates:force];
+	BOOL updated = NO;
+
+	NSInteger check = [self checkForUpdates:force];
 	[task stop];
 
-    switch (check) {
-        case kQSUpdateCheckError:
-            if (!quiet)
-                NSRunInformationalAlertPanel(@"Internet Connection Error", @"Unable to check for updates, the server could not be reached. Please check your internet connection", @"OK", nil, nil);
-            return NO;
-        break;
-        case kQSUpdateCheckUpdateAvailable:
-            if (!force && [[NSUserDefaults standardUserDefaults] boolForKey:@"QSDownloadUpdatesInBackground"]) {
-/** Diable automatically checking for updates in the background for DEBUG builds
- You can still check for updates by clicking the "Check Now" button **/
+	switch (check) {
+		case kQSUpdateCheckError:
+			if (!quiet)
+				NSRunInformationalAlertPanel(@"Internet Connection Error", @"Unable to check for updates, the server could not be reached. Please check your internet connection", @"OK", nil, nil);
+			return NO;
+			break;
+		case kQSUpdateCheckUpdateAvailable:
+			if (!force && [[NSUserDefaults standardUserDefaults] boolForKey:@"QSDownloadUpdatesInBackground"]) {
+				/** Diable automatically checking for updates in the background for DEBUG builds
+				 You can still check for updates by clicking the "Check Now" button **/
 #ifndef DEBUG
-                [self performSelectorOnMainThread:@selector(installAppUpdate) withObject:nil waitUntilDone:NO];
+				[self performSelectorOnMainThread:@selector(installAppUpdate) withObject:nil waitUntilDone:NO];
 #endif
-            } else {
-                NSInteger selection = NSRunInformationalAlertPanel([NSString stringWithFormat:@"New Version of Quicksilver Available", nil], @"A new version of Quicksilver is available, would you like to update now?\n\n(Update from %@ → %@)", @"Install Update", @"Later", nil, [[NSBundle mainBundle] objectForInfoDictionaryKey:(NSString *)kCFBundleVersionKey],newVersion); //, @"More Info");
-                if (selection == 1) {
-                    [self performSelectorOnMainThread:@selector(installAppUpdate) withObject:nil waitUntilDone:NO];
-                } else if (selection == -1) {  //Go to web site
-                    [[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:kWebSiteURL]];
-                }
-            }
-            return YES;
-        break;
-        case kQSUpdateCheckNoUpdate:
-        {
-            QSPluginUpdateStatus updateStatus;
-            updateStatus = [[QSPlugInManager sharedInstance] checkForPlugInUpdates];
-            if (updateStatus == QSPluginUpdateStatusNoUpdates) {
-                updated = NO;
-                NSLog(@"Quicksilver is up to date.");
-                if (!quiet)
-                    NSRunInformationalAlertPanel(@"You're up-to-date!", [NSString stringWithFormat:@"You already have the latest version of Quicksilver (%@) and all installed plugins", [[NSBundle mainBundle] objectForInfoDictionaryKey:(NSString *)kCFBundleVersionKey]] , @"OK", nil, nil);
-            }
-            return updated;
-        break;
-        }
-        default:
-        case kQSUpdateCheckSkip:
-        break;
-    }
+			} else {
+				NSInteger selection = NSRunInformationalAlertPanel([NSString stringWithFormat:@"New Version of Quicksilver Available", nil], @"A new version of Quicksilver is available, would you like to update now?\n\n(Update from %@ → %@)", @"Install Update", @"Later", nil, [[NSBundle mainBundle] objectForInfoDictionaryKey:(NSString *)kCFBundleVersionKey],newVersion); //, @"More Info");
+				if (selection == 1) {
+					[self performSelectorOnMainThread:@selector(installAppUpdate) withObject:nil waitUntilDone:NO];
+				} else if (selection == -1) {  //Go to web site
+					[[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:kWebSiteURL]];
+				}
+			}
+			return YES;
+			break;
+		case kQSUpdateCheckNoUpdate:
+		{
+			QSPluginUpdateStatus updateStatus;
+			updateStatus = [[QSPlugInManager sharedInstance] checkForPlugInUpdates];
+			if (updateStatus == QSPluginUpdateStatusNoUpdates) {
+				updated = NO;
+				NSLog(@"Quicksilver is up to date.");
+				if (!quiet)
+					NSRunInformationalAlertPanel(@"You're up-to-date!", [NSString stringWithFormat:@"You already have the latest version of Quicksilver (%@) and all installed plugins", [[NSBundle mainBundle] objectForInfoDictionaryKey:(NSString *)kCFBundleVersionKey]] , @"OK", nil, nil);
+			}
+			return updated;
+			break;
+		}
+		default:
+		case kQSUpdateCheckSkip:
+			break;
+	}
 
-    return NO;
+	return NO;
 }
 
 - (BOOL)threadedCheckForUpdates:(BOOL)force {
-    BOOL res = [self checkForUpdatesInBackground:NO force:force];
-    return res;
+	BOOL res = [self checkForUpdatesInBackground:NO force:force];
+	return res;
 }
 
 - (BOOL)threadedCheckForUpdatesInBackground:(BOOL)force {
-    BOOL res = [self checkForUpdatesInBackground:YES force:force];
-    return res;
+	BOOL res = [self checkForUpdatesInBackground:YES force:force];
+	return res;
 }
 
 - (IBAction)checkForUpdate:(id)sender {
 	BOOL quiet = !sender || sender == self || [sender isKindOfClass:[NSTimer class]];
 	BOOL forceUpdate = [sender isEqual:@"Force"];
 
-    [self checkForUpdatesInBackground:quiet force:forceUpdate];
+	[self checkForUpdatesInBackground:quiet force:forceUpdate];
 }
 
 - (void)handleURL:(NSURL *)url {
@@ -211,18 +207,18 @@ typedef enum {
 }
 
 - (IBAction)threadedCheckForUpdate:(id)sender {
-    QSGCDAsync(^{
-        
-        // Test to see if the update request is an automatic request (e.g. on launch)
-        BOOL quiet = !sender || sender == self || [sender isKindOfClass:[NSTimer class]];
-        
-        if (quiet) {
-            [self threadedCheckForUpdatesInBackground:NO];
-        }
-        else {
-            [self threadedCheckForUpdates:NO];
-        }
-    });
+	QSGCDAsync(^{
+
+		// Test to see if the update request is an automatic request (e.g. on launch)
+		BOOL quiet = !sender || sender == self || [sender isKindOfClass:[NSTimer class]];
+
+		if (quiet) {
+			[self threadedCheckForUpdatesInBackground:NO];
+		}
+		else {
+			[self threadedCheckForUpdates:NO];
+		}
+	});
 }
 
 - (IBAction)threadedRequestedCheckForUpdate:(id)sender {
@@ -234,15 +230,15 @@ typedef enum {
 
 	NSString *fileURL = [[[NSProcessInfo processInfo] environment] objectForKey:@"QSDownloadUpdateURL"];
 	if (!fileURL)
-        fileURL = kDownloadUpdateURL;
+		fileURL = kDownloadUpdateURL;
 
-    fileURL = [fileURL stringByAppendingFormat:@"?id=%@&type=dmg&new=yes", [[NSBundle mainBundle] objectForInfoDictionaryKey:(NSString *)kCFBundleIdentifierKey]];
+	fileURL = [fileURL stringByAppendingFormat:@"?id=%@&type=dmg&new=yes", [[NSBundle mainBundle] objectForInfoDictionaryKey:(NSString *)kCFBundleIdentifierKey]];
 
-    NSInteger versionType = [[NSUserDefaults standardUserDefaults] integerForKey:@"QSUpdateReleaseLevel"];
-    if (versionType == 2)
-        fileURL = [fileURL stringByAppendingString:@"&dev=1"];
-    else if (versionType == 1)
-        fileURL = [fileURL stringByAppendingString:@"&pre=1"];
+	NSInteger versionType = [[NSUserDefaults standardUserDefaults] integerForKey:@"QSUpdateReleaseLevel"];
+	if (versionType == 2)
+		fileURL = [fileURL stringByAppendingString:@"&dev=1"];
+	else if (versionType == 1)
+		fileURL = [fileURL stringByAppendingString:@"&pre=1"];
 #ifdef DEBUG
 	if (VERBOSE) NSLog(@"Downloading update from %@", fileURL);
 #endif
@@ -259,46 +255,34 @@ typedef enum {
 		updateTask.name = NSLocalizedString(@"Downloading Update", @"Downloading update task name");
 		updateTask.progress = -1;
 
-        __weak QSUpdateController *weakSelf = self;
-        updateTask.cancelBlock = ^{
-            __strong QSUpdateController *strongSelf = weakSelf;
-            strongSelf->shouldCancel = YES;
-            [strongSelf->appDownload cancel];
-            strongSelf->appDownload = nil;
-        };
+		__weak QSUpdateController *weakSelf = self;
+		updateTask.cancelBlock = ^{
+			__strong QSUpdateController *strongSelf = weakSelf;
+			strongSelf->shouldCancel = YES;
+			[strongSelf->appDownload cancel];
+			strongSelf->appDownload = nil;
+		};
 
 		[[QSTaskViewer sharedInstance] showWindow:self];;
 		[updateTask start];
-        [appDownload start];
+		[appDownload start];
 	}
 }
 
-//- (NSDictionary *)downloadInfoForDownload:(NSURLDownload *)download {
-//	//NSLog(@"url %@ %@", [appDownload objectForKey:@"download"] , download);
-//	if ([appDownload isEqual:download]) return appDownload;
-//
-//	NSEnumerator *e = [[self downloadsQueue] objectEnumerator];
-//
-//	NSMutableDictionary *info;
-//	while(info = [e nextObject]) {
-//		if ([[info objectForKey:@"download"] isEqual:download]) break;
-//	}
-//	return info;
-//}
 - (void)download:(QSURLDownload *)download didFailWithError:(NSError *)error {
-    if (download != appDownload)
-        return;
+	if (download != appDownload)
+		return;
 	NSLog(@"Download Failed: %@", error);
 	[updateTask stop];
 	updateTask = nil;
 	NSRunInformationalAlertPanel(@"Download Failed", @"An error occured while updating: %@", @"OK", nil, nil, [error localizedDescription] );
-    [appDownload cancel];
+	[appDownload cancel];
 	appDownload = nil;
 }
 
 - (void)downloadDidFinish:(QSURLDownload *)download {
-    if (download != appDownload)
-        return;
+	if (download != appDownload)
+		return;
 
 	[updateTask setStatus:@"Download Complete"];
 	[updateTask setProgress:1.0];
@@ -307,13 +291,13 @@ typedef enum {
 
 	if (plugInUpdates) {
 		[[NSNotificationCenter defaultCenter] addObserver:self
-												selector:@selector(finishAppInstall)
-													name:@"QSPlugInUpdatesFinished"
-												 object:nil];
+												 selector:@selector(finishAppInstall)
+													 name:@"QSPlugInUpdatesFinished"
+												   object:nil];
 		[[NSNotificationCenter defaultCenter] addObserver:self
-												selector:@selector(finishAppInstall)
-													name:@"QSPlugInUpdatesFailed"
-												 object:nil];
+												 selector:@selector(finishAppInstall)
+													 name:@"QSPlugInUpdatesFailed"
+												   object:nil];
 	} else {
 		NSLog(@"Plugins don't need update");
 		[self finishAppInstall];
@@ -321,132 +305,132 @@ typedef enum {
 }
 
 - (void)downloadDidUpdate:(QSURLDownload *)download {
-    NSString * status = [NSString stringWithFormat:@"%.0fk of %.0fk", (double) [download currentContentLength] /1024, (double)[download expectedContentLength] /1024];
-    [updateTask setStatus:status];
+	NSString * status = [NSString stringWithFormat:@"%.0fk of %.0fk", (double) [download currentContentLength] /1024, (double)[download expectedContentLength] /1024];
+	[updateTask setStatus:status];
 	[updateTask setProgress:[(QSURLDownload *)download progress]];
 }
 
 - (void)finishAppInstall {
 	NSString *path = [appDownload destination];
-    
-    NSInteger selection;
-    
-    BOOL update = [[NSUserDefaults standardUserDefaults] boolForKey:@"QSUpdateWithoutAsking"];
-    if (!update) {
-        selection = NSRunInformationalAlertPanel(@"Download Successful", @"A new version of Quicksilver has been downloaded. Quicksilver must relaunch to install it.", @"Install and Relaunch", @"Cancel Update", nil);
-        update = (selection == NSAlertDefaultReturn);
-    }
-    
-    BOOL installSuccessful = NO;
-    if (update) {
-        installSuccessful = [self installAppFromDiskImage:path];
-        if (!installSuccessful) {
-            selection = NSRunInformationalAlertPanel(@"Installation Failed", @"It was not possible to decompress downloaded file.", @"Cancel Update", @"Download manually", nil);
-            if (selection == NSAlertAlternateReturn)
-                [[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:kWebSiteURL]];
-        }
-    }
-    if (installSuccessful) {
-        BOOL relaunch = [[NSUserDefaults standardUserDefaults] boolForKey:@"QSUpdateWithoutAsking"];
-        if (!relaunch) {
-            selection = NSRunInformationalAlertPanel(@"Installation Successful", @"A new version of Quicksilver has been installed. Quicksilver must relaunch to install it.", @"Relaunch", @"Relaunch Later", nil);
-            relaunch = (selection == NSAlertDefaultReturn);
-        }
-        if (relaunch) {
-            [NSApp relaunchFromPath:nil];
-        }
-    }
+
+	NSInteger selection;
+
+	BOOL update = [[NSUserDefaults standardUserDefaults] boolForKey:@"QSUpdateWithoutAsking"];
+	if (!update) {
+		selection = NSRunInformationalAlertPanel(@"Download Successful", @"A new version of Quicksilver has been downloaded. Quicksilver must relaunch to install it.", @"Install and Relaunch", @"Cancel Update", nil);
+		update = (selection == NSAlertDefaultReturn);
+	}
+
+	BOOL installSuccessful = NO;
+	if (update) {
+		installSuccessful = [self installAppFromDiskImage:path];
+		if (!installSuccessful) {
+			selection = NSRunInformationalAlertPanel(@"Installation Failed", @"It was not possible to decompress downloaded file.", @"Cancel Update", @"Download manually", nil);
+			if (selection == NSAlertAlternateReturn)
+				[[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:kWebSiteURL]];
+		}
+	}
+	if (installSuccessful) {
+		BOOL relaunch = [[NSUserDefaults standardUserDefaults] boolForKey:@"QSUpdateWithoutAsking"];
+		if (!relaunch) {
+			selection = NSRunInformationalAlertPanel(@"Installation Successful", @"A new version of Quicksilver has been installed. Quicksilver must relaunch to install it.", @"Relaunch", @"Relaunch Later", nil);
+			relaunch = (selection == NSAlertDefaultReturn);
+		}
+		if (relaunch) {
+			[NSApp relaunchFromPath:nil];
+		}
+	}
 
 	[updateTask stop];
 	updateTask = nil;
-    appDownload = nil;
+	appDownload = nil;
 }
 
 - (BOOL)installAppFromDiskImage:(NSString *)path {
-    NSFileManager *manager = [NSFileManager defaultManager];
-    
-    // Create a temp directory to mount the .dmg
-    NSError *err = nil;
-    NSString *tempDirectory = [NSTemporaryDirectory() stringByAppendingPathComponent:[NSString uniqueString]];
-    [manager createDirectoryAtPath:tempDirectory withIntermediateDirectories:YES
-                        attributes:nil error:&err];
-    if(err) {
-        NSLog(@"Error: %@", err);
-        return NO;
-    }
-    
-    [updateTask setName:@"Installing Update"];
-    [updateTask setStatus:@"Verifying Data"];
-    [updateTask setProgress:-1.0];
-    
-    // mount the .dmg
-    NSTask *task = [NSTask launchedTaskWithLaunchPath:@"/usr/bin/hdiutil"
-                                            arguments:[NSArray arrayWithObjects:@"attach", path, @"-nobrowse", @"-mountpoint", tempDirectory, nil]];
-    
-    [task waitUntilExit];
-    
-    if ([task terminationStatus] != 0)
-        return NO;
-    
-    NSArray *extracted = [[manager contentsOfDirectoryAtPath:tempDirectory error:nil] pathsMatchingExtensions:[NSArray arrayWithObject:@"app"]];
-    if ([extracted count] != 1)
-        return NO;
-    
-    NSString *mountedAppPath = [tempDirectory stringByAppendingPathComponent:[extracted lastObject]];
-    if (!mountedAppPath) {
-        return NO;
-    }
-    
-    // Copy Quicksilver.app from the .dmg to a writeable folder (QS App Support folder)
+	NSFileManager *manager = [NSFileManager defaultManager];
 
-    // Attempt to delete any old update folders
-    if ([manager fileExistsAtPath:pUpdatePath]) {
-        [manager removeItemAtPath:pUpdatePath error:&err];
-        if (err) {
-            // report the error, but attempt to carry on
-            NSLog(@"Error: %@",err);
-            err = nil;
-        }
-    }
+	// Create a temp directory to mount the .dmg
+	NSError *err = nil;
+	NSString *tempDirectory = [NSTemporaryDirectory() stringByAppendingPathComponent:[NSString uniqueString]];
+	[manager createDirectoryAtPath:tempDirectory withIntermediateDirectories:YES
+						attributes:nil error:&err];
+	if(err) {
+		NSLog(@"Error: %@", err);
+		return NO;
+	}
 
-    [manager createDirectoryAtPath:pUpdatePath withIntermediateDirectories:YES attributes:nil error:&err];
-    if (err) {
-        NSLog(@"Error: %@",err);
-        return NO;
-    }
-    NSString *storedAppPath = [pUpdatePath stringByAppendingPathComponent:[mountedAppPath lastPathComponent]];
-    NSError *copyErr = nil;
-    [manager copyItemAtPath:mountedAppPath toPath:storedAppPath error:&copyErr];
-    if (copyErr) {
-        NSLog(@"Error: %@",copyErr);
-        return NO;
-    }
-    
-    
-    // Copy the Application over the current app
-    [updateTask setStatus:@"Copying Application"];
-    BOOL copySuccess = [NSApp moveToPath:[[NSBundle mainBundle] bundlePath] fromPath:storedAppPath];
-    [updateTask setStatus:@"Cleaning Up"];
-    
-    // Unmount .dmg and tidyup
-    task = [NSTask launchedTaskWithLaunchPath:@"/usr/bin/hdiutil"
-                                    arguments:[NSArray arrayWithObjects:@"detach", tempDirectory, nil]];
-    [task waitUntilExit];
-    [manager removeItemAtPath:tempDirectory error:&err];
-    if(err) {
-        // Couldn't delete the temp directory. Not the end of the world: report and continue
-        NSLog(@"Error: %@",err);
-        err = nil;
-    }
-    [manager removeItemAtPath:pUpdatePath error:&err];
-    if(err) {
-        // Couldn't delete the update directory. Not the end of the world: report and continue
-        NSLog(@"Error: %@",err);
-        err = nil;
-    }
-    
-    return copySuccess;
-    
+	[updateTask setName:@"Installing Update"];
+	[updateTask setStatus:@"Verifying Data"];
+	[updateTask setProgress:-1.0];
+
+	// mount the .dmg
+	NSTask *task = [NSTask launchedTaskWithLaunchPath:@"/usr/bin/hdiutil"
+											arguments:[NSArray arrayWithObjects:@"attach", path, @"-nobrowse", @"-mountpoint", tempDirectory, nil]];
+
+	[task waitUntilExit];
+
+	if ([task terminationStatus] != 0)
+		return NO;
+
+	NSArray *extracted = [[manager contentsOfDirectoryAtPath:tempDirectory error:nil] pathsMatchingExtensions:[NSArray arrayWithObject:@"app"]];
+	if ([extracted count] != 1)
+		return NO;
+
+	NSString *mountedAppPath = [tempDirectory stringByAppendingPathComponent:[extracted lastObject]];
+	if (!mountedAppPath) {
+		return NO;
+	}
+
+	// Copy Quicksilver.app from the .dmg to a writeable folder (QS App Support folder)
+
+	// Attempt to delete any old update folders
+	if ([manager fileExistsAtPath:pUpdatePath]) {
+		[manager removeItemAtPath:pUpdatePath error:&err];
+		if (err) {
+			// report the error, but attempt to carry on
+			NSLog(@"Error: %@",err);
+			err = nil;
+		}
+	}
+
+	[manager createDirectoryAtPath:pUpdatePath withIntermediateDirectories:YES attributes:nil error:&err];
+	if (err) {
+		NSLog(@"Error: %@",err);
+		return NO;
+	}
+	NSString *storedAppPath = [pUpdatePath stringByAppendingPathComponent:[mountedAppPath lastPathComponent]];
+	NSError *copyErr = nil;
+	[manager copyItemAtPath:mountedAppPath toPath:storedAppPath error:&copyErr];
+	if (copyErr) {
+		NSLog(@"Error: %@",copyErr);
+		return NO;
+	}
+
+
+	// Copy the Application over the current app
+	[updateTask setStatus:@"Copying Application"];
+	BOOL copySuccess = [NSApp moveToPath:[[NSBundle mainBundle] bundlePath] fromPath:storedAppPath];
+	[updateTask setStatus:@"Cleaning Up"];
+
+	// Unmount .dmg and tidyup
+	task = [NSTask launchedTaskWithLaunchPath:@"/usr/bin/hdiutil"
+									arguments:[NSArray arrayWithObjects:@"detach", tempDirectory, nil]];
+	[task waitUntilExit];
+	[manager removeItemAtPath:tempDirectory error:&err];
+	if(err) {
+		// Couldn't delete the temp directory. Not the end of the world: report and continue
+		NSLog(@"Error: %@",err);
+		err = nil;
+	}
+	[manager removeItemAtPath:pUpdatePath error:&err];
+	if(err) {
+		// Couldn't delete the update directory. Not the end of the world: report and continue
+		NSLog(@"Error: %@",err);
+		err = nil;
+	}
+
+	return copySuccess;
+
 }
 
 - (NSArray *)extractFilesFromQSPkg:(NSString *)path toPath:(NSString *)tempDirectory {
@@ -466,7 +450,6 @@ typedef enum {
 	} else {
 		return nil;
 	}
-
 }
 
 @end

--- a/Quicksilver/Code-App/QSUpdateController.m
+++ b/Quicksilver/Code-App/QSUpdateController.m
@@ -150,15 +150,14 @@ typedef enum {
 	return newVersionAvailable ? kQSUpdateCheckUpdateAvailable : kQSUpdateCheckNoUpdate;
 }
 
-- (BOOL)checkForUpdates:(BOOL)userInitiated {
+- (void)checkForUpdates:(BOOL)userInitiated {
 	NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
 
 	/* This is an automated check and updates are blocked or not enabled */
 	if ([defaults boolForKey:@"QSPreventAutomaticUpdate"] || ([defaults boolForKey:kCheckForUpdates] && !userInitiated)) {
 		NSLog(@"Preventing update check.");
-		return NO;
+		return;
 	}
-	BOOL updated = NO;
 
 	NSInteger check = [self checkForUpdateStatus:userInitiated];
 
@@ -166,7 +165,7 @@ typedef enum {
 		case kQSUpdateCheckError:
 			if (userInitiated)
 				NSRunInformationalAlertPanel(@"Internet Connection Error", @"Unable to check for updates, the server could not be reached. Please check your internet connection", @"OK", nil, nil);
-			return NO;
+			return;
 			break;
 		case kQSUpdateCheckUpdateAvailable:
 			if (!userInitiated && [[NSUserDefaults standardUserDefaults] boolForKey:@"QSDownloadUpdatesInBackground"]) {
@@ -183,26 +182,23 @@ typedef enum {
 					[[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:kWebSiteURL]];
 				}
 			}
-			return YES;
+			return;
 			break;
 		case kQSUpdateCheckNoUpdate:
 		{
 			QSPluginUpdateStatus updateStatus;
 			updateStatus = [[QSPlugInManager sharedInstance] checkForPlugInUpdates];
 			if (updateStatus == QSPluginUpdateStatusNoUpdates) {
-				updated = NO;
 				NSLog(@"Quicksilver is up to date.");
 				if (userInitiated)
 					NSRunInformationalAlertPanel(@"You're up-to-date!", [NSString stringWithFormat:@"You already have the latest version of Quicksilver (%@) and all installed plugins", [[NSBundle mainBundle] objectForInfoDictionaryKey:(NSString *)kCFBundleVersionKey]] , @"OK", nil, nil);
 			}
-			return updated;
+			return;
 			break;
 		}
 		default:
 			break;
 	}
-
-	return NO;
 }
 
 - (void)handleURL:(NSURL *)url {

--- a/Quicksilver/Code-App/QSUpdateController.m
+++ b/Quicksilver/Code-App/QSUpdateController.m
@@ -159,15 +159,16 @@ typedef enum {
 		return;
 	}
 
-	NSInteger check = [self checkForUpdateStatus:userInitiated];
+	{
+		NSInteger check = [self checkForUpdateStatus:userInitiated];
 
-	switch (check) {
-		case kQSUpdateCheckError:
+		if (check == kQSUpdateCheckError) {
 			if (userInitiated)
 				NSRunInformationalAlertPanel(@"Internet Connection Error", @"Unable to check for updates, the server could not be reached. Please check your internet connection", @"OK", nil, nil);
 			return;
-			break;
-		case kQSUpdateCheckUpdateAvailable:
+		}
+
+		if (check == kQSUpdateCheckUpdateAvailable) {
 			if (!userInitiated && [[NSUserDefaults standardUserDefaults] boolForKey:@"QSDownloadUpdatesInBackground"]) {
 				/** Diable automatically checking for updates in the background for DEBUG builds
 				 You can still check for updates by clicking the "Check Now" button **/
@@ -183,9 +184,9 @@ typedef enum {
 				}
 			}
 			return;
-			break;
-		case kQSUpdateCheckNoUpdate:
-		{
+		}
+
+		if (check == kQSUpdateCheckNoUpdate) {
 			QSPluginUpdateStatus updateStatus;
 			updateStatus = [[QSPlugInManager sharedInstance] checkForPlugInUpdates];
 			if (updateStatus == QSPluginUpdateStatusNoUpdates) {
@@ -194,10 +195,7 @@ typedef enum {
 					NSRunInformationalAlertPanel(@"You're up-to-date!", [NSString stringWithFormat:@"You already have the latest version of Quicksilver (%@) and all installed plugins", [[NSBundle mainBundle] objectForInfoDictionaryKey:(NSString *)kCFBundleVersionKey]] , @"OK", nil, nil);
 			}
 			return;
-			break;
 		}
-		default:
-			break;
 	}
 }
 

--- a/Quicksilver/Resources/DefaultsMap.plist
+++ b/Quicksilver/Resources/DefaultsMap.plist
@@ -80,6 +80,20 @@
 	</dict>
 	<dict>
 		<key>category</key>
+		<string>Update</string>
+		<key>default</key>
+		<string>QSUpdateWithoutAsking</string>
+		<key>image</key>
+		<string>Quicksilver</string>
+		<key>requestRelaunch</key>
+		<true/>
+		<key>title</key>
+		<string>Silently install updates</string>
+		<key>type</key>
+		<string>checkbox</string>
+	</dict>
+	<dict>
+		<key>category</key>
 		<string>Command</string>
 		<key>default</key>
 		<string>Shift Actions</string>


### PR DESCRIPTION
Since I'm currently accessing the 'ternet from my world-changing iPhone, I just noticed that the update system does its thing on the main thread. When there's a DNS hiccup at the same time, you end up with a spinning-beachball QS for _too long_.

This fixes it by generous use of dispatch queues. This also makes its API more self-contained.

Not completely tested, by which I mean I clicked on the "Check Now" button, but that's all I did.

As a bonus, every user-facing string is now wrapped in a gentle `NSLocalizedString`.
