### PR TITLE
use the right selector for relaunchApplication (forgot the colon). Fixes #1604

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSProcessSource.m
+++ b/Quicksilver/Code-QuickStepCore/QSProcessSource.m
@@ -175,7 +175,7 @@
 - (QSObject *)relaunchApplication:(QSObject *)dObject {
 	NSArray *array = [dObject arrayForType:QSProcessType];
     [array enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
-        [[NSWorkspace sharedWorkspace] performSelector:@selector(relaunchApplication) withObject:obj];
+        [[NSWorkspace sharedWorkspace] performSelector:@selector(relaunchApplication:) withObject:obj];
     }];
 	return nil;
 }


### PR DESCRIPTION
Well duh, it was just a typo - missed the colon.

Caught you @craigotis ;-)
https://github.com/quicksilver/Quicksilver/commit/8cb92f9ed286f7fb1aa066de140b76cfe43065cf#L3R178

Is there a reason why you used `performSelector` as opposed to calling the method directly?
