### PR TITLE
Remove checks for 32 bit in the plugin pusher

### DIFF
--- a/Quicksilver/Tools/qs-push-plugin
+++ b/Quicksilver/Tools/qs-push-plugin
@@ -28,20 +28,6 @@ require 'plist'
 
 # FUNCTIONS
 
-#  Check to make sure the file contains a 32/64 bit binary. If not, die
-def checkIsUniversalBinary(plist, file)
-  # Make sure the file is a 32/64 bit binary
-  bin_file = plist['CFBundleName']
-  bin_path = File.join(file, "Contents","MacOS",bin_file)
-  # Some plugins don't contain binaries
-  if not File.exists?(bin_path)
-    return
-  end
-  arch_details = %x(file "#{bin_path}")
-  if not (arch_details.include? "Mach-O 64-bit bundle x86_64" and arch_details.include? "Mach-O bundle i386")
-      Trollop::die "#{file} does not contain a 32/64 bit binary. Aborting"
-    end
-end
 
 # MAIN SCRIPT
 
@@ -128,7 +114,6 @@ files.each do |file|
       plist = Plist::parse_xml(info_path)
       
       # Make sure the file is a 32/64 bit binary
-      checkIsUniversalBinary(plist, file)
       
       image_file = if image_path = plist['QSPlugIn']['icon']
         path = Dir.glob(File.join(file, "Contents", "Resources", image_path + ".[jpg|png]"))


### PR DESCRIPTION
Since plugins build against QS 4001 or later are 64 bit only, this check in `qs-push-plugin` was annoying: at the moment you have to comment it out if you want to push the plugin
