### PR TITLE
catch `nil` strings in text proxies

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSTextProxy.m
+++ b/Quicksilver/Code-QuickStepCore/QSTextProxy.m
@@ -5,7 +5,11 @@
 #import "QSObject_PropertyList.h"
 
 @implementation QSObject (TextProxy)
-+ (id)textProxyObjectWithDefaultValue:(NSString *)string {
++ (id)textProxyObjectWithDefaultValue:(NSString *)string
+{
+    if (!string) {
+        string = @"";
+    }
 	QSObject *object = [self objectWithType:QSTextProxyType value:string name:string];
 	[object setIcon:[[NSWorkspace sharedWorkspace] iconForFileType:@"'clpt'"]];
 	return object;


### PR DESCRIPTION
I ran across a small bug this morning introduced by #1548.

To reproduce:
1. Search for something with children (an artist from iTunes in my case).
2. Right-arrow to show the children, then select one _without typing any letters_.
3. Go to the second pane and call up “Assign Abbreviation…”.

Since there is no search text, there's an exception and the interface sort of loses its mind.
