### PR TITLE
Xcode 5 static analyzer fixes

### DIFF
--- a/Quicksilver/Code-QuickStepFoundation/NSBundle_BLTRExtensions.m
+++ b/Quicksilver/Code-QuickStepFoundation/NSBundle_BLTRExtensions.m
@@ -152,9 +152,13 @@ NSMutableDictionary *scriptsDictionary = nil;
 	NSAppleScript *script = [[NSBundle scriptsDictionary] objectForKey:compositeName];
 	if (!script) {
 		NSString *path = [self pathForResource:name ofType:@"scpt"];
-		if (path) script = [[NSAppleScript alloc] initWithContentsOfURL:[NSURL fileURLWithPath:path] error:nil];
-		[[NSBundle scriptsDictionary] setObject:script forKey:compositeName];
+		if (path) {
+            script = [[NSAppleScript alloc] initWithContentsOfURL:[NSURL fileURLWithPath:path] error:nil];
+        }
 	}
+    if (script) {
+        [[NSBundle scriptsDictionary] setObject:script forKey:compositeName];
+    }
 	return script;
 }
 

--- a/Quicksilver/Code-QuickStepFoundation/NSString_BLTRExtensions.m
+++ b/Quicksilver/Code-QuickStepFoundation/NSString_BLTRExtensions.m
@@ -230,7 +230,7 @@ NSComparisonResult prefixCompare(NSString *aString, NSString *bString) {
 	CFUUIDRef uuid = CFUUIDCreate(NULL);
 	CFStringRef uuidStr = CFUUIDCreateString(NULL, uuid);
 	CFRelease(uuid);
-	return (__bridge NSString *)uuidStr;
+	return (__bridge_transfer NSString *)uuidStr;
 }
 @end
 

--- a/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
@@ -1731,9 +1731,7 @@ NSMutableDictionary *bindingsDict = nil;
         } else {
             parent = [newSelectedObject parent];
         }
-        
-        newSelectedObject = parent;
-        
+                
         // should show parent's level
         newSelectedObject = parent;
         if (newSelectedObject) {


### PR DESCRIPTION
I ran the static analyzer from Xcode 5. Lots of things in the ND classes. The things here are small, mainly typos.

A look over the `__bridge_transfer` by @craigotis would be good :)

P.S. yes - the analyzer did bring up the `cleanObjectDictionary` method ;-)
