### PR TITLE
add OS version checking to QSRequirements

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSPlugIn.m
+++ b/Quicksilver/Code-QuickStepCore/QSPlugIn.m
@@ -633,6 +633,27 @@ NSMutableDictionary *plugInBundlePaths = nil;
 				return NO;
 			}
 		}
+        NSString *osRequired = [requirementsDict objectForKey:@"osRequired"];
+        if (osRequired) {
+            if ([[NSApplication macOSXFullVersion] compare:osRequired] == NSOrderedAscending) {
+                if (error) {
+                    NSString *localizedErrorFormat = NSLocalizedString(@"Requires Mac OS X %@ or later", nil);
+                    *error = [NSString stringWithFormat:localizedErrorFormat, osRequired];
+                }
+                return NO;
+            }
+        }
+        NSString *osUnsupported = [requirementsDict objectForKey:@"osUnsupported"];
+        if (osUnsupported) {
+            NSComparisonResult versionComparison = [[NSApplication macOSXFullVersion] compare:osUnsupported];
+            if (versionComparison == NSOrderedSame || versionComparison == NSOrderedDescending) {
+                if (error) {
+                    NSString *localizedErrorFormat = NSLocalizedString(@"Unsupported on Mac OS X %@ or later", nil);
+                    *error = [NSString stringWithFormat:localizedErrorFormat, osUnsupported];
+                }
+                return NO;
+            }
+        }
 	}
 	return YES;
 }


### PR DESCRIPTION
Pretty small and self-explanitory.

I mainly did this so the new [File Tagging plug-in](/quicksilver/FileTagging-qsplugin) can require 10.9.

I've tested this under 10.9, by the way. It works if you specify either "10.9.0" or "10.9" as the required OS.

Once merged, I'll update the plug-in dev reference.
