### PR TITLE
use older method to instantiate the Preferences NIB

### DIFF
--- a/Quicksilver/Code-QuickStepInterface/QSPreferencePane.m
+++ b/Quicksilver/Code-QuickStepInterface/QSPreferencePane.m
@@ -97,7 +97,7 @@
         NSNib *nib = [[NSNib alloc] initWithNibNamed:[self mainNibName] bundle:[self mainNibBundle]];
         NSArray *objects = nil;
 
-        [nib instantiateWithOwner:self topLevelObjects:&objects];
+        [nib instantiateNibWithOwner:self topLevelObjects:&objects];
 
         _mainView = [_window contentView];
         if (QSGetLocalizationStatus())


### PR DESCRIPTION
This reverts part of 80cbf0b4184e to preserve compatibly with 10.7.

fixes #1628
