### PR TITLE
make Primer the default interface

### DIFF
--- a/Quicksilver/Resources/QSDefaults.plist
+++ b/Quicksilver/Resources/QSDefaults.plist
@@ -48,7 +48,7 @@
 	<key>QSChatMediators</key>
 	<string>com.apple.iChat</string>
 	<key>QSCommandInterfaceControllers</key>
-	<string>QSBezelInterfaceController</string>
+	<string>QSPrimerInterfaceController</string>
 	<key>QSFSBrowserMediators</key>
 	<string>com.apple.finder</string>
 	<key>QSLoadImagePreviews</key>


### PR DESCRIPTION
It was supposed to be like this already. (see #936)

I ran across this when setting up a clean install under a VM. I also saw [a recent article](http://mac.appstorm.net/reviews/productivity-review/quicksilver-the-best-free-way-to-do-everything-with-just-your-keyboard/) claim that Bezel was the default and was going to correct them, but…

Primer is correctly set as the fall-back if nothing is defined, but since there's an entry in the defaults, it's always defined.
