### PR TITLE
fix a crash related to `argumentCount`

### DIFF
--- a/Quicksilver/Code-QuickStepInterface/QSInterfaceController.m
+++ b/Quicksilver/Code-QuickStepInterface/QSInterfaceController.m
@@ -442,7 +442,7 @@
         }
         if ([obj isKindOfClass:[QSRankedObject class]])
             obj = [(QSRankedObject*)obj object];
-        if ([obj isKindOfClass:[QSAction class]]) {
+        if ([obj respondsToSelector:@selector(argumentCount)]) {
             NSInteger argumentCount = [obj argumentCount];
             // update indirects if the action requires it, or if the iSelector is already visible and the action has indirectOptional
             if (argumentCount == 2 || ([[[[self window] contentView] subviews] containsObject:iSelector] && [obj indirectOptional])) {


### PR DESCRIPTION
I _think_ this will fix a crash I’ve seen twice in as many days. If you disagree, just close it.

```
Crashed Thread:  0  Dispatch queue: com.apple.main-thread

Exception Type:  EXC_BAD_ACCESS (SIGSEGV)
Exception Codes: KERN_INVALID_ADDRESS at 0x00006570795465d7

VM Regions Near 0x6570795465d7:
    JS JIT generated code  00004c66dae01000-00004c66dae02000 [    4K] ---/rwx SM=NUL  
--> 
    MALLOC_TINY            00007fe6c9c00000-00007fe6c9f00000 [ 3072K] rw-/rwx SM=PRV  

Thread 0 Crashed:: Dispatch queue: com.apple.main-thread
0   libobjc.A.dylib                 0x00007fff8afcb758 objc_msgSend_vtable14 + 24
1   com.blacktree.QSCore            0x00000001024e24f5 -[QSAction argumentCount] + 338
2   com.blacktree.QSInterface       0x0000000102596640 -[QSInterfaceController searchObjectChanged:] + 493
3   com.qsapp.Quicksilver.NostromoInterface 0x00000001074dc193 0x1074d9000 + 12691
4   com.apple.CoreFoundation        0x00007fff88d0feda _CFXNotificationPost + 2554
5   com.apple.Foundation            0x00007fff94eb87b6 -[NSNotificationCenter postNotificationName:object:userInfo:] + 64
6   com.blacktree.QSInterface       0x00000001025a7fb4 -[QSSearchObjectView selectObjectValue:] + 482
7   com.blacktree.QSInterface       0x00000001025a82b7 -[QSSearchObjectView selectIndex:] + 211
8   com.blacktree.QSInterface       0x00000001025a8440 -[QSSearchObjectView selectObject:] + 102
9   com.blacktree.QSInterface       0x00000001025958e4 -[QSInterfaceController updateControl:withArray:] + 535
10  com.blacktree.QSInterface       0x0000000102595cb8 -[QSInterfaceController updateActionsNow] + 330
11  com.apple.Foundation            0x00007fff94ee3463 __NSFireTimer + 96
12  com.apple.CoreFoundation        0x00007fff88d1a804 __CFRUNLOOP_IS_CALLING_OUT_TO_A_TIMER_CALLBACK_FUNCTION__ + 20
13  com.apple.CoreFoundation        0x00007fff88d1a31d __CFRunLoopDoTimer + 557
14  com.apple.CoreFoundation        0x00007fff88cffad9 __CFRunLoopRun + 1529
15  com.apple.CoreFoundation        0x00007fff88cff0e2 CFRunLoopRunSpecific + 290
16  com.apple.HIToolbox             0x00007fff910b7eb4 RunCurrentEventLoopInMode + 209
17  com.apple.HIToolbox             0x00007fff910b7b94 ReceiveNextEventCommon + 166
18  com.apple.HIToolbox             0x00007fff910b7ae3 BlockUntilNextEventMatchingListInMode + 62
19  com.apple.AppKit                0x00007fff8f004533 _DPSNextEvent + 685
20  com.apple.AppKit                0x00007fff8f003df2 -[NSApplication nextEventMatchingMask:untilDate:inMode:dequeue:] + 128
21  com.apple.AppKit                0x00007fff8effb1a3 -[NSApplication run] + 517
22  com.apple.AppKit                0x00007fff8ef9fbd6 NSApplicationMain + 869
23  com.blacktree.Quicksilver       0x00000001023ec4a4 0x1023eb000 + 5284
```
