### PR TITLE
determine the current screen using the search object view

### DIFF
--- a/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
@@ -444,7 +444,7 @@ NSMutableDictionary *bindingsDict = nil;
 	if ([[resultController window] isVisible]) return; //[resultController->resultTable reloadData];
     
 	NSRect resultWindowRect = [[resultController window] frame];
-	NSRect screenRect = [[[resultController window] screen] frame];
+	NSRect screenRect = [[[self window] screen] frame];
     NSRect sovRect = [[self window] convertRectToScreen:[self frame]];
     NSRect interfaceRect = [[self window] frame];
 


### PR DESCRIPTION
It _was_ getting the screen for the result window, but that doesn’t get moved over until later in this method, so it always referred to the main display. As a result, `NSIntersectionRect()` on line 489 always returned an origin and size of (0.0, 0.0) since there was no overlap.

(FYI, I originally found that commenting out line 489 fixed it too. I wonder if we even need it.)
