### PR TITLE
Ignore opera download files for the 'latest download' proxy object

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSDownloads.m
+++ b/Quicksilver/Code-QuickStepCore/QSDownloads.m
@@ -61,7 +61,7 @@
 
 	NSNumber *isDir;
 	NSNumber *isPackage;
-	NSSet *ignoredExtensions = [NSSet setWithObjects:@"download", @"part", @"dtapart", @"crdownload", nil];
+	NSSet *ignoredExtensions = [NSSet setWithObjects:@"download", @"part", @"dtapart", @"crdownload", @"opdownload", nil];
 	for (NSURL *downloadedFile in contents) {
 		err = nil;
 		NSString *fileExtension = [downloadedFile pathExtension];


### PR DESCRIPTION
Nothing much to it really. Add `opdownload` to the existing list
