### PR TITLE
force qs-push-plugin to use Ruby 1.x

### DIFF
--- a/Quicksilver/Tools/qs-push-plugin
+++ b/Quicksilver/Tools/qs-push-plugin
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby
+#!/System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/bin/ruby
 # encoding: UTF-8
 
 #####################################################################


### PR DESCRIPTION
The alternative would be to get it working with Ruby 2.0. I leave that decision up to @tiennou.
