### PR TITLE
Change the user agent to be more like a browser's user agent

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSDefines.h
+++ b/Quicksilver/Code-QuickStepCore/QSDefines.h
@@ -1,8 +1,12 @@
 #pragma mark User Agent
 
-#define kQSUserAgent [NSString stringWithFormat:@"Quicksilver/%@ OSX/%@ (%@)",\
+#define kQSUserAgent [NSString stringWithFormat:@"Quicksilver/%@ (Macintosh; Intel Mac OS X %@; %@) (like Safari)",\
 					 (__bridge NSString *)CFBundleGetValueForInfoDictionaryKey(CFBundleGetMainBundle(), kCFBundleVersionKey),\
-					 [NSApplication macOSXFullVersion], @"x86"]
+					 [[NSApplication macOSXFullVersion] stringByReplacingOccurrencesOfString:@"." withString:@"_"],\
+                     kLocale]
+
+#define kLocale [NSString stringWithFormat:@"%@-%@", [[[NSBundle mainBundle] preferredLocalizations] objectAtIndex:0],\
+                [[[NSLocale currentLocale] objectForKey:NSLocaleCountryCode] lowercaseString]]
 
 #pragma mark Search URLs
 


### PR DESCRIPTION
Since setting up gAnalytics for the plugin update system, most of the browser information is useless, since gAnalytics doesn't understand the current format we use for the User-Agent:

`Quicksilver/4008 OSX/10.9.0 (x86)`

So I've updated the user agent to more closely mimic that of typical browsers [like Safari](http://www.useragentstring.com/pages/Safari/) meaning gAnalytics should better understand it:

`Quicksilver/4008 (Macintosh; Intel Mac OS X 10_9_0; cy-gb) (like Safari)`

Things to note:
- Safari uses `like Gecko`, I've put in `like Safari` - this should help with any browsers that reject requests based on User Agent. It's pretty [interesting why Apple did it in the first place](http://www.nczonline.net/blog/2010/01/12/history-of-the-user-agent-string/) (search for Webkit). I think it's fine for us to pretend to be Safari? :P This is mostly useful when using QS to browse sites I guess
- The locale in the user agent doesn't necessarily show the preferred locale of the current user, but shows the language they are using Quicksilver in. This was intentional. I think it's more interesting for us to know that "90% of people in Russia are using Quicksilver in Welsh" or whatever as opposed to "99% of people in Russia have their OS language set to Russian".
- The word `Intel` is hard-coded, no need to test for PPC or x86_64 now (we can tell from the QS version)
