### PR TITLE
Only show the upgrade/downgrade popups when dealing with release builds

### DIFF
--- a/Quicksilver/Code-App/QSController.m
+++ b/Quicksilver/Code-App/QSController.m
@@ -618,7 +618,12 @@ static QSController *defaultController = nil;
 }
 
 - (void)checkForFirstRun {
+
+#ifdef DEBUG
+    QSApplicationLaunchStatusFlags status = QSApplicationNormalLaunch;
+#else
 	QSApplicationLaunchStatusFlags status = [NSApp checkLaunchStatus];
+#endif
 
 	NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
 	NSString *bundlePath = [[NSBundle mainBundle] bundlePath];
@@ -697,7 +702,9 @@ static QSController *defaultController = nil;
 	}
 	if (![defaults boolForKey:kSetupAssistantCompleted] || lastVersion <= [@"3694" hexIntValue] || ![defaults boolForKey:@"QSAgreementAccepted"])
 		runningSetupAssistant = YES;
+#ifndef DEBUG
 	[NSApp updateLaunchStatusInfo];
+#endif
 }
 
 - (void)checkForCrash {

--- a/Quicksilver/Code-QuickStepFoundation/NSApplication_BLTRExtensions.m
+++ b/Quicksilver/Code-QuickStepFoundation/NSApplication_BLTRExtensions.m
@@ -116,7 +116,6 @@
 - (QSApplicationLaunchStatusFlags)checkLaunchStatus {
 	NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
 	NSString *lastLocation = [defaults objectForKey:kLastUsedLocation];
-
 	NSString *lastVersionString = [defaults objectForKey:kLastUsedVersion];
 	NSString *thisVersionString = [[[NSBundle mainBundle] infoDictionary] objectForKey:(NSString *)kCFBundleVersionKey];
 


### PR DESCRIPTION
OK, it's finally got to me! All the silly "different location", "older version" popups I get when debugging.

Now, only release builds will ever interfere with these settings :)
