### PR TITLE
Change QSProxyObject cache time to 0.5 seconds.

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSProxyObject.m
+++ b/Quicksilver/Code-QuickStepCore/QSProxyObject.m
@@ -73,7 +73,7 @@
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(objectIconModified:) name:QSObjectIconModified object:proxy];
     }
     
-    NSTimeInterval interval = 3.0f;
+    NSTimeInterval interval = 0.5f;
     
     if ([provider respondsToSelector:@selector(cacheTimeForProxy:)])
         interval = [[self proxyProvider] cacheTimeForProxy:self];


### PR DESCRIPTION
After finding out from a friend working at Apple that [the #510 bug](https://github.com/quicksilver/Quicksilver/issues/510) has _finally_ been fixed in Mavericks, I switched over to using the proxy object, and it's been reliable.

However, it was at confusing at first because the proxy cache time was still 3 seconds. This means that if you use the Finder selection more than once within three seconds, you get a stale result. This can be rather annoying if you're trying to operate on a few files in succession, or if you'd like to correct your selection.

As mentioned in #485, reducing the proxy time to 0.5 seconds makes the proxy feel really reliable. I've spent weeks (months?) running custom builds off of releases with just that one change, and I haven't run into an error attributable to shorter caching. (Then again, I manage to crash QS a lot just using weird corner cases in the preferences...)

I'd much rather run actual releases, so I'd really like to see a change to the proxy time. What are the [potential issues Rob was worried about](https://github.com/quicksilver/Quicksilver/issues/485#issuecomment-7306516)?
