### PR TITLE
Tack on a (nil) argument if the selector is asking for one

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSObjCMessageSource.m
+++ b/Quicksilver/Code-QuickStepCore/QSObjCMessageSource.m
@@ -79,7 +79,7 @@
 	else
 		target = [QSReg getClassInstance:targetClass];
 
-	BOOL returnsObject = NO;
+
 
 	if (![target respondsToSelector:selector]) {
 		NSBeep();
@@ -87,18 +87,24 @@
 		return nil;
 	}
     
-    id result;
+    // returnsObject and result are never used (never implemented?). See result = comment below
+    //	BOOL returnsObject = NO;
+    //  id result;
+    
     id argument = nil;
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Warc-performSelector-leaks"
     // NSMethodSignature numberOfArguments is always +2 from the number of 'visible' arguments. So numberOfArguments == 3 means 1 visible arg.
     if ((argument = messageInfo[kActionArgument]) || [[target methodSignatureForSelector:selector] numberOfArguments] == 3) {
-        result = [target performSelector:selector withObject:argument];
+        /* Results should never be directly taken from performSelector (according to the docs). Instead NSInvocation should be used. Since the result is never used (returnsObject is always NO) then we don't need it here */
+//        result =
+        [target performSelector:selector withObject:argument];
     } else {
-        result = [target performSelector:selector];
+//        result =
+        [target performSelector:selector];
     }
 #pragma clang diagnostic pop
-	if (returnsObject && [result isKindOfClass:[QSBasicObject class]]) return result;
+	/* if (returnsObject && [result isKindOfClass:[QSBasicObject class]]) return result; */
 	return nil;
 }
 


### PR DESCRIPTION
Seems like pre-ARC would tack on a `nil` argument when calling `performSelector:` on a selector that required an argument, but for which none was provided.
Now, we have to explicitly check if the selector requires an argument, and tack one on (`nil` in this case) if none is provided.

Fixes @philostein's bug found Rob [mentioned](https://github.com/quicksilver/Quicksilver/issues/1716#issuecomment-30711545)
