### PR TITLE
don't set identifiers on pasteboard objects

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSObject_Pasteboard.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject_Pasteboard.m
@@ -203,7 +203,6 @@ bool writeObjectToPasteboard(NSPasteboard *pasteboard, NSString *type, id data) 
                 }
                 [self setPrimaryType:key];
                 [self setName:textString];
-                [self setIdentifier:[NSString stringWithFormat:@"%@:%@",key,[NSString uniqueString]]];
                 break;
             }
 		}


### PR DESCRIPTION
fixes #1597
