### PR TITLE
don't send app launch notifications when reloading

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSProcessMonitor.m
+++ b/Quicksilver/Code-QuickStepCore/QSProcessMonitor.m
@@ -312,8 +312,8 @@ OSStatus appTerminated(EventHandlerCallRef nextHandler, EventRef theEvent, void 
 		if (!isReloading) {
 			[self didChangeValueForKey:[thisProcess isBackground] ? @"backgroundProcesses" : @"visibleProcesses"];
 			[self didChangeValueForKey:@"allProcesses"];
+			[[NSNotificationCenter defaultCenter] postNotificationName:@"QSEventNotification" object:@"QSApplicationLaunchEvent" userInfo:[NSDictionary dictionaryWithObject:procObject forKey:@"object"]];
 		}
-        [[NSNotificationCenter defaultCenter] postNotificationName:@"QSEventNotification" object:@"QSApplicationLaunchEvent" userInfo:[NSDictionary dictionaryWithObject:procObject forKey:@"object"]];
 	}
 }
 


### PR DESCRIPTION
The fix for #1756 turned out to be pretty simple. There was already an `isReloading` boolean to prevent certain behaviors when adding existing processes. I just put the app launch notification under that.
