### PR TITLE
Proof of concept showing simplicity of NSCoding

### DIFF
--- a/Quicksilver/Code-App/QSTriggersPrefPane.m
+++ b/Quicksilver/Code-App/QSTriggersPrefPane.m
@@ -167,7 +167,7 @@
     
 	[triggerTable registerForDraggedTypes:[NSArray arrayWithObjects:NSFilenamesPboardType, QSTriggerDragType, nil]];
 	[triggerTable setVerticalMotionCanBeginDrag: TRUE];
-	[triggerTable setOutlineTableColumn:[triggerTable tableColumnWithIdentifier:@"command"]];
+	[triggerTable setOutlineTableColumn:[triggerTable tableColumnWithIdentifier:kCommand]];
 	[[[triggerTable tableColumnWithIdentifier:@"type"] dataCell] setArrowPosition:NSPopUpNoArrow];
 
 	NSColor *color = [triggerSetsTable backgroundColor];
@@ -314,7 +314,7 @@
 		[info setObject:[sender representedObject] forKey:@"type"];
 		[info setObject:[NSNumber numberWithBool:YES] forKey:kItemEnabled];
 		if (command)
-			[info setObject:command forKey:@"command"];
+			[info setObject:command forKey:kCommand];
 		//		[triggerTreeController add:sender];
 	}
 	[info setObject:[NSString uniqueString] forKey:kItemID];
@@ -330,7 +330,7 @@
 	if ([[trigger type] isEqualToString:@"QSGroupTrigger"]) {
 		NSInteger row = [triggerTable selectedRow];
 		//NSLog(@"row %d %@", row, [[triggerArrayController selectedObjects] lastObject]);
-		[triggerTable editColumn:[triggerTable columnWithIdentifier:@"command"]
+		[triggerTable editColumn:[triggerTable columnWithIdentifier:kCommand]
 							 row:row withEvent:[NSApp currentEvent] select:YES];
 	} else if (!mOptionKeyIsDown) {
         [commandEditor setCommand:[selectedTrigger command]];
@@ -508,7 +508,7 @@
 			[manager performSelector:@selector(triggerDoubleClicked:) withObject:theSelectedTrigger];
 		return NO;
 	}
-	if ([[aTableColumn identifier] isEqualToString:@"command"] || [[aTableColumn identifier] isEqualToString:@"icon"]) {
+	if ([[aTableColumn identifier] isEqualToString:kCommand] || [[aTableColumn identifier] isEqualToString:@"icon"]) {
 		if ([theSelectedTrigger usesPresetCommand])
 			return NO;
 		if ([[NSApp currentEvent] type] == NSKeyDown) {

--- a/Quicksilver/Code-QuickStepCore/QSCommand.h
+++ b/Quicksilver/Code-QuickStepCore/QSCommand.h
@@ -6,7 +6,7 @@
 @interface QSCommandObjectHandler : NSObject
 @end
 
-@interface QSCommand : QSObject {
+@interface QSCommand : QSObject <NSCoding> {
     QSObject *dObject;
     QSAction *aObject;
     QSObject *iObject;

--- a/Quicksilver/Code-QuickStepCore/QSCommand.m
+++ b/Quicksilver/Code-QuickStepCore/QSCommand.m
@@ -85,7 +85,7 @@
 // CommandsAsActionsHandling
 - (QSObject *)performAction:(QSAction *)action directObject:(QSObject *)dObject indirectObject:(QSObject *)iObject {
 	NSDictionary *dict=[action objectForType:QSActionType];
-	QSCommand *command=[QSCommand commandWithInfo:[dict objectForKey:@"command"]];
+	QSCommand *command=[QSCommand commandWithInfo:[dict objectForKey:kCommand]];
 	return [command execute];
 }
 
@@ -164,7 +164,7 @@ NSTimeInterval QSTimeIntervalForString(NSString *intervalString) {
 	[info setObject:[NSNumber numberWithBool:YES] forKey:kItemEnabled];
     
 	if (command)
-		[info setObject:command forKey:@"command"];
+		[info setObject:command forKey:kCommand];
     
 	[info setObject:[NSString uniqueString] forKey:kItemID];
     
@@ -228,7 +228,7 @@ NSTimeInterval QSTimeIntervalForString(NSString *intervalString) {
     NSDictionary *commandInfo = [QSReg valueForKey:identifier inTable:@"QSCommands"];
     QSCommand *cmd = nil;
     if (commandInfo) {
-        cmd = [QSCommand commandWithDictionary:[commandInfo objectForKey:@"command"]];
+        cmd = [QSCommand commandWithDictionary:[commandInfo objectForKey:kCommand]];
         [cmd setIdentifier:identifier];
     }
     return cmd;
@@ -241,7 +241,7 @@ NSTimeInterval QSTimeIntervalForString(NSString *intervalString) {
 }
 
 + (QSCommand *)commandWithFile:(NSString *)path {
-	return [self objectWithDictionary:[[NSDictionary dictionaryWithContentsOfFile:path] objectForKey:@"command"]];
+	return [self objectWithDictionary:[[NSDictionary dictionaryWithContentsOfFile:path] objectForKey:kCommand]];
 }
 
 - (QSCommand *)initWithDirectObject:(QSObject *)directObject actionObject:(QSAction *)actionObject indirectObject:(QSObject *)indirectObject {
@@ -260,6 +260,28 @@ NSTimeInterval QSTimeIntervalForString(NSString *intervalString) {
 	return self;
 }
 
+#pragma mark NSCoding
+
+#define kDirectObject @"directObject"
+#define kActionObject @"actionObject"
+#define kIndirectObject @"indirectObject"
+
+- (id)initWithCoder:(NSCoder *)coder {
+    if (self = [super initWithCoder:coder]) {
+        dObject = [coder decodeObjectForKey:kDirectObject];
+        aObject = [coder decodeObjectForKey:kActionObject];
+        iObject = [coder decodeObjectForKey:kIndirectObject];
+    }
+    return self;
+}
+
+- (void)encodeWithCoder:(NSCoder *)coder {
+    [super encodeWithCoder:coder];
+    [coder encodeObject:dObject forKey:kDirectObject];
+    [coder encodeObject:aObject forKey:kActionObject];
+    [coder encodeObject:iObject forKey:kIndirectObject];
+}
+
 - (NSMutableDictionary*)commandDict {
     NSMutableDictionary *dict = [self objectForType:QSCommandType];
     if(!dict) [self setObject:(dict = [NSMutableDictionary dictionary]) forType:QSCommandType];
@@ -267,7 +289,7 @@ NSTimeInterval QSTimeIntervalForString(NSString *intervalString) {
 }
 
 - (void)writeToFile:(NSString *)path {
-	[[NSDictionary dictionaryWithObject:[self dictionaryRepresentation] forKey:@"command"] writeToFile:path atomically:NO];
+	[[NSDictionary dictionaryWithObject:[self dictionaryRepresentation] forKey:kCommand] writeToFile:path atomically:NO];
 }
 
 - (void)setDirectObject:(QSObject*)newObject {

--- a/Quicksilver/Code-QuickStepCore/QSKeys.h
+++ b/Quicksilver/Code-QuickStepCore/QSKeys.h
@@ -5,6 +5,7 @@
 #define kItemDescription @"description"
 #define kItemChildren @"children"
 #define kItemID @"ID"
+#define kCommand @"command"
 #define kItemEnabled @"enabled"
 #define kItemModificationDate @"modificationDate"
 #define kItemSettings @"settings"

--- a/Quicksilver/Code-QuickStepCore/QSObject.h
+++ b/Quicksilver/Code-QuickStepCore/QSObject.h
@@ -79,7 +79,7 @@ typedef struct _QSObjectFlags {
 
 
 
-@interface QSObject : QSBasicObject <NSCopying> {
+@interface QSObject : QSBasicObject <NSCopying, NSCoding> {
 	NSString *name;
 	NSString *label;
 	NSString *identifier;

--- a/Quicksilver/Code-QuickStepCore/QSObject.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject.m
@@ -95,6 +95,33 @@ NSSize QSMaxIconSize;
 	return self;
 }
 
+#pragma mark NSCoding
+
+- (id)initWithCoder:(NSCoder *)coder {
+	self = [self init];
+    
+	[meta setDictionary:[coder decodeObjectForKey:@"meta"]];
+	[data setDictionary:[coder decodeObjectForKey:@"data"]];
+	[self extractMetadata];
+	id dup = [QSLib objectWithIdentifier:[self identifier]];
+	if (dup) return dup;
+	return self;
+}
+
+- (void)encodeWithCoder:(NSCoder *)coder {
+    for (NSMutableDictionary *dict in @[data, meta]) {
+        [dict enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
+            if (![key respondsToSelector:@selector(encodeWithCoder:)] || ![obj respondsToSelector:@selector(encodeWithCoder:)]) {
+                [dict removeObjectForKey:key];
+            }
+        }];
+    }
+    [coder encodeObject:data forKey:kData];
+    [coder encodeObject:identifier forKey:kItemID];
+}
+
+#pragma mark Instance methods
+
 - (BOOL)isEqual:(id)anObject {
   if (self != anObject && [anObject isKindOfClass:[QSRankedObject class]]) {
     anObject = [anObject object];
@@ -820,16 +847,6 @@ NSSize QSMaxIconSize;
 }
 - (void)writeToFile:(NSString *)path {
 	[data writeToFile:path atomically:YES];
-}
-- (id)initWithCoder:(NSCoder *)coder {
-	self = [self init];
-
-	[meta setDictionary:[coder decodeObjectForKey:@"meta"]];
-	[data setDictionary:[coder decodeObjectForKey:@"data"]];
-	[self extractMetadata];
-	id dup = [QSLib objectWithIdentifier:[self identifier]];
-	if (dup) return dup;
-	return self;
 }
 
 - (void)extractMetadata {

--- a/Quicksilver/Code-QuickStepCore/QSTrigger.h
+++ b/Quicksilver/Code-QuickStepCore/QSTrigger.h
@@ -10,7 +10,7 @@
 #import "QSCommand.h"
 
 
-@interface QSTrigger : NSObject {
+@interface QSTrigger : NSObject <NSCoding> {
 	NSMutableDictionary *info;
 	QSCommand *command;
 	NSMutableArray *children;

--- a/Quicksilver/Code-QuickStepCore/QSTrigger.m
+++ b/Quicksilver/Code-QuickStepCore/QSTrigger.m
@@ -21,7 +21,7 @@
     NSSet *keyPaths = [super keyPathsForValuesAffectingValueForKey:key];
 
     if ([key isEqualToString:@"name"]) {
-        keyPaths = [keyPaths setByAddingObject:@"command"];
+        keyPaths = [keyPaths setByAddingObject:kCommand];
     } else if ([key isEqualToString:@"imageAndText"]) {
         keyPaths = [keyPaths setByAddingObjectsFromSet:[NSSet setWithObjects:@"name",@"icon",nil]];
     }
@@ -57,10 +57,20 @@
 	return self;
 }
 
-- (void)dealloc {
-#ifdef DEBUG
-	NSLog(@"dealloc %@", self);
-#endif
+
+#pragma mark NSCoding
+
+- (id)initWithCoder:(NSCoder *)aDecoder {
+    if (self == [super init]) {
+        info = [aDecoder decodeObjectForKey:kData];
+        command = [aDecoder decodeObjectForKey:kCommand];
+    }
+    return self;
+}
+
+- (void)encodeWithCoder:(NSCoder *)aCoder {
+    [aCoder encodeObject:self.command forKey:kCommand];
+    [aCoder encodeObject:self.info forKey:kData];
 }
 
 - (NSString *)identifier {
@@ -168,7 +178,7 @@
     if (command)
         return command;
     
-	id archivedCommand = [info objectForKey:@"command"];
+	id archivedCommand = [info objectForKey:kCommand];
     if (archivedCommand)
         command = [QSCommand commandWithInfo:archivedCommand];
 	return command;
@@ -191,7 +201,7 @@
 // if the command has a preset (e.g. a built in command/trigger for a plugin: performs a single action),
 // it is a single string as opposed to an NSDict with an 'action' and 'direct object' (or 'indirect object')
 - (BOOL)usesPresetCommand {
-	return ([[info objectForKey:@"command"] isKindOfClass:[NSString class]]);
+	return ([[info objectForKey:kCommand] isKindOfClass:[NSString class]]);
 }
 
 - (NSDictionary *)dictionaryRepresentation {
@@ -203,9 +213,9 @@
         rep = [[self command] objectForType:QSCommandType];
     }
     if (rep)
-        [dict setObject:rep forKey:@"command"];
+        [dict setObject:rep forKey:kCommand];
     else
-        [dict removeObjectForKey:@"command"];
+        [dict removeObjectForKey:kCommand];
 	return dict;
 }
 


### PR DESCRIPTION
So yeah, I got annoyed with all the bugs we have saving/loading triggers and stuff, so thought I'd do a proof-of-concept on using `NSCoding`. Who'd have thought it would only take me 40 minutes, and result in fewer lines of code? (when we're properly done, we can remove all the stupid `dictionaryRepresentation` stuff, which will remove hundreds of lines)

With this branch, only triggers are archived at the moment. Of course the goal would be to archive everything we write to disk (shelves, QSCommands, catalogs) but this is just a proof of concept at the moment.
I haven't tested too much, but it seems to work nicely. The other side effect of this working is that quicksilver/elements.trigger.event-qsplugin#2 is now way less complicated (no need to use value transformers - we can just save QSObjects! :)
### The downsides...

The reason I never did this before was because it's completely backwards incompatible (without a lot of extra work on our part). After seeing quicksilver/elements.trigger.event-qsplugin#2 though and just how much sidestepping we've been doing over the years I got fed up and figured that backwards incompatibility isn't a problem. We just bump QS to v2.0 and be done with it.
So timescale... I'm kind of lost as to where v1.2.0-dev is, but does it include the UTI stuff? If so, then that's pretty backwards incompatible... so maybe we should just bump to v2.0 now?

**warning:** back up your `triggers.plist` before trying
