### PR TITLE
Clear caches when downgrading as well as upgrading QS

### DIFF
--- a/Quicksilver/Code-App/QSController.h
+++ b/Quicksilver/Code-App/QSController.h
@@ -12,7 +12,7 @@
 	NSStatusItem *statusItem;
 	IBOutlet NSMenu *statusMenu;
 	NSConnection *controllerConnection, *dropletConnection;
-	BOOL newVersion, runningSetupAssistant;
+	BOOL versionChanged, runningSetupAssistant;
 	NSObject *dropletProxy;
     NSString *crashReportPath;
 }

--- a/Quicksilver/Code-App/QSController.m
+++ b/Quicksilver/Code-App/QSController.m
@@ -658,7 +658,7 @@ static QSController *defaultController = nil;
 			
             // Not localizing this, as it's pretty much obsolete
 			[[NSWorkspace sharedWorkspace] setComment:@"Quicksilver" forFile:[[NSBundle mainBundle] bundlePath]];
-				newVersion = YES;
+            versionChanged = YES;
 			break;
         }
 		case QSApplicationDowngradedLaunch: {
@@ -669,7 +669,8 @@ static QSController *defaultController = nil;
 			if (selection == 1)
 				[[NSWorkspace sharedWorkspace] selectFile:[[NSBundle mainBundle] bundlePath] inFileViewerRootedAtPath:@""];
 #endif
-				break;
+            versionChanged = YES;
+            break;
         }
 		case QSApplicationFirstLaunch: {
 			NSString *containerPath = [[bundlePath stringByDeletingLastPathComponent] stringByStandardizingPath];
@@ -895,7 +896,7 @@ static QSController *defaultController = nil;
 #endif
 
 #ifndef DEBUG
-	if (newVersion) {
+	if (versionChanged) {
 		if (!runningSetupAssistant) {
 			NSLog(@"New Version: Purging all Identifiers and Forcing Rescan");
 			[QSLibrarian removeIndexes];
@@ -1004,11 +1005,11 @@ static QSController *defaultController = nil;
 	if ([defaults boolForKey:kAutomaticTaskViewer])
 		[QSTaskViewer sharedInstance];
 
-	if ( ! (runningSetupAssistant || newVersion) )
+	if ( ! (runningSetupAssistant || versionChanged) )
 		[self rescanItems:self];
 
 #ifndef DEBUG
-	if (newVersion)
+	if (versionChanged)
 		[[QSUpdateController sharedInstance] forceStartupCheck];
 #endif
 


### PR DESCRIPTION
As Rob and I discussed on quicksilver/elements.trigger.event-qsplugin#2, it's also often worth clearing caches when downgrading QS.

Anyhow, rescanning the catalog is hardly a big deal. I think this should go in v1.2 (but I'm pulling against master, I hope that's OK :/)
