### PR TITLE
Fix a possible crash when releasing a CF obj

### DIFF
--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Code/QSActionProvider_EmbeddedProviders.m
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Code/QSActionProvider_EmbeddedProviders.m
@@ -301,16 +301,18 @@
 		// comma trick - get a list of apps based on the 1st selected file
 		fileURL = [NSURL fileURLWithPath:[[dObject validPaths] objectAtIndex:0]];
 
-        CFURLRef urlRef = NULL;
-		if (fileURL) LSGetApplicationForURL((__bridge CFURLRef) fileURL, kLSRolesAll, NULL, &urlRef);
+        NSURL *preferredAppURL = nil;
+        if (fileURL) {
+            CFURLRef urlRef = NULL;
+            LSGetApplicationForURL((__bridge CFURLRef) fileURL, kLSRolesAll, NULL, &urlRef);
+            if (urlRef) {
+                preferredAppURL = (__bridge_transfer NSURL*)urlRef;
+            }
+        }
 
         NSArray *fileObjects = [QSLib arrayForType:QSFilePathType];
         
-		id preferred = [QSObject fileObjectWithPath:[(__bridge NSURL *)urlRef path]];
-        if (urlRef != NULL) {
-            CFRelease(urlRef);
-        }
-
+		id preferred = [QSObject fileObjectWithPath:[preferredAppURL path]];
         
         NSIndexSet *applicationIndexes = [fileObjects indexesOfObjectsWithOptions:NSEnumerationConcurrent passingTest:^BOOL(QSObject *thisObject, NSUInteger i, BOOL *stop) {
             QSObject *resolved = [thisObject resolvedAliasObject];


### PR DESCRIPTION
I think this crash just now only occurred because of a caches problem, but if you see that when `fileURL ==  nil` then `urlRef == NULL`. We all know that trying to `CFRelease(NULL)` is bad. 
