### PR TITLE
prevent the plug-in updater from going off screen

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSPluginUpdaterWindowController.m
+++ b/Quicksilver/Code-QuickStepCore/QSPluginUpdaterWindowController.m
@@ -46,7 +46,7 @@
 
     // Values for aHeight: -ive indicates shrinkage, +ive indicates expand. 0 indicates use initial height
     if (aHeight == 0) {
-        // 121 is the 'extra' height of the window
+        // 111 is the 'extra' height of the window
         aHeight = [pluginsArray count]*kExpandHeight+111;
     } else {
         originy -= aHeight;


### PR DESCRIPTION
Another quickie for 1.2.0

One way to test is to downgrade all plug-ins. Here’s a script that will do it.

``` python
#!/usr/bin/env python

import os
from plistlib import readPlist, writePlist

plugin_path = '/path/to/copy/of/PlugIns'
for fitem in os.listdir(plugin_path):
    if fitem.endswith('.qsplugin'):
        plist_path_parts = [plugin_path, fitem, 'Contents', 'Info.plist']
        plist_path = '/'.join(plist_path_parts)
        data = readPlist(plist_path)
        current_version = data['CFBundleVersion']
        version = hex(int(current_version, 16) - 1)[2:]
        data['CFBundleVersion'] = version.upper()
        writePlist(data, plist_path)
```
