### PR TITLE
never rescan entries with QSVoyeur enabled

### DIFF
--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Code/QSFileSystemObjectSource.m
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Code/QSFileSystemObjectSource.m
@@ -394,6 +394,7 @@
 	NSMutableDictionary *settings = [theEntry objectForKey:kItemSettings];
 
     if ([[settings objectForKey:@"watchTarget"] boolValue]) {
+        // no need to scan - this entry is updated automatically
         return YES;
     }
 	NSString *itemPath = [self fullPathForSettings:settings];


### PR DESCRIPTION
These entries are kept up to date in real-time and never need to be rescanned.

Should avoid quite a bit of pointless disk activity.
