### PR TITLE
Don't try and find a nil type's UTI

### DIFF
--- a/Quicksilver/Code-QuickStepFoundation/QSUTI.m
+++ b/Quicksilver/Code-QuickStepFoundation/QSUTI.m
@@ -110,7 +110,7 @@ NSString *QSUTIWithLSInfoRec(NSString *path, LSItemInfoRecord *infoRec) {
 }
 
 NSString *QSUTIForAnyTypeString(NSString *type) {
-    if ([type isEqualToString:@"*"] || QSIsUTI(type)) {
+    if (!type || [type isEqualToString:@"*"] || QSIsUTI(type)) {
         return type;
     }
     


### PR DESCRIPTION
In some cases 'type' is nil, there's no point doing the UTI dance for a nil string.

Should be a slight optimisation over the original.
