### PR TITLE
Remove the AppleScript warning at launch about `list`.

### DIFF
--- a/Quicksilver/Scripting/Quicksilver.sdef
+++ b/Quicksilver/Scripting/Quicksilver.sdef
@@ -93,11 +93,17 @@
 		</command>
         <command name="get indirect types" code="DAEDgiob" description="Get the valid indirect (3rd pane) object types for this action. Scripts with this handler can customize the types of objects displayed in Quicksilver's 3rd pane by returning a list of types supported. Valid values are shown at http://qsapp.com/wiki/AppleScript_Types">
 			<cocoa class="NSScriptCommand"/>
-			<result description="value to return to Quicksilver" type="list"/>
+			<result description="value to return to Quicksilver">
+                <type type="text"/>
+                <type type="text" list="yes"/>
+            </result>
 		</command>
         <command name="get direct types" code="DAEDgdob" description="Get the valid direct (1st pane) object types for which this action will appear. Scripts with this handler can customize for which types of objects the action appears for, by returning a list of types supported. Valid values are shown at http://qsapp.com/wiki/AppleScript_Types">
 			<cocoa class="NSScriptCommand"/>
-			<result description="value to return to Quicksilver" type="list"/>
+			<result description="value to return to Quicksilver">
+                <type type="text"/>
+                <type type="text" list="yes"/>
+            </result>
 		</command>
 	</suite>
 </dictionary>

--- a/Quicksilver/Scripting/QuicksilverHandlers.scriptSuite
+++ b/Quicksilver/Scripting/QuicksilverHandlers.scriptSuite
@@ -28,9 +28,9 @@
 			<key>CommandClass</key>
 			<string>NSScriptCommand</string>
 			<key>ResultAppleEventCode</key>
-			<string>****</string>
-			<key>Type</key>
 			<string>list</string>
+			<key>Type</key>
+			<string>NSArray</string>
 		</dict>
 		<key>GetIndirectTypes</key>
 		<dict>
@@ -41,9 +41,9 @@
 			<key>CommandClass</key>
 			<string>NSScriptCommand</string>
 			<key>ResultAppleEventCode</key>
-			<string>****</string>
-			<key>Type</key>
 			<string>list</string>
+			<key>Type</key>
+			<string>NSArray</string>
 		</dict>
 		<key>OpenFiles</key>
 		<dict>

--- a/Quicksilver/Scripting/QuicksilverScripting.r
+++ b/Quicksilver/Scripting/QuicksilverScripting.r
@@ -14,6 +14,27 @@ resource 'aete' (0, "Quicksilver") {
 	english,
 	roman,
 	{
+		"Type Names Suite",
+		"Hidden terms",
+		kASTypeNamesSuite,
+		1,
+		1,
+		{
+			/* Events */
+
+		},
+		{
+			/* Classes */
+
+			"list of text or text", '****', "", { }, { }
+		},
+		{
+			/* Comparisons */
+		},
+		{
+			/* Enumerations */
+		},
+
 		"Standard Suite",
 		"Common classes and commands for most applications.",
 		'????',
@@ -522,7 +543,7 @@ resource 'aete' (0, "Quicksilver") {
 			'DAED', 'giob',
 			'****',
 			"value to return to Quicksilver",
-			replyRequired, singleItem, notEnumerated, Reserved13,
+			replyRequired, listOfItems, notEnumerated, Reserved13,
 			dp_none__,
 			{
 
@@ -533,7 +554,7 @@ resource 'aete' (0, "Quicksilver") {
 			'DAED', 'gdob',
 			'****',
 			"value to return to Quicksilver",
-			replyRequired, singleItem, notEnumerated, Reserved13,
+			replyRequired, listOfItems, notEnumerated, Reserved13,
 			dp_none__,
 			{
 


### PR DESCRIPTION
I found the fix almost 1 year and an half after I stopped looking ;-).

Note that I haven't checked for breakage, the rationale being that ~~it was already broken but working~~ I'm lazy, and I don't have scripts handy.
