### PR TITLE
include public.file-url data for pasteboard objects

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSObject_Pasteboard.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject_Pasteboard.m
@@ -53,7 +53,7 @@ id objectForPasteboardType(NSPasteboard *pasteboard, NSString *type) {
 		[pasteboard addTypes:[NSArray arrayWithObjects:NSURLPboardType, NSStringPboardType, nil] owner:nil];
 		[pasteboard setString:([pbData hasPrefix:@"mailto:"]) ?[pbData substringFromIndex:7] :pbData forType:NSStringPboardType];
 		[pasteboard setString:[pbData URLDecoding] forType:NSURLPboardType];
-    } else if ([type isEqualToString:@"public.file-url"]) {
+    } else if ([type isEqualToString:@"public.file-url"] && [pbData isKindOfClass:[NSArray class]]) {
         [pasteboard setString:pbData[0] forType:type];
 	} else if ([PLISTTYPES containsObject:type] || [pbData isKindOfClass:[NSDictionary class]] || [pbData isKindOfClass:[NSArray class]]) {
         if (![pbData isKindOfClass:[NSArray class]]) {


### PR DESCRIPTION
Here’s an attempt at fixing #1805. I tried to do it with as few changes as possible. Note that no changes to the plug-in were required.

Probably not perfect, but this code should all go away soon, right?
