### PR TITLE
show "Open" above "Open URL" by default

### DIFF
--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/QSCorePlugIn-Info.plist
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/QSCorePlugIn-Info.plist
@@ -1193,7 +1193,7 @@
 				<string>Apple URL pasteboard type</string>
 			</array>
 			<key>precedence</key>
-			<integer>3</integer>
+			<integer>2</integer>
 			<key>actionSelector</key>
 			<string>doURLOpenAction:</string>
 		</dict>
@@ -1299,7 +1299,7 @@
 				<string>NSFilenamesPboardType</string>
 			</array>
 			<key>precedence</key>
-			<real>1</real>
+			<real>2.5</real>
 			<key>validatesObjects</key>
 			<true/>
 			<key>actionSelector</key>


### PR DESCRIPTION
More than one new user has been confused because when copying a file from the clipboard, the object will contain a file URL. In that case, “Open URL” is what they see by default. They create a trigger with that and then the trigger quits working after a relaunch because the URL data goes away.

They should be using “Open”, but this is not obvious.

I “broke” this myself in 78079f43ed1c, but that was not the right answer. I’ll lower the precedences in Remote Hosts instead.
