### PR TITLE
assign a key code to events when “typing” text

### DIFF
--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Code/QSTextSource.m
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Code/QSTextSource.m
@@ -69,12 +69,16 @@
         keyEvent = CGEventCreateKeyboardEvent(NULL, keyCode, true);
         CGEventKeyboardSetUnicodeString(keyEvent, 1, &buffer);
         CGEventPost(kCGHIDEventTap, keyEvent);
-        CFRelease(keyEvent);
+        if (keyEvent) {
+            CFRelease(keyEvent);
+        }
         // key up event
         keyEvent = CGEventCreateKeyboardEvent(NULL, keyCode, false);
         CGEventKeyboardSetUnicodeString(keyEvent, 1, &buffer);
         CGEventPost(kCGHIDEventTap, keyEvent);
-        CFRelease(keyEvent);
+        if (keyEvent) {
+            CFRelease(keyEvent);
+        }
     }
 }
 


### PR DESCRIPTION
Thanks to CoRD being open source, I was able to run it in a debugger and examine the keyboard behavior, which gave me some ideas that led to the answer. The answer, by the way, is right there in the comments for `CGEventKeyboardSetUnicodeString()`:

> Note that application frameworks may ignore the Unicode string in a keyboard event and do their own translation based on the virtual keycode and perceived event state.

Remote Desktop clients apparently fall into this category.

I notice that we’re only sending key **down** events, but never sending the corresponding **up** event. It seems to work anyway, but should we fix that?

Also note that Type Text still mangles certain characters in Unicode-string-ignoring apps, but that was probably always the case. I can live with it.
