### PR TITLE
enhance Quicksilver version checking

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSDefines.h
+++ b/Quicksilver/Code-QuickStepCore/QSDefines.h
@@ -61,3 +61,105 @@
 
 // NSNumber (float) :
 #define kActionPrecedence @"precedence"
+
+// QSPlugin Requirements Dict (Info.plist)
+
+/**
+ *  Type: array
+ *  A key to an array of dictionaries representing required bundles before the plugin can be installed
+ */
+#define kPluginRequirementsBundles @"bundles"
+
+/**
+ *  Type: string
+ *  Name of this bundle that is requried (part of the dict specified for a bundle in a plugins Requirements dictionary)
+ */
+#define kPluginRequirementsBundleName @"name"
+
+/**
+ *  Type: string
+ *  Bundle identifier of this required bundle (part of the dict specified for a bundle in a plugins Requirements dictionary)
+ */
+#define kPluginRequirementsBundleId @"id"
+
+/**
+ *  Type: string
+ *  Required bundle version (part of the dict specified for a bundle in a plugins Requirements dictionary)
+ */
+#define kPluginRequirementsBundleVersion @"version"
+
+
+/**
+ *  Type: array
+ *  A key to an array of dictionaries representing required LOADED frameworks before the plugin can be installed
+ *  Each of these frameworks will be loaded in turn (if they exist) before the plugin is installed
+ */
+#define kPluginRequirementsFrameworks @"frameworks"
+
+/**
+ *  Type: string
+ *  Name of this framework that is requried (part of the dict specified for a framework in a plugins Requirements dictionary)
+ *  This is only used for display purposes, to show to the user
+ */
+#define kPluginRequirementsFrameworkName @"name"
+
+/**
+ *  Type: string
+ *  Bundle identifier of this required bundle/framework (part of the dict specified for a framework in a plugins Requirements dictionary)
+ *  This is only used for display purposes, to show to the user
+ */
+#define kPluginRequirementsFrameworkId @"id"
+
+/**
+ *  Type: string, array or dictionary
+ *  A represention of the framework that is required and must be loaded before this plugin will work. (part of the dict specified for a framework in a plugins Requirements dictionary)
+ *  Uses -[QSResourceManager pathWithLocatorInformation:] to resolve the resource
+ */
+#define kPluginRequirementsFrameworkResource @"resource"
+
+/**
+ *  Type: string
+ *  Required bundle/framework version (part of the dict specified for a bundle or framework in a plugins Requirements dictionary)
+ */
+#define kPluginRequirementsFrameworkVersion @"version"
+
+/**
+ *  Type: array
+ *  An array of paths that must be present on the
+ *  Host computer before the plugin can be installed
+ */
+#define kPluginRequirementsPaths @"paths"
+
+/**
+ *  Type: string
+ *  Key to the mininum required Quicksilver vertsion supported by this plugin
+ *  This key is deprecated, and should be replaced with @"minHostVersion"
+ *  (kPluginRequirementsMinHostVersion)
+ */
+#define kPluginRequirementsMinHostVersion__deprecated @"version"
+
+/**
+ *  Type: string
+ *  Key to the mininum required Quicksilver vertsion supported by this plugin
+ */
+#define kPluginRequirementsMinHostVersion @"minHostVersion"
+
+/**
+ *  Type: string
+ *  Key to the maximum Quicksilver vertsion supported by this plugin
+ *  Any Quicksilver app with a higher version that this number will not
+ *  load this plugin
+ */
+#define kPluginRequirementsMaxHostVersion @"maxHostVersion"
+/**
+ *  Type: string
+ *  Key to the minimum version of OS X supported by this plugin
+ */
+#define kPluginRequirementsOSRequiredVersion @"osRequired"
+/**
+ *  Type: string
+ *  Key to the first verison of OS X that no longer supports this plugin
+ *  E.g. if 10.7 is specified, 10.6.8, 10.6.9... would all be supported
+ */
+#define kPluginRequirementsOSUnsupportedVersion @"osUnsupported"
+

--- a/Quicksilver/Code-QuickStepCore/QSPlugIn.m
+++ b/Quicksilver/Code-QuickStepCore/QSPlugIn.m
@@ -560,9 +560,9 @@ NSMutableDictionary *plugInBundlePaths = nil;
 	*error = nil;
 	if (requirementsDict) {
 		if (![[NSUserDefaults standardUserDefaults] boolForKey:@"QSIgnorePlugInBundleRequirements"]) {
-			for (NSDictionary *bundleDict in [requirementsDict objectForKey:@"bundles"]) {
-				NSString *identifier = [bundleDict objectForKey:@"id"];
-                NSString *name = [bundleDict objectForKey:@"name"];
+			for (NSDictionary *bundleDict in requirementsDict[kPluginRequirementsBundles]) {
+				NSString *identifier = bundleDict[kPluginRequirementsBundleId];
+                NSString *name = bundleDict[kPluginRequirementsBundleName];
                 NSString *path = [[NSWorkspace sharedWorkspace] absolutePathForAppBundleWithIdentifier:identifier];
 				if (!path) {
                     if (error) {
@@ -571,7 +571,7 @@ NSMutableDictionary *plugInBundlePaths = nil;
                     }
 					return NO;
 				}
-                NSString *requiredVersion = [bundleDict objectForKey:@"version"];
+                NSString *requiredVersion = bundleDict[kPluginRequirementsBundleVersion];
                 if (requiredVersion) {
                     // check bundle's version
                     NSDictionary *details = [[NSBundle bundleWithPath:path] infoDictionary];
@@ -587,31 +587,32 @@ NSMutableDictionary *plugInBundlePaths = nil;
 			}
 		}
 
-		 {
-			NSArray *frameworks = [requirementsDict objectForKey:@"frameworks"];
-			for(NSDictionary * frameworkDict in frameworks) {
-				NSString *identifier = [frameworkDict objectForKey:@"id"];
-				NSString *resource = [frameworkDict objectForKey:@"resource"];
-				NSString *path = [[QSResourceManager sharedInstance] pathWithLocatorInformation:resource];
-				//path = @"/Volumes/Lore/Applications/Colloquy.app/Contents/Frameworks/AGRegex.framework";
-				NSBundle *pathBundle = [NSBundle bundleWithPath:path];
-				[pathBundle load];
-				//CFBundleRef b = CFBundleCreate(NULL, [NSURL fileURLWithPath:path]);
-				//int err = CFBundleLoadExecutable(b);
-				NSLog(@"path %@ %@ %@", path, resource, pathBundle);
+        NSArray *frameworks = requirementsDict[kPluginRequirementsFrameworks];
+        for(NSDictionary * frameworkDict in frameworks) {
+            NSString *identifier = frameworkDict[kPluginRequirementsFrameworkId];
+            NSString *resource = frameworkDict[kPluginRequirementsFrameworkResource];
+            NSString *name = frameworkDict[kPluginRequirementsFrameworkName];
+            NSString *path = [[QSResourceManager sharedInstance] pathWithLocatorInformation:resource];
+            NSBundle *pathBundle = [NSBundle bundleWithPath:path];
+            // try and load the framework
+            [pathBundle load];
+            
+            if (!path) {
+                if (error) {
+                    NSString *localizedErrorFormat = NSLocalizedString(@"Requires Framework '%@'", nil);
+                    *error = [NSString stringWithFormat:localizedErrorFormat, name?name:identifier];
+                }
+                return NO;
+            } else if (![pathBundle isLoaded]) {
+                if (error) {
+                    NSString *localizedErrorFormat = NSLocalizedString(@"Framework '%@' could not be loaded", nil);
+                    *error = [NSString stringWithFormat:localizedErrorFormat, name?name:identifier];
+                }
+                return NO;
+            }
+        }
 
-				if (!path) {
-                    if (error) {
-                        NSString *name = [frameworkDict objectForKey:@"name"];
-                        NSString *localizedErrorFormat = NSLocalizedString(@"Requires Framework '%@'", nil);
-                        *error = [NSString stringWithFormat:localizedErrorFormat, name?name:identifier];
-                    }
-					return NO;
-				}
-			}
-		}
-
-		NSArray *paths = [requirementsDict objectForKey:@"paths"];
+		NSArray *paths = requirementsDict[kPluginRequirementsPaths];
 		for(NSString * path in paths) {
 			if (![[NSFileManager defaultManager] fileExistsAtPath:[path stringByStandardizingPath]]) {
 				if (error) {
@@ -622,9 +623,9 @@ NSMutableDictionary *plugInBundlePaths = nil;
 			}
 		}
 
-		NSString *qsVersion = [requirementsDict objectForKey:@"version"];
+		NSString *qsVersion = requirementsDict[kPluginRequirementsMinHostVersion];
         if (!qsVersion) {
-            qsVersion = [requirementsDict objectForKey:@"minHostVersion"];
+            qsVersion = requirementsDict[kPluginRequirementsMinHostVersion__deprecated];
         }
 		if (qsVersion) {
 			NSComparisonResult sorting = [[[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleVersion"] versionCompare:qsVersion];
@@ -636,7 +637,7 @@ NSMutableDictionary *plugInBundlePaths = nil;
 				return NO;
 			}
 		}
-		NSString *qsMaxVersion = [requirementsDict objectForKey:@"maxHostVersion"];
+		NSString *qsMaxVersion = requirementsDict[kPluginRequirementsMaxHostVersion];
 		if (qsMaxVersion) {
 			NSComparisonResult sorting = [[[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleVersion"] versionCompare:qsMaxVersion];
 			if (sorting>0) {
@@ -647,7 +648,7 @@ NSMutableDictionary *plugInBundlePaths = nil;
 				return NO;
 			}
 		}
-        NSString *osRequired = [requirementsDict objectForKey:@"osRequired"];
+        NSString *osRequired = requirementsDict[kPluginRequirementsOSRequiredVersion];
         if (osRequired) {
             if ([[NSApplication macOSXFullVersion] compare:osRequired] == NSOrderedAscending) {
                 if (error) {
@@ -657,7 +658,7 @@ NSMutableDictionary *plugInBundlePaths = nil;
                 return NO;
             }
         }
-        NSString *osUnsupported = [requirementsDict objectForKey:@"osUnsupported"];
+        NSString *osUnsupported = requirementsDict[kPluginRequirementsOSUnsupportedVersion];
         if (osUnsupported) {
             NSComparisonResult versionComparison = [[NSApplication macOSXFullVersion] compare:osUnsupported];
             if (versionComparison == NSOrderedSame || versionComparison == NSOrderedDescending) {


### PR DESCRIPTION
implement `minHostVersion` and `maxHostVersion`

As discussed on the list.

I’ve already put a version of the Cube interface out that advertises its lack of support beyond 1.1.3. It’s a little messy, since the update system prevents you from _seeing_ that update if you’re already on 1.2.0. But those people have surely discovered by now that the Cube crashes QS. People still on 1.1.3 should get the update.

We need to make a small tweak on the remote side for the update system. When it’s returning a list of plug-ins that support the current version, it will still list the plug-in if `maxHostVersion` is the current version + 1. So `maxHostVersion` is acting like “minimum unsupported version” instead of “maximum supported version”. I think. Basically, I had to add 1 to what was in the database (16391 → 16392) to get the right behavior. :-)
