### PR TITLE
return file URLs as a simple string

### DIFF
--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Code/QSActionProvider_EmbeddedProviders.m
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Code/QSActionProvider_EmbeddedProviders.m
@@ -805,7 +805,8 @@
 }
 
 - (QSObject *)getFileURLs:(QSObject *)dObject {
-	return [QSObject objectWithString:[[NSURL performSelector:@selector(fileURLWithPath:) onObjectsInArray:[dObject arrayForType:QSFilePathType] returnValues:YES] componentsJoinedByString:@"\n"]];
+	NSString *fileURLs = [[NSURL performSelector:@selector(fileURLWithPath:) onObjectsInArray:[dObject arrayForType:QSFilePathType] returnValues:YES] componentsJoinedByString:@"\n"];
+    return [QSObject objectWithType:QSTextType value:fileURLs name:fileURLs];
 }
 - (QSObject *)getFileLocations:(QSObject *)dObject {
 	return [QSObject objectWithString:[[[dObject arrayForType:QSFilePathType] arrayByPerformingSelector:@selector(fileSystemPathHFSStyle)] componentsJoinedByString:@"\n"]];


### PR DESCRIPTION
Don’t call `sniffString` via `objectWithString:` because it’s a little _too_ smart for this case.
