### PR TITLE
Increase the timeout for plugin downloads

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSURLDownloadWrapper.m
+++ b/Quicksilver/Code-QuickStepCore/QSURLDownloadWrapper.m
@@ -10,7 +10,7 @@
 
 @implementation QSURLDownload
 + (id)downloadWithURL:(NSURL*)url delegate:(id)aDelegate {
-	NSMutableURLRequest *theRequest = [NSMutableURLRequest requestWithURL:url cachePolicy:NSURLRequestUseProtocolCachePolicy timeoutInterval:5.0];
+	NSMutableURLRequest *theRequest = [NSMutableURLRequest requestWithURL:url cachePolicy:NSURLRequestUseProtocolCachePolicy timeoutInterval:30.0];
     [theRequest setValue:@"gzip" forHTTPHeaderField:@"Accept-Encoding"];
 	[theRequest setValue:kQSUserAgent forHTTPHeaderField:@"User-Agent"];
     return [[self alloc] initWithRequest:theRequest delegate:aDelegate];


### PR DESCRIPTION
5.0s was a bit short, especially for slow internet connections, and it doesn't matter too much as the downloads are on a background thread
