### PR TITLE
Use the CDN URL for plugin downloading/checking

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSPaths.h
+++ b/Quicksilver/Code-QuickStepCore/QSPaths.h
@@ -14,10 +14,10 @@
 #define psMainPlugInsLocation QSApplicationSupportSubPath(@"PlugIns/", NO)
 #define psMainPlugInsToInstallLocation QSApplicationSupportSubPath(@"PlugIns/Incoming/", NO)
 
-#define kCheckUpdateURL         @"http://qs0.qsapp.com/plugins/check.php"
-#define kDownloadUpdateURL      @"http://qs0.qsapp.com/plugins/download.php"
-#define kPluginInfoURL          @"http://qs0.qsapp.com/plugins/info.php"
-#define kPluginDownloadURL      @"http://qs0.qsapp.com/plugins/download.php"
+#define kCheckUpdateURL         @"http://cdn.qsapp.com/plugins/check.php"
+#define kDownloadUpdateURL      @"http://cdn.qsapp.com/plugins/download.php"
+#define kPluginInfoURL          @"http://cdn.qsapp.com/plugins/info.php"
+#define kPluginDownloadURL      @"http://cdn.qsapp.com/plugins/download.php"
 
 #define kForumsURL				@"http://groups.google.com/group/blacktree-quicksilver"
 #define kBugsURL				@"https://github.com/quicksilver/Quicksilver/issues"


### PR DESCRIPTION
It seems like qs0.qsapp.com is really slow right now, making plugin downloads slow (even though plugins are downloaded from the CDN, which is fast).
The problem seems to be with the redirect from qs0.qsapp.com → cdn.qsapp.com (which uses Cloudflare)

I've updated the URLs QS uses to go directly to the CDN
