### PR TITLE
Perform keyboard switching on main thread.

### DIFF
--- a/Quicksilver/Code-QuickStepInterface/QSInterfaceController.m
+++ b/Quicksilver/Code-QuickStepInterface/QSInterfaceController.m
@@ -160,27 +160,26 @@
 - (void)showMainWindow:(id)sender {
     QSGCDMainAsync(^{
         [[self window] makeKeyAndOrderFront:sender];
-        QSGCDQueueAsync(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-            if ([[NSUserDefaults standardUserDefaults] boolForKey:kSuppressHotKeysInCommand]) {
-                CGSConnection conn = _CGSDefaultConnection();
-                CGSSetGlobalHotKeyOperatingMode(conn, CGSGlobalHotKeyDisable);
+        // Switch the keyboard/hotkey on the main thread.
+        if ([[NSUserDefaults standardUserDefaults] boolForKey:kSuppressHotKeysInCommand]) {
+            CGSConnection conn = _CGSDefaultConnection();
+            CGSSetGlobalHotKeyOperatingMode(conn, CGSGlobalHotKeyDisable);
+        }
+        
+        if ([[NSUserDefaults standardUserDefaults] boolForKey:@"QSSwitchKeyboardOnActivation"]) {
+            savedKeyboard = TISCopyCurrentKeyboardLayoutInputSource();
+            NSString *forcedKeyboardId = [[NSUserDefaults standardUserDefaults] objectForKey:@"QSForcedKeyboardIDOnActivation"];
+            NSDictionary *filter = [NSDictionary dictionaryWithObject:forcedKeyboardId forKey:(NSString *)kTISPropertyInputSourceID];
+            CFArrayRef keyboards = TISCreateInputSourceList((__bridge CFDictionaryRef)filter, false);
+            if (keyboards) {
+                TISInputSourceRef selected = (TISInputSourceRef)CFArrayGetValueAtIndex(keyboards, 0);
+                TISSelectInputSource(selected);
+                CFRelease(keyboards);
+            } else {
+                // If previously selected keyboard is no longer available, turn off automatic switch
+                [[NSUserDefaults standardUserDefaults] setBool:false forKey:@"QSSwitchKeyboardOnActivation"];
             }
-
-            if ([[NSUserDefaults standardUserDefaults] boolForKey:@"QSSwitchKeyboardOnActivation"]) {
-                savedKeyboard = TISCopyCurrentKeyboardLayoutInputSource();
-                NSString *forcedKeyboardId = [[NSUserDefaults standardUserDefaults] objectForKey:@"QSForcedKeyboardIDOnActivation"];
-                NSDictionary *filter = [NSDictionary dictionaryWithObject:forcedKeyboardId forKey:(NSString *)kTISPropertyInputSourceID];
-                CFArrayRef keyboards = TISCreateInputSourceList((__bridge CFDictionaryRef)filter, false);
-                if (keyboards) {
-                    TISInputSourceRef selected = (TISInputSourceRef)CFArrayGetValueAtIndex(keyboards, 0);
-                    TISSelectInputSource(selected);
-                    CFRelease(keyboards);
-                } else {
-                    // If previously selected keyboard is no longer available, turn off automatic switch
-                    [[NSUserDefaults standardUserDefaults] setBool:false forKey:@"QSSwitchKeyboardOnActivation"];
-                }
-            }
-        });
+        }
     });
 }
 


### PR DESCRIPTION
Nothing except https://developer.apple.com/library/mac/technotes/tn2125/_index.html specifies that HIToolbox can't be run on the main thread, but switching keyboards seems like something that should.

I meant to put this in with my other 'fixes' branch, but seems like I forgot.
From `git blame` I see that @tiennou changed the keyboard switching code to run on a background thread. Can I ask why?

I'm still getting crashes when activating QS, and I think it's because of this
