### PR TITLE
Fix for dragging/dropping multiple files in QS

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSObject_FileHandling.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject_FileHandling.m
@@ -346,7 +346,7 @@ NSArray *recentDocumentsForBundle(NSString *bundleIdentifier) {
 
 - (NSDragOperation)operationForDrag:(id <NSDraggingInfo>)sender ontoObject:(QSObject *)dObject withObject:(QSBasicObject *)iObject {
 	if (![iObject arrayForType:QSFilePathType])
-		return 0;
+		return NSDragOperationNone;
 	if ([dObject fileCount] > 1)
 		return NSDragOperationGeneric;
 	NSDragOperation sourceDragMask = [sender draggingSourceOperationMask];


### PR DESCRIPTION
Fixes #1866

So `public.file-url` data on the pasteboard can only hold the info for ONE file copied/dragged. We still need to use `NSFilenamesPboardType`. Even Finder does this: drag 2 files from finder; the pasteboard data for `public.file-url` refers to one of the files only, and the `NSFilenamesPboardType` refers to both
