### PR TITLE
always resolve symlinks when loading children

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSObject_FileHandling.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject_FileHandling.m
@@ -392,7 +392,7 @@ NSArray *recentDocumentsForBundle(NSString *bundleIdentifier) {
 	NSArray *newAltChildren = nil;
 
 	if ([object fileCount] == 1) {
-		NSString *path = [object singleFilePath];
+		NSString *path = [[object singleFilePath] stringByResolvingSymlinksInPath];
 		if (!path || ![path length]) return NO;
 		NSFileManager *manager = [NSFileManager defaultManager];
         // Boolean as to whether or not the alias is a directory


### PR DESCRIPTION
Is there any reason not to do this? I can’t think of one.

(I’ll give it a couple of days, and if there’s no resolution, I’ll do another 1.2.0 pre-release without this.)