### PR TITLE
correct broken format strings

### DIFF
--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/ca-ES.lproj/QSAction.commandFormat.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/ca-ES.lproj/QSAction.commandFormat.strings
@@ -77,19 +77,19 @@
     <key>FileGetURLAction</key>
     <string>Obtenir l&apos;URL file:// de %@</string>
     <key>FileMakeAliasInAction</key>
-    <string>Crear un alies de %@ a %#</string>
+    <string>Crear un alies de %@ a %@</string>
     <key>FileMakeHardLinkInAction</key>
-    <string>Crear un Hard Link de %@ a %#</string>
+    <string>Crear un Hard Link de %@ a %@</string>
     <key>FileMakeLinkInAction</key>
-    <string>Crear un vincle de %@ a %#</string>
+    <string>Crear un vincle de %@ a %@</string>
     <key>FileMoveToAction</key>
-    <string>Moure %@ a %#</string>
+    <string>Moure %@ a %@</string>
     <key>FileOpenAction</key>
     <string>Obrir %@</string>
     <key>FileOpenWithAction</key>
-    <string>Obrir %@ amb %#</string>
+    <string>Obrir %@ amb %@</string>
     <key>FileRenameAction</key>
-    <string>Cambiar el nom de %@ a %#</string>
+    <string>Cambiar el nom de %@ a %@</string>
     <key>FileRevealAction</key>
     <string>Mostrar on es %@</string>
     <key>FileToTrashAction</key>
@@ -127,13 +127,13 @@
     <key>QSLoginItemRemoveAction</key>
     <string>Eliminar %@ dels ítems del Login</string>
     <key>QSNewFolderAction</key>
-    <string>Crea una nova carpeta a %@ anomenada %#</string>
+    <string>Crea una nova carpeta a %@ anomenada %@</string>
     <key>QSObjCSendMessageAction</key>
     <string>Executa %@</string>
     <key>QSObjectAssignLabelAction</key>
-    <string>Establir l&apos;etiqueta de %@ a %#</string>
+    <string>Establir l&apos;etiqueta de %@ a %@</string>
     <key>QSObjectAssignMnemonic</key>
-    <string>Establir el mnemònic de %@ a %#</string>
+    <string>Establir el mnemònic de %@ a %@</string>
     <key>QSObjectOmitAction</key>
     <string>Ometre %@ del catàleg</string>
     <key>QSObjectSearchChildrenAction</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/cs.lproj/QSAction.commandFormat.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/cs.lproj/QSAction.commandFormat.strings
@@ -127,13 +127,13 @@
     <key>QSLoginItemRemoveAction</key>
     <string>Odstranit %@ z položek po přihlášení</string>
     <key>QSNewFolderAction</key>
-    <string>Vytvořit novou složku %# v %@</string>
+    <string>Vytvořit novou složku %@ v %@</string>
     <key>QSObjCSendMessageAction</key>
     <string>Vykonat %@</string>
     <key>QSObjectAssignLabelAction</key>
-    <string>Nastavit visačku %# položce %@</string>
+    <string>Nastavit visačku %@ položce %@</string>
     <key>QSObjectAssignMnemonic</key>
-    <string>Nastavit mnemotechnickou pomůcku %@ na %#</string>
+    <string>Nastavit mnemotechnickou pomůcku %@ na %@</string>
     <key>QSObjectOmitAction</key>
     <string>Odstranit %@ z katalogu</string>
     <key>QSObjectSearchChildrenAction</key>
@@ -159,7 +159,7 @@
     <key>QSSoundPlayAction</key>
     <string>Přehrát %@</string>
     <key>QSTextDiffAction</key>
-    <string>Najít rozdíly mezi %@ a %#</string>
+    <string>Najít rozdíly mezi %@ a %@</string>
     <key>QSTextShowDialogAction</key>
     <string>Zobrazit dialog: „%@“</string>
     <key>QSTextSpeakAction</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/de.lproj/QSAction.commandFormat.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/de.lproj/QSAction.commandFormat.strings
@@ -77,19 +77,19 @@
     <key>FileGetURLAction</key>
     <string>Zeige file://-URL von %@</string>
     <key>FileMakeAliasInAction</key>
-    <string>Erzeuge Alias von %@ in %#</string>
+    <string>Erzeuge Alias von %@ in %@</string>
     <key>FileMakeHardLinkInAction</key>
-    <string>Erzeuge Hardlink von %@ in %#</string>
+    <string>Erzeuge Hardlink von %@ in %@</string>
     <key>FileMakeLinkInAction</key>
-    <string>Erzeuge Link von %@ in %#</string>
+    <string>Erzeuge Link von %@ in %@</string>
     <key>FileMoveToAction</key>
-    <string>%@ nach %# verschieben</string>
+    <string>%@ nach %@ verschieben</string>
     <key>FileOpenAction</key>
     <string>%@ öffnen</string>
     <key>FileOpenWithAction</key>
-    <string>Öffne %@ mit %#</string>
+    <string>Öffne %@ mit %@</string>
     <key>FileRenameAction</key>
-    <string>%@ in %# umbenennen</string>
+    <string>%@ in %@ umbenennen</string>
     <key>FileRevealAction</key>
     <string>Zeige %@ im Finder</string>
     <key>FileToTrashAction</key>
@@ -127,13 +127,13 @@
     <key>QSLoginItemRemoveAction</key>
     <string>%@ aus Anmeldeobjekten entfernen</string>
     <key>QSNewFolderAction</key>
-    <string>Erzeuge neuen Ordner %# in %@</string>
+    <string>Erzeuge neuen Ordner %@ in %@</string>
     <key>QSObjCSendMessageAction</key>
     <string>Ausführen von %@</string>
     <key>QSObjectAssignLabelAction</key>
-    <string>Setze Etikett von %@ zu %#</string>
+    <string>Setze Etikett von %@ zu %@</string>
     <key>QSObjectAssignMnemonic</key>
-    <string>Ändert die Merkhilfe von %@ zu %#</string>
+    <string>Ändert die Merkhilfe von %@ zu %@</string>
     <key>QSObjectOmitAction</key>
     <string>%@ aus Katalog entfernen</string>
     <key>QSObjectSearchChildrenAction</key>
@@ -159,7 +159,7 @@
     <key>QSSoundPlayAction</key>
     <string>Spiele %@</string>
     <key>QSTextDiffAction</key>
-    <string>Diff von %@ und %#</string>
+    <string>Diff von %@ und %@</string>
     <key>QSTextShowDialogAction</key>
     <string>Zeige Dialog: &quot;%@&quot;</string>
     <key>QSTextSpeakAction</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/en.lproj/QSAction.commandFormat.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/en.lproj/QSAction.commandFormat.strings
@@ -79,19 +79,19 @@
 	<key>New item</key>
 	<string></string>
 	<key>FileMakeAliasInAction</key>
-	<string>Make alias of %@ in %#</string>
+	<string>Make alias of %@ in %@</string>
 	<key>FileMakeHardLinkInAction</key>
-	<string>Make hard link to %@ in %#</string>
+	<string>Make hard link to %@ in %@</string>
 	<key>FileMakeLinkInAction</key>
-	<string>Make link to %@ in %#</string>
+	<string>Make link to %@ in %@</string>
 	<key>FileMoveToAction</key>
-	<string>Move %@ to %#</string>
+	<string>Move %@ to %@</string>
 	<key>FileOpenAction</key>
 	<string>Open %@</string>
 	<key>FileOpenWithAction</key>
-	<string>Open %@ with %#</string>
+	<string>Open %@ with %@</string>
 	<key>FileRenameAction</key>
-	<string>Rename %@ to %#</string>
+	<string>Rename %@ to %@</string>
 	<key>FileRevealAction</key>
 	<string>Reveal %@</string>
 	<key>FileToTrashAction</key>
@@ -131,13 +131,13 @@
 	<key>QSLoginItemRemoveAction</key>
 	<string>Remove %@ from login items</string>
 	<key>QSNewFolderAction</key>
-	<string>Make new folder in %@ named %#</string>
+	<string>Make new folder in %@ named %@</string>
 	<key>QSObjCSendMessageAction</key>
 	<string>Execute %@</string>
 	<key>QSObjectAssignLabelAction</key>
-	<string>Set label of %@ to %#</string>
+	<string>Set label of %@ to %@</string>
 	<key>QSObjectAssignMnemonic</key>
-	<string>Set mnemonic of %@ to %#</string>
+	<string>Set mnemonic of %@ to %@</string>
 	<key>QSObjectOmitAction</key>
 	<string>Omit %@ from catalog</string>
 	<key>QSObjectSearchChildrenAction</key>
@@ -163,7 +163,7 @@
 	<key>QSSoundPlayAction</key>
 	<string>Play %@</string>
 	<key>QSTextDiffAction</key>
-	<string>Diff %@ and %#</string>
+	<string>Diff %@ and %@</string>
 	<key>QSTextShowDialogAction</key>
 	<string>Show dialog: \&quot;%@\&quot;</string>
 	<key>QSTextSpeakAction</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/es-ES.lproj/QSAction.commandFormat.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/es-ES.lproj/QSAction.commandFormat.strings
@@ -77,19 +77,19 @@
     <key>FileGetURLAction</key>
     <string>Obtener URL file:// de %@</string>
     <key>FileMakeAliasInAction</key>
-    <string>Hacer alias de %@ en %#</string>
+    <string>Hacer alias de %@ en %@</string>
     <key>FileMakeHardLinkInAction</key>
-    <string>Hacer enlace fijo a %@ en %#</string>
+    <string>Hacer enlace fijo a %@ en %@</string>
     <key>FileMakeLinkInAction</key>
-    <string>Hacer enlace a %@ en %#</string>
+    <string>Hacer enlace a %@ en %@</string>
     <key>FileMoveToAction</key>
-    <string>Mover %@ a %#</string>
+    <string>Mover %@ a %@</string>
     <key>FileOpenAction</key>
     <string>Abrir %@</string>
     <key>FileOpenWithAction</key>
-    <string>Abrir %@ con %#</string>
+    <string>Abrir %@ con %@</string>
     <key>FileRenameAction</key>
-    <string>Renombrar %@ a %#</string>
+    <string>Renombrar %@ a %@</string>
     <key>FileRevealAction</key>
     <string>Revelar %@</string>
     <key>FileToTrashAction</key>
@@ -127,13 +127,13 @@
     <key>QSLoginItemRemoveAction</key>
     <string>Remover %@ de los items de inicio</string>
     <key>QSNewFolderAction</key>
-    <string>Crear nueva carpeta en %@ llamada %#</string>
+    <string>Crear nueva carpeta en %@ llamada %@</string>
     <key>QSObjCSendMessageAction</key>
     <string>Ejecutar %@</string>
     <key>QSObjectAssignLabelAction</key>
-    <string>Poner etiqueta de %@ a %#</string>
+    <string>Poner etiqueta de %@ a %@</string>
     <key>QSObjectAssignMnemonic</key>
-    <string>Establecer mnemónico de %@ a %#</string>
+    <string>Establecer mnemónico de %@ a %@</string>
     <key>QSObjectOmitAction</key>
     <string>Omitir %@ del catálogo</string>
     <key>QSObjectSearchChildrenAction</key>
@@ -159,7 +159,7 @@
     <key>QSSoundPlayAction</key>
     <string>Reproducir %@</string>
     <key>QSTextDiffAction</key>
-    <string>Diff %@ y %#</string>
+    <string>Diff %@ y %@</string>
     <key>QSTextShowDialogAction</key>
     <string>Mostrar diálogo: &quot;%@&quot;</string>
     <key>QSTextSpeakAction</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/es-MX.lproj/QSAction.commandFormat.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/es-MX.lproj/QSAction.commandFormat.strings
@@ -79,19 +79,19 @@
 	<key>New item</key>
 	<string></string>
 	<key>FileMakeAliasInAction</key>
-	<string>Make alias of %@ in %#</string>
+	<string>Make alias of %@ in %@</string>
 	<key>FileMakeHardLinkInAction</key>
-	<string>Make hard link to %@ in %#</string>
+	<string>Make hard link to %@ in %@</string>
 	<key>FileMakeLinkInAction</key>
-	<string>Make link to %@ in %#</string>
+	<string>Make link to %@ in %@</string>
 	<key>FileMoveToAction</key>
-	<string>Move %@ to %#</string>
+	<string>Move %@ to %@</string>
 	<key>FileOpenAction</key>
 	<string>Open %@</string>
 	<key>FileOpenWithAction</key>
-	<string>Open %@ with %#</string>
+	<string>Open %@ with %@</string>
 	<key>FileRenameAction</key>
-	<string>Rename %@ to %#</string>
+	<string>Rename %@ to %@</string>
 	<key>FileRevealAction</key>
 	<string>Reveal %@</string>
 	<key>FileToTrashAction</key>
@@ -131,13 +131,13 @@
 	<key>QSLoginItemRemoveAction</key>
 	<string>Remove %@ from login items</string>
 	<key>QSNewFolderAction</key>
-	<string>Make new folder in %@ named %#</string>
+	<string>Make new folder in %@ named %@</string>
 	<key>QSObjCSendMessageAction</key>
 	<string>Execute %@</string>
 	<key>QSObjectAssignLabelAction</key>
-	<string>Set label of %@ to %#</string>
+	<string>Set label of %@ to %@</string>
 	<key>QSObjectAssignMnemonic</key>
-	<string>Set mnemonic of %@ to %#</string>
+	<string>Set mnemonic of %@ to %@</string>
 	<key>QSObjectOmitAction</key>
 	<string>Omit %@ from catalog</string>
 	<key>QSObjectSearchChildrenAction</key>
@@ -163,7 +163,7 @@
 	<key>QSSoundPlayAction</key>
 	<string>Play %@</string>
 	<key>QSTextDiffAction</key>
-	<string>Diff %@ and %#</string>
+	<string>Diff %@ and %@</string>
 	<key>QSTextShowDialogAction</key>
 	<string>Show dialog: \&quot;%@\&quot;</string>
 	<key>QSTextSpeakAction</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/es.lproj/QSAction.commandFormat.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/es.lproj/QSAction.commandFormat.strings
@@ -77,19 +77,19 @@
     <key>FileGetURLAction</key>
     <string>Obtener URL file:// de %@</string>
     <key>FileMakeAliasInAction</key>
-    <string>Hacer alias de %@ en %#</string>
+    <string>Hacer alias de %@ en %@</string>
     <key>FileMakeHardLinkInAction</key>
-    <string>Hacer enlace fijo a %@ en %#</string>
+    <string>Hacer enlace fijo a %@ en %@</string>
     <key>FileMakeLinkInAction</key>
-    <string>Hacer enlace a %@ en %#</string>
+    <string>Hacer enlace a %@ en %@</string>
     <key>FileMoveToAction</key>
-    <string>Mover %@ a %#</string>
+    <string>Mover %@ a %@</string>
     <key>FileOpenAction</key>
     <string>Abrir %@</string>
     <key>FileOpenWithAction</key>
-    <string>Abrir %@ con %#</string>
+    <string>Abrir %@ con %@</string>
     <key>FileRenameAction</key>
-    <string>Renombrar %@ a %#</string>
+    <string>Renombrar %@ a %@</string>
     <key>FileRevealAction</key>
     <string>Revelar %@</string>
     <key>FileToTrashAction</key>
@@ -127,13 +127,13 @@
     <key>QSLoginItemRemoveAction</key>
     <string>Remover %@ de los items de inicio</string>
     <key>QSNewFolderAction</key>
-    <string>Crear nueva carpeta en %@ llamada %#</string>
+    <string>Crear nueva carpeta en %@ llamada %@</string>
     <key>QSObjCSendMessageAction</key>
     <string>Ejecutar %@</string>
     <key>QSObjectAssignLabelAction</key>
-    <string>Poner etiqueta de %@ a %#</string>
+    <string>Poner etiqueta de %@ a %@</string>
     <key>QSObjectAssignMnemonic</key>
-    <string>Establecer mnemónico de %@ a %#</string>
+    <string>Establecer mnemónico de %@ a %@</string>
     <key>QSObjectOmitAction</key>
     <string>Omitir %@ del catálogo</string>
     <key>QSObjectSearchChildrenAction</key>
@@ -159,7 +159,7 @@
     <key>QSSoundPlayAction</key>
     <string>Reproducir %@</string>
     <key>QSTextDiffAction</key>
-    <string>Diff %@ y %#</string>
+    <string>Diff %@ y %@</string>
     <key>QSTextShowDialogAction</key>
     <string>Mostrar diálogo: &quot;%@&quot;</string>
     <key>QSTextSpeakAction</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/et.lproj/QSAction.commandFormat.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/et.lproj/QSAction.commandFormat.strings
@@ -77,19 +77,19 @@
 	<key>FileGetURLAction</key>
 	<string>Get file:// URL of %@</string>
 	<key>FileMakeAliasInAction</key>
-	<string>Make alias of %@ in %#</string>
+	<string>Make alias of %@ in %@</string>
 	<key>FileMakeHardLinkInAction</key>
-	<string>Make hard link to %@ in %#</string>
+	<string>Make hard link to %@ in %@</string>
 	<key>FileMakeLinkInAction</key>
-	<string>Make link to %@ in %#</string>
+	<string>Make link to %@ in %@</string>
 	<key>FileMoveToAction</key>
-	<string>Move %@ to %#</string>
+	<string>Move %@ to %@</string>
 	<key>FileOpenAction</key>
 	<string>Open %@</string>
 	<key>FileOpenWithAction</key>
-	<string>Open %@ with %#</string>
+	<string>Open %@ with %@</string>
 	<key>FileRenameAction</key>
-	<string>Rename %@ to %#</string>
+	<string>Rename %@ to %@</string>
 	<key>FileRevealAction</key>
 	<string>Reveal %@</string>
 	<key>FileToTrashAction</key>
@@ -127,13 +127,13 @@
 	<key>QSLoginItemRemoveAction</key>
 	<string>Remove %@ from login items</string>
 	<key>QSNewFolderAction</key>
-	<string>Make new folder in %@ named %#</string>
+	<string>Make new folder in %@ named %@</string>
 	<key>QSObjCSendMessageAction</key>
 	<string>Execute %@</string>
 	<key>QSObjectAssignLabelAction</key>
-	<string>Set label of %@ to %#</string>
+	<string>Set label of %@ to %@</string>
 	<key>QSObjectAssignMnemonic</key>
-	<string>Set mnemonic of %@ to %#</string>
+	<string>Set mnemonic of %@ to %@</string>
 	<key>QSObjectOmitAction</key>
 	<string>Omit %@ from catalog</string>
 	<key>QSObjectSearchChildrenAction</key>
@@ -159,7 +159,7 @@
 	<key>QSSoundPlayAction</key>
 	<string>Play %@</string>
 	<key>QSTextDiffAction</key>
-	<string>Diff %@ and %#</string>
+	<string>Diff %@ and %@</string>
 	<key>QSTextShowDialogAction</key>
 	<string>Show dialog: \"%@\"</string>
 	<key>QSTextSpeakAction</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/fi.lproj/QSAction.commandFormat.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/fi.lproj/QSAction.commandFormat.strings
@@ -77,19 +77,19 @@
 	<key>FileGetURLAction</key>
 	<string>Get file:// URL of %@</string>
 	<key>FileMakeAliasInAction</key>
-	<string>Make alias of %@ in %#</string>
+	<string>Make alias of %@ in %@</string>
 	<key>FileMakeHardLinkInAction</key>
-	<string>Make hard link to %@ in %#</string>
+	<string>Make hard link to %@ in %@</string>
 	<key>FileMakeLinkInAction</key>
-	<string>Make link to %@ in %#</string>
+	<string>Make link to %@ in %@</string>
 	<key>FileMoveToAction</key>
-	<string>Move %@ to %#</string>
+	<string>Move %@ to %@</string>
 	<key>FileOpenAction</key>
 	<string>Open %@</string>
 	<key>FileOpenWithAction</key>
-	<string>Open %@ with %#</string>
+	<string>Open %@ with %@</string>
 	<key>FileRenameAction</key>
-	<string>Rename %@ to %#</string>
+	<string>Rename %@ to %@</string>
 	<key>FileRevealAction</key>
 	<string>Reveal %@</string>
 	<key>FileToTrashAction</key>
@@ -127,13 +127,13 @@
 	<key>QSLoginItemRemoveAction</key>
 	<string>Remove %@ from login items</string>
 	<key>QSNewFolderAction</key>
-	<string>Make new folder in %@ named %#</string>
+	<string>Make new folder in %@ named %@</string>
 	<key>QSObjCSendMessageAction</key>
 	<string>Execute %@</string>
 	<key>QSObjectAssignLabelAction</key>
-	<string>Set label of %@ to %#</string>
+	<string>Set label of %@ to %@</string>
 	<key>QSObjectAssignMnemonic</key>
-	<string>Set mnemonic of %@ to %#</string>
+	<string>Set mnemonic of %@ to %@</string>
 	<key>QSObjectOmitAction</key>
 	<string>Omit %@ from catalog</string>
 	<key>QSObjectSearchChildrenAction</key>
@@ -159,7 +159,7 @@
 	<key>QSSoundPlayAction</key>
 	<string>Play %@</string>
 	<key>QSTextDiffAction</key>
-	<string>Diff %@ and %#</string>
+	<string>Diff %@ and %@</string>
 	<key>QSTextShowDialogAction</key>
 	<string>Show dialog: \"%@\"</string>
 	<key>QSTextSpeakAction</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/fr.lproj/QSAction.commandFormat.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/fr.lproj/QSAction.commandFormat.strings
@@ -77,9 +77,9 @@
     <key>FileGetURLAction</key>
     <string>Obtenir l&apos;URL file:// de %@</string>
     <key>FileMakeAliasInAction</key>
-    <string>Créer un alias de %@ dans %#</string>
+    <string>Créer un alias de %@ dans %@</string>
     <key>FileMakeHardLinkInAction</key>
-    <string>Créer un lien dur de %@ dans %#</string>
+    <string>Créer un lien dur de %@ dans %@</string>
     <key>FileMakeLinkInAction</key>
     <string>Créer un lien de %@ dans %@</string>
     <key>FileMoveToAction</key>
@@ -89,7 +89,7 @@
     <key>FileOpenWithAction</key>
     <string>Ouvrir %@ avec %@</string>
     <key>FileRenameAction</key>
-    <string>Renommer %@ en %#</string>
+    <string>Renommer %@ en %@</string>
     <key>FileRevealAction</key>
     <string>Révéler %@</string>
     <key>FileToTrashAction</key>
@@ -127,13 +127,13 @@
     <key>QSLoginItemRemoveAction</key>
     <string>Ne plus lancer %@ à l&apos;ouverture de session</string>
     <key>QSNewFolderAction</key>
-    <string>Nouveau dossier dans %@ nommé %#</string>
+    <string>Nouveau dossier dans %@ nommé %@</string>
     <key>QSObjCSendMessageAction</key>
     <string>Exécuter %@</string>
     <key>QSObjectAssignLabelAction</key>
-    <string>Définir la famille de %@ à %#</string>
+    <string>Définir la famille de %@ à %@</string>
     <key>QSObjectAssignMnemonic</key>
-    <string>Définir la mnémonique de %@ à %#</string>
+    <string>Définir la mnémonique de %@ à %@</string>
     <key>QSObjectOmitAction</key>
     <string>Omettre %@ du Catalogue</string>
     <key>QSObjectSearchChildrenAction</key>
@@ -159,7 +159,7 @@
     <key>QSSoundPlayAction</key>
     <string>Lire %@</string>
     <key>QSTextDiffAction</key>
-    <string>Obtenir les différences entre %@ et %#</string>
+    <string>Obtenir les différences entre %@ et %@</string>
     <key>QSTextShowDialogAction</key>
     <string>Montrer le dialogue: &quot;%@&quot;</string>
     <key>QSTextSpeakAction</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/id.lproj/QSAction.commandFormat.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/id.lproj/QSAction.commandFormat.strings
@@ -77,19 +77,19 @@
     <key>FileGetURLAction</key>
     <string>Dapatkan alamat URL file:// dari %@</string>
     <key>FileMakeAliasInAction</key>
-    <string>Buat alias dari %@ di %#</string>
+    <string>Buat alias dari %@ di %@</string>
     <key>FileMakeHardLinkInAction</key>
-    <string>Buat tautan keras untuk %@ di %# </string>
+    <string>Buat tautan keras untuk %@ di %@ </string>
     <key>FileMakeLinkInAction</key>
-    <string>Buat tautan untuk %@ di %#</string>
+    <string>Buat tautan untuk %@ di %@</string>
     <key>FileMoveToAction</key>
-    <string>Pindahkan %@ ke %#</string>
+    <string>Pindahkan %@ ke %@</string>
     <key>FileOpenAction</key>
     <string>Buka %@</string>
     <key>FileOpenWithAction</key>
-    <string>Buka %@ dengan %#</string>
+    <string>Buka %@ dengan %@</string>
     <key>FileRenameAction</key>
-    <string>Ubah nama %@ menjadi %#</string>
+    <string>Ubah nama %@ menjadi %@</string>
     <key>FileRevealAction</key>
     <string>Tampilkan %@</string>
     <key>FileToTrashAction</key>
@@ -127,13 +127,13 @@
     <key>QSLoginItemRemoveAction</key>
     <string>Buang %@ dari butir-butir login</string>
     <key>QSNewFolderAction</key>
-    <string>Buat folder baru di %@ bernama %#</string>
+    <string>Buat folder baru di %@ bernama %@</string>
     <key>QSObjCSendMessageAction</key>
     <string>Jalankan %@</string>
     <key>QSObjectAssignLabelAction</key>
-    <string>Pasang label dari %@ dengan %#</string>
+    <string>Pasang label dari %@ dengan %@</string>
     <key>QSObjectAssignMnemonic</key>
-    <string>Pasang mnemonic dari %@ dengan %#</string>
+    <string>Pasang mnemonic dari %@ dengan %@</string>
     <key>QSObjectOmitAction</key>
     <string>Abaikan %@ dari katalog</string>
     <key>QSObjectSearchChildrenAction</key>
@@ -159,7 +159,7 @@
     <key>QSSoundPlayAction</key>
     <string>Mainkan %@</string>
     <key>QSTextDiffAction</key>
-    <string>Tampilkan Diff dari %@ dan %#</string>
+    <string>Tampilkan Diff dari %@ dan %@</string>
     <key>QSTextShowDialogAction</key>
     <string>Tampilkan kotak dialog: &quot;%@&quot;</string>
     <key>QSTextSpeakAction</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/it.lproj/QSAction.commandFormat.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/it.lproj/QSAction.commandFormat.strings
@@ -77,9 +77,9 @@
     <key>FileGetURLAction</key>
     <string>Ottieni file:// URL di %@</string>
     <key>FileMakeAliasInAction</key>
-    <string>Crea alias di %@ in %#</string>
+    <string>Crea alias di %@ in %@</string>
     <key>FileMakeHardLinkInAction</key>
-    <string>Crea collegamento di %@ in %#</string>
+    <string>Crea collegamento di %@ in %@</string>
     <key>FileMakeLinkInAction</key>
     <string>Crea collegamento a %@ in %@</string>
     <key>FileMoveToAction</key>
@@ -89,7 +89,7 @@
     <key>FileOpenWithAction</key>
     <string>Apri %@ con %@</string>
     <key>FileRenameAction</key>
-    <string>Rinomina %@ in %#</string>
+    <string>Rinomina %@ in %@</string>
     <key>FileRevealAction</key>
     <string>Mostra %@</string>
     <key>FileToTrashAction</key>
@@ -127,13 +127,13 @@
     <key>QSLoginItemRemoveAction</key>
     <string>Rimuovi %@ dagli elementi di login</string>
     <key>QSNewFolderAction</key>
-    <string>Crea nuova cartella in %@ di nome %#</string>
+    <string>Crea nuova cartella in %@ di nome %@</string>
     <key>QSObjCSendMessageAction</key>
     <string>Esegui %@</string>
     <key>QSObjectAssignLabelAction</key>
-    <string>Imposta etichetta di %@ a %#</string>
+    <string>Imposta etichetta di %@ a %@</string>
     <key>QSObjectAssignMnemonic</key>
-    <string>Imposta etichetta di %@ a %#</string>
+    <string>Imposta etichetta di %@ a %@</string>
     <key>QSObjectOmitAction</key>
     <string>Ometti %@ dal catalogo</string>
     <key>QSObjectSearchChildrenAction</key>
@@ -159,7 +159,7 @@
     <key>QSSoundPlayAction</key>
     <string>Riproduci %@</string>
     <key>QSTextDiffAction</key>
-    <string>Differenza tra %@ e %#</string>
+    <string>Differenza tra %@ e %@</string>
     <key>QSTextShowDialogAction</key>
     <string>Mostra dialogo: &quot;%@&quot;</string>
     <key>QSTextSpeakAction</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/ja.lproj/QSAction.commandFormat.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/ja.lproj/QSAction.commandFormat.strings
@@ -77,19 +77,19 @@
 	<key>FileGetURLAction</key>
 	<string>Get file:// URL of %@</string>
 	<key>FileMakeAliasInAction</key>
-	<string>Make alias of %@ in %#</string>
+	<string>Make alias of %@ in %@</string>
 	<key>FileMakeHardLinkInAction</key>
-	<string>Make hard link to %@ in %#</string>
+	<string>Make hard link to %@ in %@</string>
 	<key>FileMakeLinkInAction</key>
-	<string>Make link to %@ in %#</string>
+	<string>Make link to %@ in %@</string>
 	<key>FileMoveToAction</key>
-	<string>Move %@ to %#</string>
+	<string>Move %@ to %@</string>
 	<key>FileOpenAction</key>
 	<string>Open %@</string>
 	<key>FileOpenWithAction</key>
-	<string>Open %@ with %#</string>
+	<string>Open %@ with %@</string>
 	<key>FileRenameAction</key>
-	<string>Rename %@ to %#</string>
+	<string>Rename %@ to %@</string>
 	<key>FileRevealAction</key>
 	<string>Reveal %@</string>
 	<key>FileToTrashAction</key>
@@ -127,13 +127,13 @@
 	<key>QSLoginItemRemoveAction</key>
 	<string>Remove %@ from login items</string>
 	<key>QSNewFolderAction</key>
-	<string>Make new folder in %@ named %#</string>
+	<string>Make new folder in %@ named %@</string>
 	<key>QSObjCSendMessageAction</key>
 	<string>Execute %@</string>
 	<key>QSObjectAssignLabelAction</key>
-	<string>Set label of %@ to %#</string>
+	<string>Set label of %@ to %@</string>
 	<key>QSObjectAssignMnemonic</key>
-	<string>Set mnemonic of %@ to %#</string>
+	<string>Set mnemonic of %@ to %@</string>
 	<key>QSObjectOmitAction</key>
 	<string>Omit %@ from catalog</string>
 	<key>QSObjectSearchChildrenAction</key>
@@ -159,7 +159,7 @@
 	<key>QSSoundPlayAction</key>
 	<string>Play %@</string>
 	<key>QSTextDiffAction</key>
-	<string>Diff %@ and %#</string>
+	<string>Diff %@ and %@</string>
 	<key>QSTextShowDialogAction</key>
 	<string>Show dialog: \"%@\"</string>
 	<key>QSTextSpeakAction</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/ko.lproj/QSAction.commandFormat.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/ko.lproj/QSAction.commandFormat.strings
@@ -77,19 +77,19 @@
     <key>FileGetURLAction</key>
     <string>%@ 에 대한 file:// URL 가져오기</string>
     <key>FileMakeAliasInAction</key>
-    <string>%@ 의 가상본을 %# 에 만들기</string>
+    <string>%@ 의 가상본을 %@ 에 만들기</string>
     <key>FileMakeHardLinkInAction</key>
-    <string>%@ 의 하드 링크를 %# 에 만들기</string>
+    <string>%@ 의 하드 링크를 %@ 에 만들기</string>
     <key>FileMakeLinkInAction</key>
-    <string>%@ 의 링크를 %# 에 만들기</string>
+    <string>%@ 의 링크를 %@ 에 만들기</string>
     <key>FileMoveToAction</key>
-    <string>%@ 을(를) %# 으로(로) 옮기기</string>
+    <string>%@ 을(를) %@ 으로(로) 옮기기</string>
     <key>FileOpenAction</key>
     <string>%@ 열기</string>
     <key>FileOpenWithAction</key>
-    <string>%@ 을(를) %# 으로(로) 열기</string>
+    <string>%@ 을(를) %@ 으로(로) 열기</string>
     <key>FileRenameAction</key>
-    <string>%@ 의 이름을 %# 으로(로) 바꾸기</string>
+    <string>%@ 의 이름을 %@ 으로(로) 바꾸기</string>
     <key>FileRevealAction</key>
     <string>%@ 보이기</string>
     <key>FileToTrashAction</key>
@@ -127,13 +127,13 @@
     <key>QSLoginItemRemoveAction</key>
     <string>로그인 항목에서 %@ 없에기</string>
     <key>QSNewFolderAction</key>
-    <string>%# 이름으로 %@ 안에 새 폴더 만들기</string>
+    <string>%@ 이름으로 %@ 안에 새 폴더 만들기</string>
     <key>QSObjCSendMessageAction</key>
     <string>%@ 실행</string>
     <key>QSObjectAssignLabelAction</key>
-    <string>%@ 에 %# 꼬리표 달기</string>
+    <string>%@ 에 %@ 꼬리표 달기</string>
     <key>QSObjectAssignMnemonic</key>
-    <string>%@ 의 줄임말로 %# 설정</string>
+    <string>%@ 의 줄임말로 %@ 설정</string>
     <key>QSObjectOmitAction</key>
     <string>보관함에서 %@ 생략</string>
     <key>QSObjectSearchChildrenAction</key>
@@ -159,7 +159,7 @@
     <key>QSSoundPlayAction</key>
     <string>%@ 재생</string>
     <key>QSTextDiffAction</key>
-    <string>%@ 와(과) %# 의 차이점 찾기</string>
+    <string>%@ 와(과) %@ 의 차이점 찾기</string>
     <key>QSTextShowDialogAction</key>
     <string>대화창 보이기: &quot;%@&quot;</string>
     <key>QSTextSpeakAction</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/nb-NO.lproj/QSAction.commandFormat.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/nb-NO.lproj/QSAction.commandFormat.strings
@@ -77,19 +77,19 @@
 	<key>FileGetURLAction</key>
 	<string>Get file:// URL of %@</string>
 	<key>FileMakeAliasInAction</key>
-	<string>Make alias of %@ in %#</string>
+	<string>Make alias of %@ in %@</string>
 	<key>FileMakeHardLinkInAction</key>
-	<string>Make hard link to %@ in %#</string>
+	<string>Make hard link to %@ in %@</string>
 	<key>FileMakeLinkInAction</key>
-	<string>Make link to %@ in %#</string>
+	<string>Make link to %@ in %@</string>
 	<key>FileMoveToAction</key>
-	<string>Move %@ to %#</string>
+	<string>Move %@ to %@</string>
 	<key>FileOpenAction</key>
 	<string>Open %@</string>
 	<key>FileOpenWithAction</key>
-	<string>Open %@ with %#</string>
+	<string>Open %@ with %@</string>
 	<key>FileRenameAction</key>
-	<string>Rename %@ to %#</string>
+	<string>Rename %@ to %@</string>
 	<key>FileRevealAction</key>
 	<string>Reveal %@</string>
 	<key>FileToTrashAction</key>
@@ -127,13 +127,13 @@
 	<key>QSLoginItemRemoveAction</key>
 	<string>Remove %@ from login items</string>
 	<key>QSNewFolderAction</key>
-	<string>Make new folder in %@ named %#</string>
+	<string>Make new folder in %@ named %@</string>
 	<key>QSObjCSendMessageAction</key>
 	<string>Execute %@</string>
 	<key>QSObjectAssignLabelAction</key>
-	<string>Set label of %@ to %#</string>
+	<string>Set label of %@ to %@</string>
 	<key>QSObjectAssignMnemonic</key>
-	<string>Set mnemonic of %@ to %#</string>
+	<string>Set mnemonic of %@ to %@</string>
 	<key>QSObjectOmitAction</key>
 	<string>Omit %@ from catalog</string>
 	<key>QSObjectSearchChildrenAction</key>
@@ -159,7 +159,7 @@
 	<key>QSSoundPlayAction</key>
 	<string>Play %@</string>
 	<key>QSTextDiffAction</key>
-	<string>Diff %@ and %#</string>
+	<string>Diff %@ and %@</string>
 	<key>QSTextShowDialogAction</key>
 	<string>Show dialog: \"%@\"</string>
 	<key>QSTextSpeakAction</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/nl.lproj/QSAction.commandFormat.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/nl.lproj/QSAction.commandFormat.strings
@@ -77,19 +77,19 @@
 	<key>FileGetURLAction</key>
 	<string>Get file:// URL of %@</string>
 	<key>FileMakeAliasInAction</key>
-	<string>Make alias of %@ in %#</string>
+	<string>Make alias of %@ in %@</string>
 	<key>FileMakeHardLinkInAction</key>
-	<string>Make hard link to %@ in %#</string>
+	<string>Make hard link to %@ in %@</string>
 	<key>FileMakeLinkInAction</key>
-	<string>Make link to %@ in %#</string>
+	<string>Make link to %@ in %@</string>
 	<key>FileMoveToAction</key>
-	<string>Move %@ to %#</string>
+	<string>Move %@ to %@</string>
 	<key>FileOpenAction</key>
 	<string>Open %@</string>
 	<key>FileOpenWithAction</key>
-	<string>Open %@ with %#</string>
+	<string>Open %@ with %@</string>
 	<key>FileRenameAction</key>
-	<string>Rename %@ to %#</string>
+	<string>Rename %@ to %@</string>
 	<key>FileRevealAction</key>
 	<string>Reveal %@</string>
 	<key>FileToTrashAction</key>
@@ -127,13 +127,13 @@
 	<key>QSLoginItemRemoveAction</key>
 	<string>Remove %@ from login items</string>
 	<key>QSNewFolderAction</key>
-	<string>Make new folder in %@ named %#</string>
+	<string>Make new folder in %@ named %@</string>
 	<key>QSObjCSendMessageAction</key>
 	<string>Execute %@</string>
 	<key>QSObjectAssignLabelAction</key>
-	<string>Set label of %@ to %#</string>
+	<string>Set label of %@ to %@</string>
 	<key>QSObjectAssignMnemonic</key>
-	<string>Set mnemonic of %@ to %#</string>
+	<string>Set mnemonic of %@ to %@</string>
 	<key>QSObjectOmitAction</key>
 	<string>Omit %@ from catalog</string>
 	<key>QSObjectSearchChildrenAction</key>
@@ -159,7 +159,7 @@
 	<key>QSSoundPlayAction</key>
 	<string>Play %@</string>
 	<key>QSTextDiffAction</key>
-	<string>Diff %@ and %#</string>
+	<string>Diff %@ and %@</string>
 	<key>QSTextShowDialogAction</key>
 	<string>Show dialog: \"%@\"</string>
 	<key>QSTextSpeakAction</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/pl.lproj/QSAction.commandFormat.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/pl.lproj/QSAction.commandFormat.strings
@@ -77,19 +77,19 @@
     <key>FileGetURLAction</key>
     <string>Wyświetl adres URL file:// pliku %@</string>
     <key>FileMakeAliasInAction</key>
-    <string>Utwórz skrót %@ w %#</string>
+    <string>Utwórz skrót %@ w %@</string>
     <key>FileMakeHardLinkInAction</key>
-    <string>Utwórz dowiązanie twarde dla %@ w %#</string>
+    <string>Utwórz dowiązanie twarde dla %@ w %@</string>
     <key>FileMakeLinkInAction</key>
-    <string>Utwórz łącze do %@ w %#</string>
+    <string>Utwórz łącze do %@ w %@</string>
     <key>FileMoveToAction</key>
-    <string>Przenieś %@ do %#</string>
+    <string>Przenieś %@ do %@</string>
     <key>FileOpenAction</key>
     <string>Otwórz %@</string>
     <key>FileOpenWithAction</key>
-    <string>Otwórz %@ w %#</string>
+    <string>Otwórz %@ w %@</string>
     <key>FileRenameAction</key>
-    <string>Zmień nazwę %@ w %#</string>
+    <string>Zmień nazwę %@ w %@</string>
     <key>FileRevealAction</key>
     <string>Pokaż %@</string>
     <key>FileToTrashAction</key>
@@ -127,13 +127,13 @@
     <key>QSLoginItemRemoveAction</key>
     <string>Usuń %@ z listy automatycznie uruchamiających się przy logowaniu aplikacji</string>
     <key>QSNewFolderAction</key>
-    <string>Utwórz w %@ nowy katalog o nazwie %#</string>
+    <string>Utwórz w %@ nowy katalog o nazwie %@</string>
     <key>QSObjCSendMessageAction</key>
     <string>Uruchom %@</string>
     <key>QSObjectAssignLabelAction</key>
-    <string>Ustaw etykietę %@ na %#</string>
+    <string>Ustaw etykietę %@ na %@</string>
     <key>QSObjectAssignMnemonic</key>
-    <string>Ustaw mnemonik %@ na %#</string>
+    <string>Ustaw mnemonik %@ na %@</string>
     <key>QSObjectOmitAction</key>
     <string>Pomiń %@ z katalogu</string>
     <key>QSObjectSearchChildrenAction</key>
@@ -159,7 +159,7 @@
     <key>QSSoundPlayAction</key>
     <string>Odtwórz %@</string>
     <key>QSTextDiffAction</key>
-    <string>Różnice między %@ i %#</string>
+    <string>Różnice między %@ i %@</string>
     <key>QSTextShowDialogAction</key>
     <string>Pokaż dialog: &quot;%@&quot;</string>
     <key>QSTextSpeakAction</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/pt-BR.lproj/QSAction.commandFormat.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/pt-BR.lproj/QSAction.commandFormat.strings
@@ -77,19 +77,19 @@
     <key>FileGetURLAction</key>
     <string>Pega file:// URL de %@</string>
     <key>FileMakeAliasInAction</key>
-    <string>Faça apelido de %@ em %#</string>
+    <string>Faça apelido de %@ em %@</string>
     <key>FileMakeHardLinkInAction</key>
-    <string>Faça um link manual para %@ em %#</string>
+    <string>Faça um link manual para %@ em %@</string>
     <key>FileMakeLinkInAction</key>
-    <string>Faça link para %@ em %#</string>
+    <string>Faça link para %@ em %@</string>
     <key>FileMoveToAction</key>
-    <string>Move %@ para %#</string>
+    <string>Move %@ para %@</string>
     <key>FileOpenAction</key>
     <string>Abre %@</string>
     <key>FileOpenWithAction</key>
-    <string>Abre %@ com %#</string>
+    <string>Abre %@ com %@</string>
     <key>FileRenameAction</key>
-    <string>Renomeia %@ para %#</string>
+    <string>Renomeia %@ para %@</string>
     <key>FileRevealAction</key>
     <string>Revela %@</string>
     <key>FileToTrashAction</key>
@@ -127,13 +127,13 @@
     <key>QSLoginItemRemoveAction</key>
     <string>Retira %@ de itens de login</string>
     <key>QSNewFolderAction</key>
-    <string>Criar uma nova pasta em %@ chamada %#</string>
+    <string>Criar uma nova pasta em %@ chamada %@</string>
     <key>QSObjCSendMessageAction</key>
     <string>Executa %@</string>
     <key>QSObjectAssignLabelAction</key>
-    <string>Ajusta etiqueta de %@ para %#</string>
+    <string>Ajusta etiqueta de %@ para %@</string>
     <key>QSObjectAssignMnemonic</key>
-    <string>Set mnemonic of %@ to %#</string>
+    <string>Set mnemonic of %@ to %@</string>
     <key>QSObjectOmitAction</key>
     <string>Omitir %@ do catalogo</string>
     <key>QSObjectSearchChildrenAction</key>
@@ -159,7 +159,7 @@
     <key>QSSoundPlayAction</key>
     <string>Tocar %@</string>
     <key>QSTextDiffAction</key>
-    <string>Dieferenças entre %@ e %#</string>
+    <string>Dieferenças entre %@ e %@</string>
     <key>QSTextShowDialogAction</key>
     <string>Mostra diálogo: &quot;#@&quot;</string>
     <key>QSTextSpeakAction</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/ru.lproj/QSAction.commandFormat.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/ru.lproj/QSAction.commandFormat.strings
@@ -77,19 +77,19 @@
     <key>FileGetURLAction</key>
     <string>Получить file:// URL %@</string>
     <key>FileMakeAliasInAction</key>
-    <string>Создать псевдоним %@ в %#</string>
+    <string>Создать псевдоним %@ в %@</string>
     <key>FileMakeHardLinkInAction</key>
-    <string>Создать жесткую ссылку %@ в %#</string>
+    <string>Создать жесткую ссылку %@ в %@</string>
     <key>FileMakeLinkInAction</key>
-    <string>Создать ссылку на %@ в %#</string>
+    <string>Создать ссылку на %@ в %@</string>
     <key>FileMoveToAction</key>
-    <string>Переместить %@ в %#</string>
+    <string>Переместить %@ в %@</string>
     <key>FileOpenAction</key>
     <string>Открыть %@</string>
     <key>FileOpenWithAction</key>
-    <string>Открыть %@ в %#</string>
+    <string>Открыть %@ в %@</string>
     <key>FileRenameAction</key>
-    <string>Переименовать %@ в %#</string>
+    <string>Переименовать %@ в %@</string>
     <key>FileRevealAction</key>
     <string>Показать размещение %@</string>
     <key>FileToTrashAction</key>
@@ -127,13 +127,13 @@
     <key>QSLoginItemRemoveAction</key>
     <string>Убрать %@ из элементов входа</string>
     <key>QSNewFolderAction</key>
-    <string>Создать в %@ папку %#</string>
+    <string>Создать в %@ папку %@</string>
     <key>QSObjCSendMessageAction</key>
     <string>Исполнить %@</string>
     <key>QSObjectAssignLabelAction</key>
-    <string>Установить на %@ метку %#</string>
+    <string>Установить на %@ метку %@</string>
     <key>QSObjectAssignMnemonic</key>
-    <string>Установить %# как мнемонику %@</string>
+    <string>Установить %@ как мнемонику %@</string>
     <key>QSObjectOmitAction</key>
     <string>Убрать %@ из каталога</string>
     <key>QSObjectSearchChildrenAction</key>
@@ -159,7 +159,7 @@
     <key>QSSoundPlayAction</key>
     <string>Проиграть %@</string>
     <key>QSTextDiffAction</key>
-    <string>Разница между %@ и %#</string>
+    <string>Разница между %@ и %@</string>
     <key>QSTextShowDialogAction</key>
     <string>Показать сообщение &quot;%@&quot;</string>
     <key>QSTextSpeakAction</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/sv.lproj/QSAction.commandFormat.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/sv.lproj/QSAction.commandFormat.strings
@@ -77,19 +77,19 @@
     <key>FileGetURLAction</key>
     <string>Hämta file://-URL för %@</string>
     <key>FileMakeAliasInAction</key>
-    <string>Skapa alias av %@ i %#</string>
+    <string>Skapa alias av %@ i %@</string>
     <key>FileMakeHardLinkInAction</key>
-    <string>Skapa hård länk till %@ i %#</string>
+    <string>Skapa hård länk till %@ i %@</string>
     <key>FileMakeLinkInAction</key>
-    <string>Skapa länk till %@ i %#</string>
+    <string>Skapa länk till %@ i %@</string>
     <key>FileMoveToAction</key>
-    <string>Flytta %@ till %#</string>
+    <string>Flytta %@ till %@</string>
     <key>FileOpenAction</key>
     <string>Öppna %@</string>
     <key>FileOpenWithAction</key>
-    <string>Öppna %@ med %#</string>
+    <string>Öppna %@ med %@</string>
     <key>FileRenameAction</key>
-    <string>Byt namn från %@ till %#</string>
+    <string>Byt namn från %@ till %@</string>
     <key>FileRevealAction</key>
     <string>Avslöja %@</string>
     <key>FileToTrashAction</key>
@@ -131,9 +131,9 @@
     <key>QSObjCSendMessageAction</key>
     <string>Utför %@</string>
     <key>QSObjectAssignLabelAction</key>
-    <string>Sätt etikett för %@ till %#</string>
+    <string>Sätt etikett för %@ till %@</string>
     <key>QSObjectAssignMnemonic</key>
-    <string>Sätt påminnelse för %@ till %#</string>
+    <string>Sätt påminnelse för %@ till %@</string>
     <key>QSObjectOmitAction</key>
     <string>Utelämna %@ från katalog</string>
     <key>QSObjectSearchChildrenAction</key>
@@ -159,7 +159,7 @@
     <key>QSSoundPlayAction</key>
     <string>Spela %@</string>
     <key>QSTextDiffAction</key>
-    <string>Differentiera %@ och %#</string>
+    <string>Differentiera %@ och %@</string>
     <key>QSTextShowDialogAction</key>
     <string>Visa dialog: &quot;%@&quot;</string>
     <key>QSTextSpeakAction</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/th.lproj/QSAction.commandFormat.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/th.lproj/QSAction.commandFormat.strings
@@ -79,19 +79,19 @@
 	<key>New item</key>
 	<string></string>
 	<key>FileMakeAliasInAction</key>
-	<string>Make alias of %@ in %#</string>
+	<string>Make alias of %@ in %@</string>
 	<key>FileMakeHardLinkInAction</key>
-	<string>Make hard link to %@ in %#</string>
+	<string>Make hard link to %@ in %@</string>
 	<key>FileMakeLinkInAction</key>
-	<string>Make link to %@ in %#</string>
+	<string>Make link to %@ in %@</string>
 	<key>FileMoveToAction</key>
-	<string>Move %@ to %#</string>
+	<string>Move %@ to %@</string>
 	<key>FileOpenAction</key>
 	<string>Open %@</string>
 	<key>FileOpenWithAction</key>
-	<string>Open %@ with %#</string>
+	<string>Open %@ with %@</string>
 	<key>FileRenameAction</key>
-	<string>Rename %@ to %#</string>
+	<string>Rename %@ to %@</string>
 	<key>FileRevealAction</key>
 	<string>Reveal %@</string>
 	<key>FileToTrashAction</key>
@@ -131,13 +131,13 @@
 	<key>QSLoginItemRemoveAction</key>
 	<string>Remove %@ from login items</string>
 	<key>QSNewFolderAction</key>
-	<string>Make new folder in %@ named %#</string>
+	<string>Make new folder in %@ named %@</string>
 	<key>QSObjCSendMessageAction</key>
 	<string>Execute %@</string>
 	<key>QSObjectAssignLabelAction</key>
-	<string>Set label of %@ to %#</string>
+	<string>Set label of %@ to %@</string>
 	<key>QSObjectAssignMnemonic</key>
-	<string>Set mnemonic of %@ to %#</string>
+	<string>Set mnemonic of %@ to %@</string>
 	<key>QSObjectOmitAction</key>
 	<string>Omit %@ from catalog</string>
 	<key>QSObjectSearchChildrenAction</key>
@@ -163,7 +163,7 @@
 	<key>QSSoundPlayAction</key>
 	<string>Play %@</string>
 	<key>QSTextDiffAction</key>
-	<string>Diff %@ and %#</string>
+	<string>Diff %@ and %@</string>
 	<key>QSTextShowDialogAction</key>
 	<string>Show dialog: \&quot;%@\&quot;</string>
 	<key>QSTextSpeakAction</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/tr.lproj/QSAction.commandFormat.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/tr.lproj/QSAction.commandFormat.strings
@@ -77,19 +77,19 @@
     <key>FileGetURLAction</key>
     <string>%@ öğesinin file:// URL&apos;sini al</string>
     <key>FileMakeAliasInAction</key>
-    <string>%@ öğesine %# içinde kısayol oluştur</string>
+    <string>%@ öğesine %@ içinde kısayol oluştur</string>
     <key>FileMakeHardLinkInAction</key>
-    <string>%@ öğesine %# içinde Arma oluştur</string>
+    <string>%@ öğesine %@ içinde Arma oluştur</string>
     <key>FileMakeLinkInAction</key>
-    <string>%@ öğesine %# içinde bağ oluştur</string>
+    <string>%@ öğesine %@ içinde bağ oluştur</string>
     <key>FileMoveToAction</key>
-    <string>%@ öğesini %# konumuna taşı</string>
+    <string>%@ öğesini %@ konumuna taşı</string>
     <key>FileOpenAction</key>
     <string>Aç: %@</string>
     <key>FileOpenWithAction</key>
-    <string>%@ öğesini %# ile aç</string>
+    <string>%@ öğesini %@ ile aç</string>
     <key>FileRenameAction</key>
-    <string>%@ öğesini %# olarak yeniden adlandır</string>
+    <string>%@ öğesini %@ olarak yeniden adlandır</string>
     <key>FileRevealAction</key>
     <string>Göster: %@</string>
     <key>FileToTrashAction</key>
@@ -127,13 +127,13 @@
     <key>QSLoginItemRemoveAction</key>
     <string>Oturum açma öğelerinden çıkar: %@</string>
     <key>QSNewFolderAction</key>
-    <string>%# adlı yeni bir dizini %@ içinde oluştur</string>
+    <string>%@ adlı yeni bir dizini %@ içinde oluştur</string>
     <key>QSObjCSendMessageAction</key>
     <string>Çalıştır: %@</string>
     <key>QSObjectAssignLabelAction</key>
-    <string>%@ öğesinin etiketini %# yap</string>
+    <string>%@ öğesinin etiketini %@ yap</string>
     <key>QSObjectAssignMnemonic</key>
-    <string>%@ öğesinin anımsatıcısını %# yap</string>
+    <string>%@ öğesinin anımsatıcısını %@ yap</string>
     <key>QSObjectOmitAction</key>
     <string>Katalogdan yoksay: %@</string>
     <key>QSObjectSearchChildrenAction</key>
@@ -159,7 +159,7 @@
     <key>QSSoundPlayAction</key>
     <string>Oynat: %@</string>
     <key>QSTextDiffAction</key>
-    <string>%@ ile %# arasındaki farkları bul</string>
+    <string>%@ ile %@ arasındaki farkları bul</string>
     <key>QSTextShowDialogAction</key>
     <string>İletişim kutusunu göster: &quot;%@&quot;</string>
     <key>QSTextSpeakAction</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/zh-Hans.lproj/QSAction.commandFormat.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/zh-Hans.lproj/QSAction.commandFormat.strings
@@ -77,19 +77,19 @@
     <key>FileGetURLAction</key>
     <string>获取 %@ 的 file:// 地址</string>
     <key>FileMakeAliasInAction</key>
-    <string>在 %# 创建 %@ 的别名</string>
+    <string>在 %@ 创建 %@ 的别名</string>
     <key>FileMakeHardLinkInAction</key>
-    <string>在 %# 创建 %@ 的硬链接</string>
+    <string>在 %@ 创建 %@ 的硬链接</string>
     <key>FileMakeLinkInAction</key>
-    <string>在 %# 创建 %@ 的链接</string>
+    <string>在 %@ 创建 %@ 的链接</string>
     <key>FileMoveToAction</key>
-    <string>将 %@ 移动到 %#</string>
+    <string>将 %@ 移动到 %@</string>
     <key>FileOpenAction</key>
     <string>以 %@ 打开</string>
     <key>FileOpenWithAction</key>
-    <string>用 %# 打开 %@</string>
+    <string>用 %@ 打开 %@</string>
     <key>FileRenameAction</key>
-    <string>将 %@ 重命名为 %#</string>
+    <string>将 %@ 重命名为 %@</string>
     <key>FileRevealAction</key>
     <string>显示 %@</string>
     <key>FileToTrashAction</key>
@@ -127,13 +127,13 @@
     <key>QSLoginItemRemoveAction</key>
     <string>从启动项中删除 %@</string>
     <key>QSNewFolderAction</key>
-    <string>以 %# 为名在 %@ 创建新目录</string>
+    <string>以 %@ 为名在 %@ 创建新目录</string>
     <key>QSObjCSendMessageAction</key>
     <string>执行 %@</string>
     <key>QSObjectAssignLabelAction</key>
-    <string>将 %@ 标签设置为 %#</string>
+    <string>将 %@ 标签设置为 %@</string>
     <key>QSObjectAssignMnemonic</key>
-    <string>设置 %@ 的助记符为 %#</string>
+    <string>设置 %@ 的助记符为 %@</string>
     <key>QSObjectOmitAction</key>
     <string>从类别中省略 %@</string>
     <key>QSObjectSearchChildrenAction</key>
@@ -159,7 +159,7 @@
     <key>QSSoundPlayAction</key>
     <string>播放 %@</string>
     <key>QSTextDiffAction</key>
-    <string>比较 %@ 和 %#</string>
+    <string>比较 %@ 和 %@</string>
     <key>QSTextShowDialogAction</key>
     <string>显示对话框：&quot;%@&quot;</string>
     <key>QSTextSpeakAction</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/zh-Hant.lproj/QSAction.commandFormat.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/zh-Hant.lproj/QSAction.commandFormat.strings
@@ -77,19 +77,19 @@
     <key>FileGetURLAction</key>
     <string>取得 %@ 的 file:// 網址</string>
     <key>FileMakeAliasInAction</key>
-    <string>製作 %@ 的替身於 %#</string>
+    <string>製作 %@ 的替身於 %@</string>
     <key>FileMakeHardLinkInAction</key>
-    <string>製作 %@ 的永久連結於 %#</string>
+    <string>製作 %@ 的永久連結於 %@</string>
     <key>FileMakeLinkInAction</key>
-    <string>製作 %@ 的連結於 %#</string>
+    <string>製作 %@ 的連結於 %@</string>
     <key>FileMoveToAction</key>
-    <string>移動 %@ 至 %#</string>
+    <string>移動 %@ 至 %@</string>
     <key>FileOpenAction</key>
     <string>開啟 %@</string>
     <key>FileOpenWithAction</key>
-    <string>以 %# 開啟 %@</string>
+    <string>以 %@ 開啟 %@</string>
     <key>FileRenameAction</key>
-    <string>重新命名 %@ 為 %#</string>
+    <string>重新命名 %@ 為 %@</string>
     <key>FileRevealAction</key>
     <string>顯示 %@</string>
     <key>FileToTrashAction</key>
@@ -127,13 +127,13 @@
     <key>QSLoginItemRemoveAction</key>
     <string>從登入啟動項目中移除 %@</string>
     <key>QSNewFolderAction</key>
-    <string>在 %@ 中製作新資料夾 %#</string>
+    <string>在 %@ 中製作新資料夾 %@</string>
     <key>QSObjCSendMessageAction</key>
     <string>執行 %@</string>
     <key>QSObjectAssignLabelAction</key>
-    <string>將 %@ 的標籤設為 %#</string>
+    <string>將 %@ 的標籤設為 %@</string>
     <key>QSObjectAssignMnemonic</key>
-    <string>將 %@ 的助記符設為 %#</string>
+    <string>將 %@ 的助記符設為 %@</string>
     <key>QSObjectOmitAction</key>
     <string>從目錄中忽略 %@</string>
     <key>QSObjectSearchChildrenAction</key>
@@ -159,7 +159,7 @@
     <key>QSSoundPlayAction</key>
     <string>播放 %@</string>
     <key>QSTextDiffAction</key>
-    <string>區別 %@ 與 %#</string>
+    <string>區別 %@ 與 %@</string>
     <key>QSTextShowDialogAction</key>
     <string>顯示對話：&quot;%@&quot;</string>
     <key>QSTextSpeakAction</key>


### PR DESCRIPTION
Looks like tons of format strings were corrupted. Do we need to do something on the Transifex side to keep `%#` from getting re-introduced?