### PR TITLE
Use UTIs for AppleScript actions Fixes #1916

### DIFF
--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Code/QSAppleScriptActions.m
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Code/QSAppleScriptActions.m
@@ -28,7 +28,7 @@
 	NSMutableDictionary *actionDict = [NSMutableDictionary dictionaryWithObjectsAndKeys:
                                        NSStringFromClass([self class]),    kActionClass,
                                        self,    kActionProvider,
-                                       path,    kActionScript,
+                                    path,    kActionScript,
                                        [NSNumber numberWithBool:YES],      kActionDisplaysResult,
                                        nil];
     
@@ -393,7 +393,9 @@
         NSAppleEventDescriptor *result = [script executeAppleEvent:event error:&errorDict];
         if( result ) {
             // Convert the AS list type to an array
-            types = (NSArray *)[result arrayValue];
+            types = [(NSArray *)[result arrayValue] arrayByEnumeratingArrayUsingBlock:^id(NSString *obj) {
+                return QSUTIForAnyTypeString(obj);
+            }];
         } else if( errorDict != nil )
             NSLog(@"error %@", errorDict);
     }


### PR DESCRIPTION
Makes sure that AppleScript actions have their direct/indirect types converted to UTIs.

Note: The wiki/docs should be updated to state that UTIs can now be used for AppleScript actions, so you can filter by UTI for direct/indirect type.
E.g. indirect type: only folders 

:)
