### PR TITLE
update the results window to use AutoLayout

### DIFF
--- a/Quicksilver/Code-App/QSMainPreferencePanes.h
+++ b/Quicksilver/Code-App/QSMainPreferencePanes.h
@@ -12,8 +12,6 @@
 @interface QSSearchPrefPane : QSPreferencePane {
     IBOutlet NSPopUpButton *keyboardPopUp;
 }
-- (BOOL)showChildrenInSplitView;
-- (void)setShowChildrenInSplitView:(BOOL)flag;
 - (void)updateKeyboardPopUp;
 @end
 

--- a/Quicksilver/Code-App/QSMainPreferencePanes.m
+++ b/Quicksilver/Code-App/QSMainPreferencePanes.m
@@ -88,19 +88,6 @@
 	[self setModifier:[defaults integerForKey:@"QSModifierActivationKey"] count:[defaults integerForKey:@"QSModifierActivationCount"]];
 }
 
-- (BOOL)showChildrenInSplitView {
-	return [[NSUserDefaults standardUserDefaults] boolForKey:@"QSResultsShowChildren"];
-}
-
-- (void)setShowChildrenInSplitView:(BOOL)flag {
-	NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-	
-	[defaults setBool:flag forKey:@"QSResultsShowChildren"];
-
-	[defaults synchronize];
-	[NSApp requestRelaunch:nil];
-}
-
 - (void)updateKeyboardPopUp {
     [keyboardPopUp removeAllItems];
 

--- a/Quicksilver/Code-QuickStepInterface/QSResultController.h
+++ b/Quicksilver/Code-QuickStepInterface/QSResultController.h
@@ -10,7 +10,6 @@
 	IBOutlet NSTextField *	searchStringField;	// What the user types when searching (seen in the results view)
 	IBOutlet NSTextField * searchModeField;	// Seen in the result view. Either: @"Filter Catalog", @"Filter Results" or @"Snap to Best"
 	IBOutlet NSTextField *	selectionView;
-	IBOutlet NSSplitView *	splitView;
 	IBOutlet QSTableView *	resultTable;
 	IBOutlet QSTableView *	resultChildTable;
 	QSIconLoader *resultIconLoader;

--- a/Quicksilver/Code-QuickStepInterface/QSResultController.m
+++ b/Quicksilver/Code-QuickStepInterface/QSResultController.m
@@ -93,18 +93,6 @@ NSMutableDictionary *kindDescriptions = nil;
     windowHeight = [[self window] frame].size.height;
 	[self setupResultTable];
 
-	[splitView setAutosaveName:@"QSResultWindowSplitView"];
-    
-	if (![[NSUserDefaults standardUserDefaults] boolForKey:@"QSResultsShowChildren"]) {
-		NSView *tableView = [resultTable enclosingScrollView];
-		[tableView removeFromSuperview];
-		[tableView setFrame:[splitView frame]];
-		[tableView setAutoresizingMask:[splitView autoresizingMask]];
-
-		[[splitView superview] addSubview:tableView];
-		resultChildTable = nil;
-		[splitView removeFromSuperview];
-	}
     NSUserDefaultsController *sucd = [NSUserDefaultsController sharedUserDefaultsController];
     [sucd addObserver:self
            forKeyPath:@"values.QSAppearance3B"
@@ -222,28 +210,6 @@ NSMutableDictionary *kindDescriptions = nil;
 	[resultChildTable reloadData];
 }
 
-/*- (void)setSplitLocation {
-	NSNumber *resultWidth = [[NSUserDefaults standardUserDefaults] objectForKey:kResultTableSplit];
-    
-	if (resultWidth) {
-		NSView *firstView = [[splitView subviews] objectAtIndex:0];
-		NSRect frame = [firstView frame];
-		frame.size.width = [resultWidth floatValue] *NSWidth([splitView frame]);
-        
-		NSLog(@"%f", frame.size.width);
-        
-		[firstView setFrame:frame];
-        
-		frame.origin.x += NSWidth(frame);
-		frame.size.width = NSWidth([splitView frame]) - NSWidth(frame) - [splitView dividerThickness];
-        
-		[[[splitView subviews] lastObject] setFrame:frame];
-        
-		[splitView adjustSubviews];
-		[splitView display];
-	}
-}*/
-
 #pragma mark -
 #pragma mark Icon Loading
 
@@ -304,13 +270,6 @@ NSMutableDictionary *kindDescriptions = nil;
             if (ind != NSNotFound) {
                 [resultTable setNeedsDisplayInRect:[resultTable rectOfRow:ind]];
             }
-            // if updated object is is in the child results, update it in the list
-            if ([[NSUserDefaults standardUserDefaults] boolForKey:@"QSResultsShowChildren"]) {
-                ind = [[[self selectedItem] children] indexOfObject:object];
-                if (ind != NSNotFound) {
-                    [resultChildTable setNeedsDisplayInRect:[resultChildTable rectOfRow:ind]];
-                }
-            }
         }
     });
 }
@@ -359,11 +318,6 @@ NSMutableDictionary *kindDescriptions = nil;
     NSUInteger resultCount = [currentResults count];
     NSUInteger verticalSpacing = [resultTable intercellSpacing].height;
     NSUInteger newWindowHeight =  (([resultTable rowHeight] + verticalSpacing) * resultCount) + 31;
-    if ([[NSUserDefaults standardUserDefaults] boolForKey:@"QSResultsShowChildren"]) {
-        // Be sure to chose the taller of the two: results list or results child list
-        NSUInteger childResultHeight = (([resultChildTable rowHeight] + [resultChildTable intercellSpacing].height) * [resultChildTable numberOfRows]) + 31;
-        newWindowHeight = MAX(newWindowHeight, childResultHeight);
-    }
     windowFrame.size.height =  newWindowHeight > windowHeight || [currentResults count] == 0 ? windowHeight : newWindowHeight;
     if (windowFrame.size.height != [[self window] frame].size.height) {
         windowFrame.origin.y = windowFrame.origin.y - (windowFrame.size.height - [[self window] frame].size.height);
@@ -402,12 +356,6 @@ NSMutableDictionary *kindDescriptions = nil;
         shouldSaveWindowSize = NO;
         [[self window] setFrame:windowFrame display:YES animate:YES];
         shouldSaveWindowSize = YES;
-    }
-    
-    /* Restart the icon loading for the children view */
-    if ([[NSUserDefaults standardUserDefaults] boolForKey:@"QSResultsShowChildren"]) {
-        [self setResultChildIconLoader:nil];
-        [[self resultChildIconLoader] loadIconsInRange:[resultChildTable rowsInRect:[resultChildTable visibleRect]]];
     }
 }
 
@@ -476,58 +424,6 @@ NSMutableDictionary *kindDescriptions = nil;
     windowHeight = [self window].frame.size.height;
 }
 
-#pragma mark -
-#pragma mark NSSplitView Delegate
-- (CGFloat) splitView:(NSSplitView *)sender constrainMaxCoordinate:(CGFloat)proposedMax ofSubviewAt:(NSInteger)offset {
-	//NSLog(@"constrainMax: %f, %d", proposedMax, offset);
-	// return proposedMax-36;
-	return proposedMax; // - 165;
-}
-
-- (CGFloat) splitView:(NSSplitView *)sender constrainMinCoordinate:(CGFloat)proposedMin ofSubviewAt:(NSInteger)offset {
-	//NSLog(@"constrainMin: %f, %d", proposedMin, offset);
-	return NSWidth([sender frame]) / 2;
-}
-
-- (BOOL)splitView:(NSSplitView *)sender canCollapseSubview:(NSView *)subview {
-	//NSLog(@"collapse");
-	return subview != [resultTable enclosingScrollView];
-	// if (subview == infoBox) return YES;
-	// else return NO;
-}
-
-- (void)splitView:(NSSplitView *)sender resizeSubviewsWithOldSize:(NSSize)oldSize {
-	CGFloat dividerThickness = [sender dividerThickness];
-	id sv1 = [[sender subviews] objectAtIndex:0];
-	id sv2 = [[sender subviews] objectAtIndex:1];
-	NSRect leftFrame = [sv1 frame];
-	NSRect rightFrame = [sv2 frame];
-	NSRect newFrame = [sender frame];
-
-	// if (sender != m_SourceItemSplitView) return;
-
-	leftFrame.origin = NSMakePoint(0, 0);
-	leftFrame.size.height = newFrame.size.height;
-	rightFrame.size.height = newFrame.size.height;
-
-	rightFrame.size.width = MIN(rightFrame.size.width, newFrame.size.width/2);
-	if (rightFrame.size.width < 32) rightFrame.size.width = 0;
-
-	leftFrame.size.width = newFrame.size.width - rightFrame.size.width - dividerThickness;
-
-	rightFrame.origin = NSMakePoint(leftFrame.size.width + dividerThickness, 0);
-
-	[sv1 setFrame:leftFrame];
-	[sv2 setFrame:rightFrame];
-}
-
-- (void)splitViewDidResizeSubviews:(NSNotification *)notification {
-	if ([[NSApp currentEvent] type] == NSLeftMouseDragged) {
-        CGFloat split = NSWidth([[resultChildTable enclosingScrollView] frame]) / NSWidth([splitView frame]);
-        [[NSUserDefaults standardUserDefaults] setFloat:split
-                                                 forKey:kResultTableSplit];
-    }
-}
 @end
 
 @implementation QSResultController (Table)

--- a/Quicksilver/Nibs/QSSearchPrefPane.xib
+++ b/Quicksilver/Nibs/QSSearchPrefPane.xib
@@ -2,13 +2,13 @@
 <archive type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="8.00">
 	<data>
 		<int key="IBDocument.SystemTarget">1070</int>
-		<string key="IBDocument.SystemVersion">12E55</string>
-		<string key="IBDocument.InterfaceBuilderVersion">3084</string>
-		<string key="IBDocument.AppKitVersion">1187.39</string>
-		<string key="IBDocument.HIToolboxVersion">626.00</string>
+		<string key="IBDocument.SystemVersion">14A343f</string>
+		<string key="IBDocument.InterfaceBuilderVersion">6154.17</string>
+		<string key="IBDocument.AppKitVersion">1334</string>
+		<string key="IBDocument.HIToolboxVersion">751.00</string>
 		<object class="NSMutableDictionary" key="IBDocument.PluginVersions">
 			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin</string>
-			<string key="NS.object.0">3084</string>
+			<string key="NS.object.0">6154.17</string>
 		</object>
 		<array key="IBDocument.IntegratedClassDependencies">
 			<string>NSBox</string>
@@ -50,7 +50,7 @@
 			<object class="NSWindowTemplate" id="755988772">
 				<int key="NSWindowStyleMask">7</int>
 				<int key="NSWindowBacking">2</int>
-				<string key="NSWindowRect">{{157, 15}, {384, 404}}</string>
+				<string key="NSWindowRect">{{157, 15}, {384, 384}}</string>
 				<int key="NSWTFlags">1081606144</int>
 				<string key="NSWindowTitle">&lt;&lt; do not localize &gt;&gt;</string>
 				<string key="NSWindowClass">NSWindow</string>
@@ -66,8 +66,9 @@
 						<object class="NSTextField" id="537327491">
 							<reference key="NSNextResponder" ref="1047065009"/>
 							<int key="NSvFlags">264</int>
-							<string key="NSFrame">{{67, 351}, {76, 19}}</string>
+							<string key="NSFrame">{{67, 331}, {76, 19}}</string>
 							<reference key="NSSuperview" ref="1047065009"/>
+							<reference key="NSWindow"/>
 							<reference key="NSNextKeyView" ref="733446928"/>
 							<bool key="NSEnabled">YES</bool>
 							<object class="NSTextFieldCell" key="NSCell" id="214863107">
@@ -75,7 +76,7 @@
 								<int key="NSCellFlags2">138544128</int>
 								<string key="NSContents"/>
 								<object class="NSFont" key="NSSupport" id="26">
-									<string key="NSName">LucidaGrande</string>
+									<bool key="IBIsSystemFont">YES</bool>
 									<double key="NSSize">11</double>
 									<int key="NSfFlags">3100</int>
 								</object>
@@ -102,27 +103,33 @@
 								</object>
 							</object>
 							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
+							<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
 						</object>
 						<object class="NSButton" id="733446928">
 							<reference key="NSNextResponder" ref="1047065009"/>
 							<int key="NSvFlags">264</int>
-							<string key="NSFrame">{{145, 350}, {29, 21}}</string>
+							<string key="NSFrame">{{145, 330}, {29, 21}}</string>
 							<reference key="NSSuperview" ref="1047065009"/>
+							<reference key="NSWindow"/>
 							<reference key="NSNextKeyView" ref="653991431"/>
 							<bool key="NSEnabled">YES</bool>
 							<object class="NSButtonCell" key="NSCell" id="689536090">
 								<int key="NSCellFlags">67108864</int>
 								<int key="NSCellFlags2">134479872</int>
 								<string key="NSContents">Edit</string>
-								<object class="NSFont" key="NSSupport" id="676616987">
-									<string key="NSName">LucidaGrande</string>
+								<object class="NSFont" key="NSSupport">
+									<bool key="IBIsSystemFont">YES</bool>
 									<double key="NSSize">9.5</double>
-									<int key="NSfFlags">16</int>
+									<int key="NSfFlags">1044</int>
 								</object>
 								<reference key="NSControlView" ref="733446928"/>
 								<int key="NSButtonFlags">914505728</int>
 								<int key="NSButtonFlags2">34</int>
-								<reference key="NSAlternateImage" ref="676616987"/>
+								<object class="NSFont" key="NSAlternateImage">
+									<string key="NSName">LucidaGrande</string>
+									<double key="NSSize">9.5</double>
+									<int key="NSfFlags">16</int>
+								</object>
 								<string key="NSAlternateContents"/>
 								<object class="NSMutableString" key="NSKeyEquivalent">
 									<characters key="NS.bytes"/>
@@ -135,8 +142,9 @@
 						<object class="NSTextField" id="930287179">
 							<reference key="NSNextResponder" ref="1047065009"/>
 							<int key="NSvFlags">264</int>
-							<string key="NSFrame">{{136, 182}, {54, 14}}</string>
+							<string key="NSFrame">{{136, 162}, {54, 14}}</string>
 							<reference key="NSSuperview" ref="1047065009"/>
+							<reference key="NSWindow"/>
 							<reference key="NSNextKeyView" ref="248346902"/>
 							<bool key="NSEnabled">YES</bool>
 							<object class="NSTextFieldCell" key="NSCell" id="740145810">
@@ -206,12 +214,14 @@
 								</object>
 							</object>
 							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
+							<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
 						</object>
 						<object class="NSTextField" id="95908204">
 							<reference key="NSNextResponder" ref="1047065009"/>
 							<int key="NSvFlags">264</int>
-							<string key="NSFrame">{{18, 229}, {172, 14}}</string>
+							<string key="NSFrame">{{18, 209}, {172, 14}}</string>
 							<reference key="NSSuperview" ref="1047065009"/>
+							<reference key="NSWindow"/>
 							<reference key="NSNextKeyView" ref="151921610"/>
 							<bool key="NSEnabled">YES</bool>
 							<object class="NSTextFieldCell" key="NSCell" id="567932843">
@@ -237,12 +247,14 @@
 								</object>
 							</object>
 							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
+							<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
 						</object>
 						<object class="NSSlider" id="813410363">
 							<reference key="NSNextResponder" ref="1047065009"/>
 							<int key="NSvFlags">264</int>
-							<string key="NSFrame">{{194, 159}, {165, 16}}</string>
+							<string key="NSFrame">{{194, 139}, {165, 16}}</string>
 							<reference key="NSSuperview" ref="1047065009"/>
+							<reference key="NSWindow"/>
 							<reference key="NSNextKeyView" ref="20350282"/>
 							<bool key="NSEnabled">YES</bool>
 							<object class="NSSliderCell" key="NSCell" id="53335988">
@@ -271,8 +283,9 @@
 						<object class="NSButton" id="505510077">
 							<reference key="NSNextResponder" ref="1047065009"/>
 							<int key="NSvFlags">264</int>
-							<string key="NSFrame">{{18, 202}, {335, 18}}</string>
+							<string key="NSFrame">{{18, 182}, {335, 18}}</string>
 							<reference key="NSSuperview" ref="1047065009"/>
+							<reference key="NSWindow"/>
 							<reference key="NSNextKeyView" ref="898699028"/>
 							<bool key="NSEnabled">YES</bool>
 							<object class="NSButtonCell" key="NSCell" id="719853453">
@@ -300,8 +313,9 @@
 						<object class="NSButton" id="898699028">
 							<reference key="NSNextResponder" ref="1047065009"/>
 							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{18, 181}, {22, 18}}</string>
+							<string key="NSFrame">{{18, 161}, {22, 18}}</string>
 							<reference key="NSSuperview" ref="1047065009"/>
+							<reference key="NSWindow"/>
 							<reference key="NSNextKeyView" ref="96489828"/>
 							<bool key="NSEnabled">YES</bool>
 							<object class="NSButtonCell" key="NSCell" id="857459834">
@@ -323,8 +337,9 @@
 						<object class="NSTextField" id="96489828">
 							<reference key="NSNextResponder" ref="1047065009"/>
 							<int key="NSvFlags">264</int>
-							<string key="NSFrame">{{37, 182}, {119, 13}}</string>
+							<string key="NSFrame">{{37, 162}, {119, 13}}</string>
 							<reference key="NSSuperview" ref="1047065009"/>
+							<reference key="NSWindow"/>
 							<reference key="NSNextKeyView" ref="930287179"/>
 							<bool key="NSEnabled">YES</bool>
 							<object class="NSTextFieldCell" key="NSCell" id="992311453">
@@ -332,7 +347,7 @@
 								<int key="NSCellFlags2">4325376</int>
 								<string key="NSContents">Reset search after:</string>
 								<object class="NSFont" key="NSSupport" id="24431594">
-									<string key="NSName">LucidaGrande</string>
+									<bool key="IBIsSystemFont">YES</bool>
 									<double key="NSSize">10</double>
 									<int key="NSfFlags">2843</int>
 								</object>
@@ -341,12 +356,14 @@
 								<reference key="NSTextColor" ref="443504295"/>
 							</object>
 							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
+							<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
 						</object>
 						<object class="NSTextField" id="151034742">
 							<reference key="NSNextResponder" ref="1047065009"/>
 							<int key="NSvFlags">264</int>
-							<string key="NSFrame">{{136, 160}, {54, 14}}</string>
+							<string key="NSFrame">{{136, 140}, {54, 14}}</string>
 							<reference key="NSSuperview" ref="1047065009"/>
+							<reference key="NSWindow"/>
 							<reference key="NSNextKeyView" ref="813410363"/>
 							<bool key="NSEnabled">YES</bool>
 							<object class="NSTextFieldCell" key="NSCell" id="25995340">
@@ -400,12 +417,14 @@
 								</object>
 							</object>
 							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
+							<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
 						</object>
 						<object class="NSSlider" id="248346902">
 							<reference key="NSNextResponder" ref="1047065009"/>
 							<int key="NSvFlags">264</int>
-							<string key="NSFrame">{{194, 180}, {165, 16}}</string>
+							<string key="NSFrame">{{194, 160}, {165, 16}}</string>
 							<reference key="NSSuperview" ref="1047065009"/>
+							<reference key="NSWindow"/>
 							<reference key="NSNextKeyView" ref="56014405"/>
 							<bool key="NSEnabled">YES</bool>
 							<object class="NSSliderCell" key="NSCell" id="1008536832">
@@ -430,8 +449,9 @@
 						<object class="NSTextField" id="56014405">
 							<reference key="NSNextResponder" ref="1047065009"/>
 							<int key="NSvFlags">264</int>
-							<string key="NSFrame">{{37, 160}, {119, 13}}</string>
+							<string key="NSFrame">{{37, 140}, {119, 13}}</string>
 							<reference key="NSSuperview" ref="1047065009"/>
+							<reference key="NSWindow"/>
 							<reference key="NSNextKeyView" ref="151034742"/>
 							<bool key="NSEnabled">YES</bool>
 							<object class="NSTextFieldCell" key="NSCell" id="93226876">
@@ -444,12 +464,14 @@
 								<reference key="NSTextColor" ref="443504295"/>
 							</object>
 							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
+							<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
 						</object>
 						<object class="NSPopUpButton" id="151921610">
 							<reference key="NSNextResponder" ref="1047065009"/>
 							<int key="NSvFlags">264</int>
-							<string key="NSFrame">{{184, 225}, {178, 22}}</string>
+							<string key="NSFrame">{{184, 205}, {178, 22}}</string>
 							<reference key="NSSuperview" ref="1047065009"/>
+							<reference key="NSWindow"/>
 							<reference key="NSNextKeyView" ref="505510077"/>
 							<bool key="NSEnabled">YES</bool>
 							<object class="NSPopUpButtonCell" key="NSCell" id="274069028">
@@ -563,8 +585,9 @@
 						<object class="NSTextField" id="242277331">
 							<reference key="NSNextResponder" ref="1047065009"/>
 							<int key="NSvFlags">264</int>
-							<string key="NSFrame">{{17, 353}, {51, 14}}</string>
+							<string key="NSFrame">{{17, 333}, {51, 14}}</string>
 							<reference key="NSSuperview" ref="1047065009"/>
+							<reference key="NSWindow"/>
 							<reference key="NSNextKeyView" ref="537327491"/>
 							<bool key="NSEnabled">YES</bool>
 							<object class="NSTextFieldCell" key="NSCell" id="458821019">
@@ -577,12 +600,14 @@
 								<reference key="NSTextColor" ref="443504295"/>
 							</object>
 							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
+							<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
 						</object>
 						<object class="NSPopUpButton" id="6514072">
 							<reference key="NSNextResponder" ref="1047065009"/>
 							<int key="NSvFlags">264</int>
-							<string key="NSFrame">{{266, 303}, {96, 22}}</string>
+							<string key="NSFrame">{{266, 283}, {96, 22}}</string>
 							<reference key="NSSuperview" ref="1047065009"/>
+							<reference key="NSWindow"/>
 							<reference key="NSNextKeyView" ref="389928224"/>
 							<bool key="NSEnabled">YES</bool>
 							<object class="NSPopUpButtonCell" key="NSCell" id="67232536">
@@ -693,8 +718,9 @@
 						<object class="NSPopUpButton" id="524028010">
 							<reference key="NSNextResponder" ref="1047065009"/>
 							<int key="NSvFlags">264</int>
-							<string key="NSFrame">{{184, 303}, {83, 22}}</string>
+							<string key="NSFrame">{{184, 283}, {83, 22}}</string>
 							<reference key="NSSuperview" ref="1047065009"/>
+							<reference key="NSWindow"/>
 							<reference key="NSNextKeyView" ref="6514072"/>
 							<bool key="NSEnabled">YES</bool>
 							<object class="NSPopUpButtonCell" key="NSCell" id="1048295320">
@@ -758,8 +784,9 @@
 						<object class="NSBox" id="863250097">
 							<reference key="NSNextResponder" ref="1047065009"/>
 							<int key="NSvFlags">264</int>
-							<string key="NSFrame">{{19, 270}, {344, 5}}</string>
+							<string key="NSFrame">{{19, 250}, {344, 5}}</string>
 							<reference key="NSSuperview" ref="1047065009"/>
+							<reference key="NSWindow"/>
 							<reference key="NSNextKeyView" ref="169014065"/>
 							<string key="NSOffsets">{0, 0}</string>
 							<object class="NSTextFieldCell" key="NSTitleCell">
@@ -767,14 +794,16 @@
 								<int key="NSCellFlags2">0</int>
 								<string key="NSContents">Box</string>
 								<object class="NSFont" key="NSSupport" id="479794509">
-									<string key="NSName">LucidaGrande</string>
+									<bool key="IBIsSystemFont">YES</bool>
 									<double key="NSSize">13</double>
 									<int key="NSfFlags">1044</int>
 								</object>
 								<reference key="NSBackgroundColor" ref="451117482"/>
-								<object class="NSColor" key="NSTextColor">
-									<int key="NSColorSpace">3</int>
-									<bytes key="NSWhite">MCAwLjgwMDAwMDAxAA</bytes>
+								<object class="NSColor" key="NSTextColor" id="458257249">
+									<int key="NSColorSpace">6</int>
+									<string key="NSCatalogName">System</string>
+									<string key="NSColorName">labelColor</string>
+									<reference key="NSColor" ref="879877961"/>
 								</object>
 							</object>
 							<int key="NSBorderType">3</int>
@@ -785,8 +814,9 @@
 						<object class="NSBox" id="20350282">
 							<reference key="NSNextResponder" ref="1047065009"/>
 							<int key="NSvFlags">264</int>
-							<string key="NSFrame">{{19, 142}, {344, 5}}</string>
+							<string key="NSFrame">{{19, 122}, {344, 5}}</string>
 							<reference key="NSSuperview" ref="1047065009"/>
+							<reference key="NSWindow"/>
 							<reference key="NSNextKeyView" ref="923338190"/>
 							<string key="NSOffsets">{0, 0}</string>
 							<object class="NSTextFieldCell" key="NSTitleCell">
@@ -795,10 +825,7 @@
 								<string key="NSContents">Box</string>
 								<reference key="NSSupport" ref="479794509"/>
 								<reference key="NSBackgroundColor" ref="451117482"/>
-								<object class="NSColor" key="NSTextColor">
-									<int key="NSColorSpace">3</int>
-									<bytes key="NSWhite">MCAwLjgwMDAwMDAxAA</bytes>
-								</object>
+								<reference key="NSTextColor" ref="458257249"/>
 							</object>
 							<int key="NSBorderType">3</int>
 							<int key="NSBoxType">2</int>
@@ -808,8 +835,9 @@
 						<object class="NSButton" id="644836631">
 							<reference key="NSNextResponder" ref="1047065009"/>
 							<int key="NSvFlags">264</int>
-							<string key="NSFrame">{{17, 306}, {172, 18}}</string>
+							<string key="NSFrame">{{17, 286}, {172, 18}}</string>
 							<reference key="NSSuperview" ref="1047065009"/>
+							<reference key="NSWindow"/>
 							<reference key="NSNextKeyView" ref="524028010"/>
 							<bool key="NSEnabled">YES</bool>
 							<object class="NSButtonCell" key="NSCell" id="1007167822">
@@ -832,8 +860,9 @@
 						<object class="NSButton" id="389928224">
 							<reference key="NSNextResponder" ref="1047065009"/>
 							<int key="NSvFlags">264</int>
-							<string key="NSFrame">{{17, 285}, {211, 18}}</string>
+							<string key="NSFrame">{{17, 265}, {211, 18}}</string>
 							<reference key="NSSuperview" ref="1047065009"/>
+							<reference key="NSWindow"/>
 							<reference key="NSNextKeyView" ref="666565161"/>
 							<bool key="NSEnabled">YES</bool>
 							<object class="NSButtonCell" key="NSCell" id="701084659">
@@ -856,8 +885,9 @@
 						<object class="NSTextField" id="653991431">
 							<reference key="NSNextResponder" ref="1047065009"/>
 							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{30, 328}, {337, 17}}</string>
+							<string key="NSFrame">{{30, 308}, {337, 17}}</string>
 							<reference key="NSSuperview" ref="1047065009"/>
+							<reference key="NSWindow"/>
 							<reference key="NSNextKeyView" ref="644836631"/>
 							<string key="NSReuseIdentifierKey">_NS:1505</string>
 							<bool key="NSEnabled">YES</bool>
@@ -880,12 +910,14 @@
 								</object>
 							</object>
 							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
+							<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
 						</object>
 						<object class="NSTextField" id="584969102">
 							<reference key="NSNextResponder" ref="1047065009"/>
 							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{17, 378}, {139, 17}}</string>
+							<string key="NSFrame">{{17, 358}, {139, 17}}</string>
 							<reference key="NSSuperview" ref="1047065009"/>
+							<reference key="NSWindow"/>
 							<reference key="NSNextKeyView" ref="242277331"/>
 							<string key="NSReuseIdentifierKey">_NS:1505</string>
 							<bool key="NSEnabled">YES</bool>
@@ -900,12 +932,14 @@
 								<reference key="NSTextColor" ref="443504295"/>
 							</object>
 							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
+							<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
 						</object>
 						<object class="NSTextField" id="169014065">
 							<reference key="NSNextResponder" ref="1047065009"/>
 							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{17, 247}, {130, 17}}</string>
+							<string key="NSFrame">{{17, 227}, {130, 17}}</string>
 							<reference key="NSSuperview" ref="1047065009"/>
+							<reference key="NSWindow"/>
 							<reference key="NSNextKeyView" ref="95908204"/>
 							<string key="NSReuseIdentifierKey">_NS:1505</string>
 							<bool key="NSEnabled">YES</bool>
@@ -920,12 +954,14 @@
 								<reference key="NSTextColor" ref="443504295"/>
 							</object>
 							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
+							<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
 						</object>
 						<object class="NSStepper" id="138959037">
 							<reference key="NSNextResponder" ref="1047065009"/>
 							<int key="NSvFlags">264</int>
 							<string key="NSFrame">{{203, 44}, {19, 28}}</string>
 							<reference key="NSSuperview" ref="1047065009"/>
+							<reference key="NSWindow"/>
 							<reference key="NSNextKeyView" ref="994724971"/>
 							<bool key="NSEnabled">YES</bool>
 							<object class="NSStepperCell" key="NSCell" id="404837380">
@@ -944,6 +980,7 @@
 							<int key="NSvFlags">264</int>
 							<string key="NSFrame">{{17, 45}, {130, 20}}</string>
 							<reference key="NSSuperview" ref="1047065009"/>
+							<reference key="NSWindow"/>
 							<reference key="NSNextKeyView" ref="54063461"/>
 							<bool key="NSEnabled">YES</bool>
 							<object class="NSTextFieldCell" key="NSCell" id="393823609">
@@ -956,12 +993,14 @@
 								<reference key="NSTextColor" ref="443504295"/>
 							</object>
 							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
+							<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
 						</object>
 						<object class="NSTextField" id="54063461">
 							<reference key="NSNextResponder" ref="1047065009"/>
 							<int key="NSvFlags">264</int>
 							<string key="NSFrame">{{162, 47}, {36, 22}}</string>
 							<reference key="NSSuperview" ref="1047065009"/>
+							<reference key="NSWindow"/>
 							<reference key="NSNextKeyView" ref="138959037"/>
 							<bool key="NSEnabled">YES</bool>
 							<object class="NSTextFieldCell" key="NSCell" id="608387806">
@@ -975,13 +1014,14 @@
 								<reference key="NSTextColor" ref="806188867"/>
 							</object>
 							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
+							<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
 						</object>
 						<object class="NSPopUpButton" id="410412925">
 							<reference key="NSNextResponder" ref="1047065009"/>
 							<int key="NSvFlags">264</int>
 							<string key="NSFrame">{{156, 18}, {163, 22}}</string>
 							<reference key="NSSuperview" ref="1047065009"/>
-							<reference key="NSNextKeyView"/>
+							<reference key="NSWindow"/>
 							<bool key="NSEnabled">YES</bool>
 							<object class="NSPopUpButtonCell" key="NSCell" id="320354359">
 								<int key="NSCellFlags">-2076180416</int>
@@ -1054,6 +1094,7 @@
 							<int key="NSvFlags">264</int>
 							<string key="NSFrame">{{17, 20}, {139, 17}}</string>
 							<reference key="NSSuperview" ref="1047065009"/>
+							<reference key="NSWindow"/>
 							<reference key="NSNextKeyView" ref="410412925"/>
 							<bool key="NSEnabled">YES</bool>
 							<object class="NSTextFieldCell" key="NSCell" id="618120245">
@@ -1066,13 +1107,15 @@
 								<reference key="NSTextColor" ref="443504295"/>
 							</object>
 							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
+							<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
 						</object>
 						<object class="NSButton" id="17425714">
 							<reference key="NSNextResponder" ref="1047065009"/>
 							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{17, 95}, {316, 18}}</string>
+							<string key="NSFrame">{{17, 75}, {316, 18}}</string>
 							<reference key="NSSuperview" ref="1047065009"/>
-							<reference key="NSNextKeyView" ref="492096779"/>
+							<reference key="NSWindow"/>
+							<reference key="NSNextKeyView"/>
 							<bool key="NSEnabled">YES</bool>
 							<object class="NSButtonCell" key="NSCell" id="703821848">
 								<int key="NSCellFlags">67108864</int>
@@ -1094,8 +1137,9 @@
 						<object class="NSTextField" id="923338190">
 							<reference key="NSNextResponder" ref="1047065009"/>
 							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{17, 119}, {208, 17}}</string>
+							<string key="NSFrame">{{17, 99}, {208, 17}}</string>
 							<reference key="NSSuperview" ref="1047065009"/>
+							<reference key="NSWindow"/>
 							<reference key="NSNextKeyView" ref="17425714"/>
 							<string key="NSReuseIdentifierKey">_NS:1505</string>
 							<bool key="NSEnabled">YES</bool>
@@ -1110,36 +1154,14 @@
 								<reference key="NSTextColor" ref="443504295"/>
 							</object>
 							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-						</object>
-						<object class="NSButton" id="492096779">
-							<reference key="NSNextResponder" ref="1047065009"/>
-							<int key="NSvFlags">264</int>
-							<string key="NSFrame">{{17, 75}, {316, 18}}</string>
-							<reference key="NSSuperview" ref="1047065009"/>
-							<reference key="NSNextKeyView" ref="465090644"/>
-							<bool key="NSEnabled">YES</bool>
-							<object class="NSButtonCell" key="NSCell" id="198256579">
-								<int key="NSCellFlags">67108864</int>
-								<int key="NSCellFlags2">131072</int>
-								<string key="NSContents">Show children in result list</string>
-								<reference key="NSSupport" ref="26"/>
-								<reference key="NSControlView" ref="492096779"/>
-								<int key="NSButtonFlags">1211912448</int>
-								<int key="NSButtonFlags2">2</int>
-								<reference key="NSNormalImage" ref="167888238"/>
-								<reference key="NSAlternateImage" ref="58344504"/>
-								<string key="NSAlternateContents"/>
-								<string key="NSKeyEquivalent"/>
-								<int key="NSPeriodicDelay">200</int>
-								<int key="NSPeriodicInterval">25</int>
-							</object>
-							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
+							<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
 						</object>
 						<object class="NSPopUpButton" id="666565161">
 							<reference key="NSNextResponder" ref="1047065009"/>
 							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{231, 282}, {131, 22}}</string>
+							<string key="NSFrame">{{231, 262}, {131, 22}}</string>
 							<reference key="NSSuperview" ref="1047065009"/>
+							<reference key="NSWindow"/>
 							<reference key="NSNextKeyView" ref="863250097"/>
 							<string key="NSReuseIdentifierKey">_NS:9</string>
 							<bool key="NSEnabled">YES</bool>
@@ -1205,8 +1227,9 @@
 							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 						</object>
 					</array>
-					<string key="NSFrameSize">{384, 404}</string>
+					<string key="NSFrameSize">{384, 384}</string>
 					<reference key="NSSuperview"/>
+					<reference key="NSWindow"/>
 					<reference key="NSNextKeyView" ref="584969102"/>
 				</object>
 				<string key="NSScreenRect">{{0, 0}, {1280, 778}}</string>
@@ -1221,9 +1244,11 @@
 				<string key="NSClassName">NSApplication</string>
 			</object>
 			<object class="NSView" id="1038232599">
-				<nil key="NSNextResponder"/>
+				<reference key="NSNextResponder"/>
 				<int key="NSvFlags">256</int>
 				<string key="NSFrameSize">{125, 1}</string>
+				<reference key="NSSuperview"/>
+				<reference key="NSWindow"/>
 			</object>
 		</array>
 		<object class="IBObjectContainer" key="IBDocument.Objects">
@@ -1594,26 +1619,6 @@
 				</object>
 				<object class="IBConnectionRecord">
 					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: showChildrenInSplitView</string>
-						<reference key="source" ref="198256579"/>
-						<reference key="destination" ref="204909127"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="198256579"/>
-							<reference key="NSDestination" ref="204909127"/>
-							<string key="NSLabel">value: showChildrenInSplitView</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">showChildrenInSplitView</string>
-							<dictionary key="NSOptions">
-								<boolean value="YES" key="NSConditionallySetsEditable"/>
-								<boolean value="NO" key="NSConditionallySetsEnabled"/>
-							</dictionary>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">372</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
 						<string key="label">value: values.QSSwitchKeyboardOnActivation</string>
 						<reference key="source" ref="389928224"/>
 						<reference key="destination" ref="1039794070"/>
@@ -1718,7 +1723,6 @@
 							<reference ref="994724971"/>
 							<reference ref="923338190"/>
 							<reference ref="20350282"/>
-							<reference ref="492096779"/>
 							<reference ref="524028010"/>
 							<reference ref="410412925"/>
 							<reference ref="138959037"/>
@@ -2259,19 +2263,6 @@
 						<reference key="parent" ref="1047065009"/>
 					</object>
 					<object class="IBObjectRecord">
-						<int key="objectID">368</int>
-						<reference key="object" ref="492096779"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="198256579"/>
-						</array>
-						<reference key="parent" ref="1047065009"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">371</int>
-						<reference key="object" ref="198256579"/>
-						<reference key="parent" ref="492096779"/>
-					</object>
-					<object class="IBObjectRecord">
 						<int key="objectID">373</int>
 						<reference key="object" ref="389928224"/>
 						<array class="NSMutableArray" key="children">
@@ -2357,6 +2348,7 @@
 				<string key="111.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="115.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="116.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="12.IBPersistedLastKnownCanvasPosition">{419, 11}</string>
 				<string key="12.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="12.IBWindowTemplateEditedContentRect">{{411, 247}, {384, 358}}</string>
 				<string key="120.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
@@ -2462,16 +2454,6 @@
 				<string key="365.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="366.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="367.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<object class="NSMutableDictionary" key="368.IBAttributePlaceholdersKey">
-					<string key="NS.key.0">ToolTip</string>
-					<object class="IBToolTipAttribute" key="NS.object.0">
-						<string key="name">ToolTip</string>
-						<reference key="object" ref="492096779"/>
-						<string key="toolTip">Split the results list into two columns to display the children of results</string>
-					</object>
-				</object>
-				<string key="368.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="371.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<object class="NSMutableDictionary" key="373.IBAttributePlaceholdersKey">
 					<string key="NS.key.0">ToolTip</string>
 					<object class="IBToolTipAttribute" key="NS.object.0">
@@ -2488,6 +2470,7 @@
 				<string key="379.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="380.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="381.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<reference key="6.IBNSViewMetadataGestureRecognizers" ref="0"/>
 				<string key="6.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 			</dictionary>
 			<dictionary class="NSMutableDictionary" key="unlocalizedProperties"/>
@@ -2496,22 +2479,284 @@
 			<nil key="sourceID"/>
 			<int key="maxID">405</int>
 		</object>
-		<object class="IBClassDescriber" key="IBDocument.Classes"/>
+		<object class="IBClassDescriber" key="IBDocument.Classes">
+			<array class="NSMutableArray" key="referencedPartialClassDescriptions">
+				<object class="IBPartialClassDescription">
+					<string key="className">FirstResponder</string>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBUserSource</string>
+						<string key="minorKey"/>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">NSApplication</string>
+					<object class="NSMutableDictionary" key="actions">
+						<string key="NS.key.0">relaunch:</string>
+						<string key="NS.object.0">id</string>
+					</object>
+					<object class="NSMutableDictionary" key="actionInfosByName">
+						<string key="NS.key.0">relaunch:</string>
+						<object class="IBActionInfo" key="NS.object.0">
+							<string key="name">relaunch:</string>
+							<string key="candidateClassName">id</string>
+						</object>
+					</object>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBProjectSource</string>
+						<string key="minorKey">../Code-QuickStepFoundation/NSApplication_BLTRExtensions.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">NSApplication</string>
+					<object class="NSMutableDictionary" key="actions">
+						<string key="NS.key.0">relaunch:</string>
+						<string key="NS.object.0">id</string>
+					</object>
+					<object class="NSMutableDictionary" key="actionInfosByName">
+						<string key="NS.key.0">relaunch:</string>
+						<object class="IBActionInfo" key="NS.object.0" id="723551108">
+							<string key="name">relaunch:</string>
+							<string key="candidateClassName">id</string>
+						</object>
+					</object>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBProjectSource</string>
+						<string key="minorKey">../Code-QuickStepFoundation/NSApplication_BLTRExtensions.m</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">NSApplication</string>
+					<object class="NSMutableDictionary" key="actions">
+						<string key="NS.key.0">relaunch:</string>
+						<string key="NS.object.0">id</string>
+					</object>
+					<object class="NSMutableDictionary" key="actionInfosByName">
+						<string key="NS.key.0">relaunch:</string>
+						<reference key="NS.object.0" ref="723551108"/>
+					</object>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBProjectSource</string>
+						<string key="minorKey">./Classes/NSApplication.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">QSHotKeyField</string>
+					<string key="superclassName">NSTextField</string>
+					<object class="NSMutableDictionary" key="actions">
+						<string key="NS.key.0">set:</string>
+						<string key="NS.object.0">id</string>
+					</object>
+					<object class="NSMutableDictionary" key="actionInfosByName">
+						<string key="NS.key.0">set:</string>
+						<object class="IBActionInfo" key="NS.object.0" id="956964955">
+							<string key="name">set:</string>
+							<string key="candidateClassName">id</string>
+						</object>
+					</object>
+					<object class="NSMutableDictionary" key="outlets">
+						<string key="NS.key.0">setButton</string>
+						<string key="NS.object.0">NSButton</string>
+					</object>
+					<object class="NSMutableDictionary" key="toOneOutletInfosByName">
+						<string key="NS.key.0">setButton</string>
+						<object class="IBToOneOutletInfo" key="NS.object.0" id="620619944">
+							<string key="name">setButton</string>
+							<string key="candidateClassName">NSButton</string>
+						</object>
+					</object>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBProjectSource</string>
+						<string key="minorKey">../Code-QuickStepInterface/QSHotKeyEditor.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">QSHotKeyField</string>
+					<object class="NSMutableDictionary" key="actions">
+						<string key="NS.key.0">set:</string>
+						<string key="NS.object.0">id</string>
+					</object>
+					<object class="NSMutableDictionary" key="actionInfosByName">
+						<string key="NS.key.0">set:</string>
+						<object class="IBActionInfo" key="NS.object.0">
+							<string key="name">set:</string>
+							<string key="candidateClassName">id</string>
+						</object>
+					</object>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBProjectSource</string>
+						<string key="minorKey">../Code-QuickStepInterface/QSHotKeyEditor.m</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">QSHotKeyField</string>
+					<string key="superclassName">NSTextField</string>
+					<object class="NSMutableDictionary" key="actions">
+						<string key="NS.key.0">set:</string>
+						<string key="NS.object.0">id</string>
+					</object>
+					<object class="NSMutableDictionary" key="actionInfosByName">
+						<string key="NS.key.0">set:</string>
+						<reference key="NS.object.0" ref="956964955"/>
+					</object>
+					<object class="NSMutableDictionary" key="outlets">
+						<string key="NS.key.0">setButton</string>
+						<string key="NS.object.0">NSButton</string>
+					</object>
+					<object class="NSMutableDictionary" key="toOneOutletInfosByName">
+						<string key="NS.key.0">setButton</string>
+						<reference key="NS.object.0" ref="620619944"/>
+					</object>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBProjectSource</string>
+						<string key="minorKey">./Classes/QSHotKeyField.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">QSPreferencePane</string>
+					<string key="superclassName">NSObject</string>
+					<object class="NSMutableDictionary" key="actions">
+						<string key="NS.key.0">showPaneHelp:</string>
+						<string key="NS.object.0">id</string>
+					</object>
+					<object class="NSMutableDictionary" key="actionInfosByName">
+						<string key="NS.key.0">showPaneHelp:</string>
+						<object class="IBActionInfo" key="NS.object.0" id="777140154">
+							<string key="name">showPaneHelp:</string>
+							<string key="candidateClassName">id</string>
+						</object>
+					</object>
+					<dictionary class="NSMutableDictionary" key="outlets">
+						<string key="_firstKeyView">NSView</string>
+						<string key="_initialKeyView">NSView</string>
+						<string key="_lastKeyView">NSView</string>
+						<string key="_window">NSWindow</string>
+					</dictionary>
+					<dictionary class="NSMutableDictionary" key="toOneOutletInfosByName">
+						<object class="IBToOneOutletInfo" key="_firstKeyView" id="282842163">
+							<string key="name">_firstKeyView</string>
+							<string key="candidateClassName">NSView</string>
+						</object>
+						<object class="IBToOneOutletInfo" key="_initialKeyView" id="265941126">
+							<string key="name">_initialKeyView</string>
+							<string key="candidateClassName">NSView</string>
+						</object>
+						<object class="IBToOneOutletInfo" key="_lastKeyView" id="608532389">
+							<string key="name">_lastKeyView</string>
+							<string key="candidateClassName">NSView</string>
+						</object>
+						<object class="IBToOneOutletInfo" key="_window" id="863280799">
+							<string key="name">_window</string>
+							<string key="candidateClassName">NSWindow</string>
+						</object>
+					</dictionary>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBProjectSource</string>
+						<string key="minorKey">../Code-QuickStepInterface/QSPreferencePane.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">QSPreferencePane</string>
+					<object class="NSMutableDictionary" key="actions">
+						<string key="NS.key.0">showPaneHelp:</string>
+						<string key="NS.object.0">id</string>
+					</object>
+					<object class="NSMutableDictionary" key="actionInfosByName">
+						<string key="NS.key.0">showPaneHelp:</string>
+						<object class="IBActionInfo" key="NS.object.0">
+							<string key="name">showPaneHelp:</string>
+							<string key="candidateClassName">id</string>
+						</object>
+					</object>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBProjectSource</string>
+						<string key="minorKey">../Code-QuickStepInterface/QSPreferencePane.m</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">QSPreferencePane</string>
+					<string key="superclassName">NSObject</string>
+					<object class="NSMutableDictionary" key="actions">
+						<string key="NS.key.0">showPaneHelp:</string>
+						<string key="NS.object.0">id</string>
+					</object>
+					<object class="NSMutableDictionary" key="actionInfosByName">
+						<string key="NS.key.0">showPaneHelp:</string>
+						<reference key="NS.object.0" ref="777140154"/>
+					</object>
+					<dictionary class="NSMutableDictionary" key="outlets">
+						<string key="_firstKeyView">NSView</string>
+						<string key="_initialKeyView">NSView</string>
+						<string key="_lastKeyView">NSView</string>
+						<string key="_window">NSWindow</string>
+					</dictionary>
+					<dictionary class="NSMutableDictionary" key="toOneOutletInfosByName">
+						<reference key="_firstKeyView" ref="282842163"/>
+						<reference key="_initialKeyView" ref="265941126"/>
+						<reference key="_lastKeyView" ref="608532389"/>
+						<reference key="_window" ref="863280799"/>
+					</dictionary>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBProjectSource</string>
+						<string key="minorKey">./Classes/QSPreferencePane.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">QSSearchPrefPane</string>
+					<string key="superclassName">QSPreferencePane</string>
+					<object class="NSMutableDictionary" key="outlets">
+						<string key="NS.key.0">keyboardPopUp</string>
+						<string key="NS.object.0">NSPopUpButton</string>
+					</object>
+					<object class="NSMutableDictionary" key="toOneOutletInfosByName">
+						<string key="NS.key.0">keyboardPopUp</string>
+						<object class="IBToOneOutletInfo" key="NS.object.0" id="588441655">
+							<string key="name">keyboardPopUp</string>
+							<string key="candidateClassName">NSPopUpButton</string>
+						</object>
+					</object>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBProjectSource</string>
+						<string key="minorKey">../Code-App/QSMainPreferencePanes.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">QSSearchPrefPane</string>
+					<string key="superclassName">QSPreferencePane</string>
+					<object class="NSMutableDictionary" key="outlets">
+						<string key="NS.key.0">keyboardPopUp</string>
+						<string key="NS.object.0">NSPopUpButton</string>
+					</object>
+					<object class="NSMutableDictionary" key="toOneOutletInfosByName">
+						<string key="NS.key.0">keyboardPopUp</string>
+						<reference key="NS.object.0" ref="588441655"/>
+					</object>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBProjectSource</string>
+						<string key="minorKey">./Classes/QSSearchPrefPane.h</string>
+					</object>
+				</object>
+			</array>
+		</object>
 		<int key="IBDocument.localizationMode">0</int>
 		<string key="IBDocument.TargetRuntimeIdentifier">IBCocoaFramework</string>
+		<bool key="IBDocument.previouslyAttemptedUpgradeToXcode5">NO</bool>
 		<object class="NSMutableDictionary" key="IBDocument.PluginDeclaredDependencies">
+			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin.macosx</string>
+			<real value="1070" key="NS.object.0"/>
+		</object>
+		<object class="NSMutableDictionary" key="IBDocument.PluginDeclaredDependencyDefaults">
 			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin.macosx</string>
 			<real value="1070" key="NS.object.0"/>
 		</object>
 		<object class="NSMutableDictionary" key="IBDocument.PluginDeclaredDevelopmentDependencies">
 			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin.InterfaceBuilder3</string>
-			<real value="4500" key="NS.object.0"/>
+			<integer value="4600" key="NS.object.0"/>
 		</object>
 		<bool key="IBDocument.PluginDeclaredDependenciesTrackSystemTargetVersion">YES</bool>
 		<int key="IBDocument.defaultPropertyAccessControl">3</int>
 		<dictionary class="NSMutableDictionary" key="IBDocument.LastKnownImageSizes">
-			<string key="NSMenuCheckmark">{11, 11}</string>
-			<string key="NSMenuMixedState">{10, 3}</string>
+			<string key="NSMenuCheckmark">{12, 12}</string>
+			<string key="NSMenuMixedState">{10, 2}</string>
 			<string key="NSSwitch">{15, 15}</string>
 		</dictionary>
 	</data>

--- a/Quicksilver/Nibs/ResultWindow.xib
+++ b/Quicksilver/Nibs/ResultWindow.xib
@@ -1,15 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="5056" systemVersion="13D65" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="6154.17" systemVersion="14A343f" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment version="1070" defaultVersion="1070" identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="5056"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="6154.17"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="QSResultController">
             <connections>
                 <outlet property="filterCatalog" destination="269" id="295"/>
                 <outlet property="filterResults" destination="268" id="296"/>
-                <outlet property="resultChildTable" destination="68" id="77"/>
                 <outlet property="resultTable" destination="58" id="65"/>
                 <outlet property="searchModeField" destination="307" id="309"/>
                 <outlet property="searchModeMenu" destination="265" id="280"/>
@@ -18,7 +17,6 @@
                 <outlet property="snapToBest" destination="267" id="297"/>
                 <outlet property="sortByName" destination="237" id="303"/>
                 <outlet property="sortByScore" destination="238" id="302"/>
-                <outlet property="splitView" destination="71" id="142"/>
                 <outlet property="window" destination="9" id="33"/>
             </connections>
         </customObject>
@@ -28,25 +26,18 @@
             <windowStyleMask key="styleMask" titled="YES" closable="YES" resizable="YES" nonactivatingPanel="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="48" y="35" width="322" height="198"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1280" height="778"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="877"/>
             <value key="minSize" type="size" width="200" height="150"/>
             <view key="contentView" id="16">
                 <rect key="frame" x="0.0" y="0.0" width="322" height="198"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <customView translatesAutoresizingMaskIntoConstraints="NO" id="314" customClass="BLTRResizeView">
-                        <rect key="frame" x="306" y="0.0" width="16" height="16"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
-                        <constraints>
-                            <constraint firstAttribute="height" constant="16" id="8Ow-ca-P4f"/>
-                            <constraint firstAttribute="width" constant="16" id="QwA-zI-T2X"/>
-                        </constraints>
-                    </customView>
                     <textField toolTip="Selected item information" horizontalHuggingPriority="10" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="130">
                         <rect key="frame" x="1" y="1" width="304" height="13"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                         <constraints>
-                            <constraint firstAttribute="height" constant="13" id="EMh-pY-flU"/>
+                            <constraint firstAttribute="width" constant="300" id="FFo-0a-gUk"/>
+                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="13" id="Mf1-sh-GIc"/>
+                            <constraint firstAttribute="height" constant="13" id="TPG-5g-eD2"/>
                         </constraints>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" state="on" alignment="left" title="Details" id="283">
                             <font key="font" metaFont="systemBold" size="10"/>
@@ -54,136 +45,10 @@
                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
-                    <splitView horizontalCompressionResistancePriority="250" vertical="YES" translatesAutoresizingMaskIntoConstraints="NO" id="71">
-                        <rect key="frame" x="-1" y="14" width="324" height="169"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <subviews>
-                            <scrollView fixedFrame="YES" autohidesScrollers="YES" horizontalLineScroll="15" horizontalPageScroll="10" verticalLineScroll="15" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" id="59">
-                                <rect key="frame" x="0.0" y="0.0" width="157" height="169"/>
-                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                <clipView key="contentView" horizontalHuggingPriority="100" drawsBackground="NO" copiesOnScroll="NO" id="9Ay-Fd-WxY">
-                                    <rect key="frame" x="1" y="1" width="155" height="167"/>
-                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                    <subviews>
-                                        <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnReordering="NO" columnSelection="YES" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" rowHeight="12" id="58" customClass="QSTableView">
-                                            <rect key="frame" x="0.0" y="0.0" width="155" height="167"/>
-                                            <autoresizingMask key="autoresizingMask" widthSizable="YES"/>
-                                            <size key="intercellSpacing" width="3" height="3"/>
-                                            <color key="backgroundColor" red="1" green="1" blue="1" alpha="0.0" colorSpace="calibratedRGB"/>
-                                            <color key="gridColor" white="0.94758063999999997" alpha="1" colorSpace="calibratedWhite"/>
-                                            <tableColumns>
-                                                <tableColumn identifier="RankColumn" width="24" minWidth="13.611000061035156" maxWidth="24" id="143">
-                                                    <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="center" title="•">
-                                                        <font key="font" metaFont="miniSystemBold"/>
-                                                        <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
-                                                    </tableHeaderCell>
-                                                    <textFieldCell key="dataCell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" allowsUndo="NO" alignment="center" id="286">
-                                                        <font key="font" metaFont="miniSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                </tableColumn>
-                                                <tableColumn identifier="NameColumn" editable="NO" width="112.14500045776367" minWidth="42.145000457763672" maxWidth="1000" id="60">
-                                                    <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Results">
-                                                        <font key="font" metaFont="miniSystemBold"/>
-                                                        <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" white="0.33333299" alpha="1" colorSpace="calibratedWhite"/>
-                                                    </tableHeaderCell>
-                                                    <textFieldCell key="dataCell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" alignment="left" id="285">
-                                                        <font key="font" metaFont="miniSystem"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                                    </textFieldCell>
-                                                    <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
-                                                </tableColumn>
-                                                <tableColumn identifier="hasChildren" editable="NO" width="10" minWidth="4" maxWidth="1000" id="157">
-                                                    <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
-                                                    </tableHeaderCell>
-                                                    <imageCell key="dataCell" refusesFirstResponder="YES" alignment="left" animates="YES" imageScaling="proportionallyDown" id="159"/>
-                                                </tableColumn>
-                                            </tableColumns>
-                                            <connections>
-                                                <binding destination="195" name="rowHeight" keyPath="values.QSResultViewRowHeight" id="197"/>
-                                                <outlet property="dataSource" destination="-2" id="62"/>
-                                                <outlet property="delegate" destination="-2" id="63"/>
-                                            </connections>
-                                        </tableView>
-                                    </subviews>
-                                    <color key="backgroundColor" red="1" green="1" blue="1" alpha="0.0" colorSpace="calibratedRGB"/>
-                                </clipView>
-                                <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="YES" id="289">
-                                    <rect key="frame" x="-100" y="-100" width="429" height="15"/>
-                                    <autoresizingMask key="autoresizingMask"/>
-                                </scroller>
-                                <scroller key="verticalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="NO" id="288">
-                                    <rect key="frame" x="-30" y="1" width="15" height="167"/>
-                                    <autoresizingMask key="autoresizingMask"/>
-                                </scroller>
-                            </scrollView>
-                            <scrollView fixedFrame="YES" autohidesScrollers="YES" horizontalLineScroll="21" horizontalPageScroll="10" verticalLineScroll="21" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" id="69">
-                                <rect key="frame" x="166" y="0.0" width="158" height="169"/>
-                                <autoresizingMask key="autoresizingMask"/>
-                                <clipView key="contentView" horizontalHuggingPriority="100" drawsBackground="NO" copiesOnScroll="NO" id="tHA-Dz-WTb">
-                                    <rect key="frame" x="1" y="1" width="156" height="167"/>
-                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                    <subviews>
-                                        <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" rowHeight="18" id="68" customClass="QSTableView">
-                                            <rect key="frame" x="0.0" y="0.0" width="156" height="167"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <size key="intercellSpacing" width="3" height="3"/>
-                                            <color key="backgroundColor" white="1" alpha="0.0" colorSpace="calibratedWhite"/>
-                                            <color key="gridColor" white="0.94758063999999997" alpha="1" colorSpace="calibratedWhite"/>
-                                            <tableColumns>
-                                                <tableColumn identifier="NameColumn" editable="NO" width="153" minWidth="8" maxWidth="1000" id="67">
-                                                    <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
-                                                        <font key="font" metaFont="smallSystem"/>
-                                                        <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" white="0.33333299" alpha="1" colorSpace="calibratedWhite"/>
-                                                    </tableHeaderCell>
-                                                    <textFieldCell key="dataCell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" alignment="left" id="287">
-                                                        <font key="font" metaFont="system"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" white="1" alpha="0.0" colorSpace="calibratedWhite"/>
-                                                    </textFieldCell>
-                                                    <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
-                                                </tableColumn>
-                                            </tableColumns>
-                                            <connections>
-                                                <binding destination="195" name="rowHeight" keyPath="values.QSResultViewRowHeight" id="198"/>
-                                                <outlet property="dataSource" destination="-2" id="115"/>
-                                                <outlet property="delegate" destination="-2" id="114"/>
-                                            </connections>
-                                        </tableView>
-                                    </subviews>
-                                    <color key="backgroundColor" white="1" alpha="0.94999999000000002" colorSpace="calibratedWhite"/>
-                                </clipView>
-                                <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" controlSize="small" horizontal="YES" id="291">
-                                    <rect key="frame" x="-100" y="-100" width="429" height="15"/>
-                                    <autoresizingMask key="autoresizingMask"/>
-                                </scroller>
-                                <scroller key="verticalScroller" hidden="YES" verticalHuggingPriority="750" controlSize="small" horizontal="NO" id="290">
-                                    <rect key="frame" x="143" y="1" width="14" height="0.0"/>
-                                    <autoresizingMask key="autoresizingMask"/>
-                                </scroller>
-                            </scrollView>
-                        </subviews>
-                        <holdingPriorities>
-                            <real value="250"/>
-                            <real value="250"/>
-                        </holdingPriorities>
-                        <connections>
-                            <outlet property="delegate" destination="-2" id="133"/>
-                        </connections>
-                    </splitView>
                     <textField toolTip="Search string" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="43">
                         <rect key="frame" x="4" y="183" width="220" height="13"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <constraints>
-                            <constraint firstAttribute="height" constant="13" id="CAW-Gu-8c2"/>
+                            <constraint firstAttribute="height" constant="13" id="d6L-3v-rGZ"/>
                         </constraints>
                         <textFieldCell key="cell" controlSize="mini" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" state="on" alignment="left" title="SEARCH" id="282">
                             <font key="font" metaFont="systemBold" size="10"/>
@@ -193,10 +58,10 @@
                     </textField>
                     <textField toolTip="Search string" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="307">
                         <rect key="frame" x="225" y="184" width="72" height="13"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
                         <constraints>
-                            <constraint firstAttribute="width" constant="68" id="HFx-lA-tty"/>
-                            <constraint firstAttribute="height" constant="13" id="wAt-eB-emp"/>
+                            <constraint firstAttribute="width" constant="68" id="IFy-kv-cub"/>
+                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="68" id="rIK-jT-9MZ"/>
+                            <constraint firstAttribute="height" constant="13" id="vQx-Nj-lll"/>
                         </constraints>
                         <textFieldCell key="cell" controlSize="mini" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" state="on" alignment="right" title="RESULTS MODE" id="308">
                             <font key="font" metaFont="systemBold" size="10"/>
@@ -206,10 +71,11 @@
                     </textField>
                     <button translatesAutoresizingMaskIntoConstraints="NO" id="248" customClass="QSMenuButton">
                         <rect key="frame" x="297" y="181" width="25" height="20"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
                         <constraints>
-                            <constraint firstAttribute="width" constant="25" id="Hfu-Rf-46g"/>
-                            <constraint firstAttribute="height" constant="20" id="YG5-eA-Wyg"/>
+                            <constraint firstAttribute="width" constant="25" id="4gg-r7-xam"/>
+                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="20" id="ZSD-IE-PLA"/>
+                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="25" id="iPf-eV-ZPG"/>
+                            <constraint firstAttribute="height" constant="20" id="rEU-Di-d86"/>
                         </constraints>
                         <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="Button-GearMenu" imagePosition="only" alignment="center" inset="2" id="284">
                             <behavior key="behavior" lightByContents="YES"/>
@@ -221,30 +87,106 @@
                             <outlet property="menu" destination="231" id="249"/>
                         </connections>
                     </button>
+                    <scrollView horizontalHuggingPriority="1" verticalHuggingPriority="1" borderType="none" autohidesScrollers="YES" horizontalLineScroll="15" horizontalPageScroll="10" verticalLineScroll="15" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="59">
+                        <rect key="frame" x="0.0" y="15" width="322" height="168"/>
+                        <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="9Ay-Fd-WxY">
+                            <rect key="frame" x="1" y="1" width="155" height="167"/>
+                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                            <subviews>
+                                <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnReordering="NO" columnSelection="YES" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" rowHeight="12" id="58" customClass="QSTableView">
+                                    <rect key="frame" x="0.0" y="0.0" width="322" height="15"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES"/>
+                                    <size key="intercellSpacing" width="3" height="3"/>
+                                    <color key="backgroundColor" red="1" green="1" blue="1" alpha="0.0" colorSpace="calibratedRGB"/>
+                                    <color key="gridColor" white="0.94758063999999997" alpha="1" colorSpace="calibratedWhite"/>
+                                    <tableColumns>
+                                        <tableColumn identifier="RankColumn" width="24" minWidth="13.611000061035156" maxWidth="24" id="143">
+                                            <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="center" title="•">
+                                                <font key="font" metaFont="miniSystemBold"/>
+                                                <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
+                                            </tableHeaderCell>
+                                            <textFieldCell key="dataCell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" allowsUndo="NO" alignment="center" id="286">
+                                                <font key="font" metaFont="miniSystem"/>
+                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </tableColumn>
+                                        <tableColumn identifier="NameColumn" editable="NO" width="279.14500045776367" minWidth="42.145000457763672" maxWidth="1000" id="60">
+                                            <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Results">
+                                                <font key="font" metaFont="miniSystemBold"/>
+                                                <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" white="0.33333299" alpha="1" colorSpace="calibratedWhite"/>
+                                            </tableHeaderCell>
+                                            <textFieldCell key="dataCell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" alignment="left" id="285">
+                                                <font key="font" metaFont="miniSystem"/>
+                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                            </textFieldCell>
+                                            <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                        </tableColumn>
+                                        <tableColumn identifier="hasChildren" editable="NO" width="10" minWidth="4" maxWidth="1000" id="157">
+                                            <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
+                                                <font key="font" metaFont="smallSystem"/>
+                                                <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
+                                            </tableHeaderCell>
+                                            <imageCell key="dataCell" refusesFirstResponder="YES" alignment="left" animates="YES" imageScaling="proportionallyDown" id="159"/>
+                                        </tableColumn>
+                                    </tableColumns>
+                                    <connections>
+                                        <binding destination="195" name="rowHeight" keyPath="values.QSResultViewRowHeight" id="197"/>
+                                        <outlet property="dataSource" destination="-2" id="62"/>
+                                        <outlet property="delegate" destination="-2" id="63"/>
+                                    </connections>
+                                </tableView>
+                            </subviews>
+                            <color key="backgroundColor" red="1" green="1" blue="1" alpha="0.0" colorSpace="calibratedRGB"/>
+                        </clipView>
+                        <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="YES" id="289">
+                            <rect key="frame" x="-100" y="-100" width="429" height="15"/>
+                            <autoresizingMask key="autoresizingMask"/>
+                        </scroller>
+                        <scroller key="verticalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="NO" id="288">
+                            <rect key="frame" x="-30" y="1" width="15" height="167"/>
+                            <autoresizingMask key="autoresizingMask"/>
+                        </scroller>
+                    </scrollView>
+                    <customView translatesAutoresizingMaskIntoConstraints="NO" id="314" customClass="BLTRResizeView">
+                        <rect key="frame" x="306" y="0.0" width="16" height="16"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="16" id="BWF-eX-gCt"/>
+                            <constraint firstAttribute="width" constant="16" id="jo1-SX-V6s"/>
+                        </constraints>
+                    </customView>
                 </subviews>
                 <constraints>
-                    <constraint firstItem="71" firstAttribute="top" secondItem="307" secondAttribute="bottom" constant="1" id="6is-ye-egl"/>
-                    <constraint firstAttribute="trailing" secondItem="314" secondAttribute="trailing" id="8Tk-6C-QDq"/>
-                    <constraint firstItem="314" firstAttribute="leading" secondItem="130" secondAttribute="trailing" constant="3" id="Ak8-UK-ki9"/>
-                    <constraint firstAttribute="bottom" secondItem="314" secondAttribute="bottom" id="JTt-TD-LT1"/>
-                    <constraint firstItem="314" firstAttribute="trailing" secondItem="248" secondAttribute="trailing" id="Meb-Ly-jVr"/>
-                    <constraint firstItem="130" firstAttribute="leading" secondItem="16" secondAttribute="leading" constant="3" id="SBW-Kg-plP"/>
-                    <constraint firstItem="71" firstAttribute="top" secondItem="43" secondAttribute="bottom" id="T4h-ss-IpW"/>
-                    <constraint firstItem="248" firstAttribute="leading" secondItem="307" secondAttribute="trailing" constant="2" id="TGM-ni-NYW"/>
-                    <constraint firstItem="71" firstAttribute="leading" secondItem="16" secondAttribute="leading" constant="-1" id="Ujl-OO-kDP"/>
-                    <constraint firstItem="248" firstAttribute="top" secondItem="16" secondAttribute="top" constant="-3" id="ZlX-He-rPU"/>
-                    <constraint firstItem="130" firstAttribute="top" secondItem="71" secondAttribute="bottom" id="aIK-cu-Uvv"/>
-                    <constraint firstAttribute="trailing" secondItem="71" secondAttribute="trailing" constant="-1" id="aR8-kg-nQw"/>
-                    <constraint firstItem="43" firstAttribute="leading" secondItem="16" secondAttribute="leading" constant="6" id="bnt-e2-8Yb"/>
-                    <constraint firstAttribute="bottom" secondItem="130" secondAttribute="bottom" constant="1" id="fs0-wX-nYn"/>
-                    <constraint firstAttribute="bottom" secondItem="314" secondAttribute="bottom" id="hiN-EH-Tpu"/>
-                    <constraint firstItem="307" firstAttribute="leading" secondItem="43" secondAttribute="trailing" constant="5" id="m6g-QD-WOX"/>
-                    <constraint firstItem="248" firstAttribute="leading" secondItem="307" secondAttribute="trailing" constant="2" id="n2z-01-fC8"/>
-                    <constraint firstItem="307" firstAttribute="top" secondItem="16" secondAttribute="top" constant="1" id="nfw-Uq-tbf"/>
-                    <constraint firstAttribute="trailing" secondItem="248" secondAttribute="trailing" id="rN2-QP-Dbr"/>
-                    <constraint firstItem="307" firstAttribute="leading" secondItem="43" secondAttribute="trailing" constant="5" id="vSV-jO-2qo"/>
-                    <constraint firstItem="43" firstAttribute="top" secondItem="16" secondAttribute="top" constant="2" id="vre-ew-pFR"/>
-                    <constraint firstItem="71" firstAttribute="top" secondItem="43" secondAttribute="bottom" id="w5z-Rf-3xO"/>
+                    <constraint firstItem="314" firstAttribute="trailing" secondItem="248" secondAttribute="trailing" id="1WG-6t-Xg6"/>
+                    <constraint firstItem="59" firstAttribute="centerY" secondItem="16" secondAttribute="centerY" id="5W2-dV-YeU"/>
+                    <constraint firstItem="307" firstAttribute="top" secondItem="16" secondAttribute="top" constant="1" id="96t-Bh-Lxt"/>
+                    <constraint firstAttribute="bottom" secondItem="314" secondAttribute="bottom" id="A0x-Ew-9QY"/>
+                    <constraint firstItem="43" firstAttribute="leading" secondItem="16" secondAttribute="leading" constant="6" id="Dm6-oT-Zt7"/>
+                    <constraint firstItem="130" firstAttribute="leading" relation="lessThanOrEqual" secondItem="16" secondAttribute="leading" constant="3" id="FjL-GD-1xU"/>
+                    <constraint firstAttribute="trailing" secondItem="314" secondAttribute="trailing" id="Gct-YM-rxW"/>
+                    <constraint firstItem="43" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="16" secondAttribute="leading" constant="6" id="HJa-d8-1yG"/>
+                    <constraint firstAttribute="bottom" secondItem="130" secondAttribute="bottom" constant="1" id="HiM-mk-b1D"/>
+                    <constraint firstItem="248" firstAttribute="leading" secondItem="307" secondAttribute="trailing" constant="2" id="Lb8-Fr-tCc"/>
+                    <constraint firstItem="59" firstAttribute="trailing" secondItem="314" secondAttribute="trailing" id="Quu-RD-UQ7"/>
+                    <constraint firstItem="59" firstAttribute="leading" secondItem="16" secondAttribute="leading" id="WRm-0e-SLe"/>
+                    <constraint firstItem="248" firstAttribute="leading" secondItem="307" secondAttribute="trailing" constant="2" id="XHB-hY-SM2"/>
+                    <constraint firstItem="307" firstAttribute="top" relation="greaterThanOrEqual" secondItem="16" secondAttribute="top" constant="1" id="b3q-0v-y1e"/>
+                    <constraint firstItem="43" firstAttribute="top" secondItem="16" secondAttribute="top" constant="2" id="cI6-cl-hKl"/>
+                    <constraint firstItem="130" firstAttribute="top" secondItem="59" secondAttribute="bottom" constant="1" id="dpz-hS-Yd9"/>
+                    <constraint firstItem="248" firstAttribute="top" secondItem="16" secondAttribute="top" constant="-3" id="hIx-yT-faJ"/>
+                    <constraint firstItem="130" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="16" secondAttribute="leading" constant="3" id="hhx-oG-5E4"/>
+                    <constraint firstItem="307" firstAttribute="leading" secondItem="43" secondAttribute="trailing" constant="5" id="i55-os-Ywz"/>
+                    <constraint firstAttribute="bottom" relation="lessThanOrEqual" secondItem="130" secondAttribute="bottom" constant="1" id="iCv-ZM-UmH"/>
+                    <constraint firstItem="130" firstAttribute="leading" secondItem="16" secondAttribute="leading" constant="3" id="m7C-fu-18f"/>
+                    <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="130" secondAttribute="bottom" constant="1" id="veG-fp-egG"/>
+                    <constraint firstItem="307" firstAttribute="leading" secondItem="43" secondAttribute="trailing" constant="5" id="wBd-5h-beF"/>
+                    <constraint firstItem="43" firstAttribute="top" relation="greaterThanOrEqual" secondItem="16" secondAttribute="top" constant="2" id="wp3-GI-Em1"/>
+                    <constraint firstItem="248" firstAttribute="top" relation="greaterThanOrEqual" secondItem="16" secondAttribute="top" constant="-3" id="xvr-Ui-g7h"/>
+                    <constraint firstAttribute="trailing" secondItem="248" secondAttribute="trailing" id="zTU-4Z-JCb"/>
                 </constraints>
             </view>
             <connections>


### PR DESCRIPTION
Here’s an attempted fix.

I initially got the results to show up by adding constraints, but they drew all over the top of the other stuff in the window. I assumed because those things needed constraints too before AutoLayout could figure out how to put them together. Nothing I did would make it respect its neighbors, but by trying a bunch of things and accepting some suggested fixes from Xcode, it seems to be working correctly now.

Chance that I missed something or did something wrong: 82%
