### PR TITLE
allow status icon to work with dark mode

### DIFF
--- a/Quicksilver/Code-App/QSController.m
+++ b/Quicksilver/Code-App/QSController.m
@@ -144,8 +144,9 @@ static QSController *defaultController = nil;
         return;
     }
     statusItem = [[NSStatusBar systemStatusBar] statusItemWithLength:29.0f];
-	[statusItem setImage:[NSImage imageNamed:@"QuicksilverMenu"]];
-	[statusItem setAlternateImage:[NSImage imageNamed:@"QuicksilverMenuPressed"]];
+    NSImage *statusImage = [NSImage imageNamed:@"QuicksilverMenu"];
+    [statusImage setTemplate:YES];
+	[statusItem setImage:statusImage];
 	[statusItem setMenu:[self statusMenuWithQuit]];
 	[statusItem setHighlightMode:YES];
 }


### PR DESCRIPTION
One last thing for 1.2.0 to support Yosemite.

normal: kinda blurry and crappy
normal w/ retina: looks good
dark mode: looks good
dark mode w/ retina: unable to test yet
