### PR TITLE
remove `dispatch_release` call

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSCatalogEntry.m
+++ b/Quicksilver/Code-QuickStepCore/QSCatalogEntry.m
@@ -89,7 +89,6 @@ NSDictionary *enabledPresetDictionary;*/
 	id theSource = [self source];
 	if ([theSource respondsToSelector:@selector(disableEntry:)])
 		[theSource disableEntry:self];
-    dispatch_release(scanQueue);
     scanQueue = NULL;
 }
 


### PR DESCRIPTION
From glancing at the documentation, it looks like we shouldn’t be doing this under ARC.
