### PR TITLE
Reset modifier only hotkey activation between key presses

### DIFF
--- a/Quicksilver/Code-App/QSModifierKeyEvents.m
+++ b/Quicksilver/Code-App/QSModifierKeyEvents.m
@@ -54,6 +54,13 @@ BOOL modifierEventsEnabled = YES;
 
     QSModifierKeyEvent *match = [modifierKeyEvents objectForKey:(mods ? @(mods) : @(lastModifiers))];
     
+    [modifierKeyEvents enumerateKeysAndObjectsUsingBlock:^(id key, QSModifierKeyEvent *ev, BOOL *stop) {
+        if (match != ev) {
+            // reset the modifier state for any non-matching modifier key events (Issue #1950)
+            [ev resetTimesKeysPressed:self];
+        }
+    }];
+    
     BOOL modsAdded = mods >= lastModifiers;
     
 	lastModifiers = mods;


### PR DESCRIPTION
If a different modifier was pressed between two 'activation modifier' key presses, QS could still be activated.
E.g. in a 'double shift activation' scenario, if ⇪⌥⇧ was pressed, QS would still activate.
This change ensures that the state of any modifier events is reset when any non-related keys are pressed.

Fixes #1950
