### PR TITLE
keep NSBundle calls on a single thread

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSResourceManager.h
+++ b/Quicksilver/Code-QuickStepCore/QSResourceManager.h
@@ -9,7 +9,7 @@ extern id QSRez;
     dispatch_queue_t resourceQueue;
 }
 
-+ (id)sharedInstance;
++ (instancetype)sharedInstance;
 + (NSImage *)imageNamed:(NSString *)name;
 + (NSImage *)imageNamed:(NSString *)name inBundle:(NSBundle *)bundle;
 - (NSImage *)imageNamed:(NSString *)name;

--- a/Quicksilver/Code-QuickStepCore/QSResourceManager.m
+++ b/Quicksilver/Code-QuickStepCore/QSResourceManager.m
@@ -9,7 +9,7 @@ QSResourceManager * QSRez;
 
 @implementation QSResourceManager
 
-+ (id)sharedInstance {
++ (instancetype)sharedInstance {
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         QSRez = [[self alloc] init];


### PR DESCRIPTION
…in `QSResourceManager`

I think @pjrobertson was right in #1861 when he said these calls should be on a single thread. But the actual code in #1871 didn’t keep it on one thread. It just locked `QSRez` so multiple threads couldn’t make changes simultaneously. We should probably avoid locking frequently used singletons like `QSRez` unless absolutely necessary.

I’ve attempted to change this so it queues things up on a single thread instead of locking the object. It seems to prevent the freezes people are reporting.

There aren’t as many changes as it looks like. It’s mostly indentation changes for things that aren’t wrapped in `@synchronized` any more.

fixes #1957
