### PR TITLE
small adjustment

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSObject.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject.m
@@ -37,7 +37,7 @@ NSSize QSMaxIconSize;
 
     // Make copies of the sets so we can purge them without bothering about threading
     // We're synchronizing on the class instance, since those are class-ivars
-    @synchronized ([self class]) {
+    @synchronized ([QSObject class]) {
         tempLastAccess = globalLastAccess;
         tempIconSet = [iconLoadedSet copy];
         tempChildSet = [childLoadedSet copy];
@@ -560,7 +560,7 @@ NSSize QSMaxIconSize;
 	[self setAltChildren:nil];
 	flags.childrenLoaded = NO;
 	[self setChildrenLoadedDate:0];
-    @synchronized ([self class]) {
+    @synchronized ([QSObject class]) {
         [childLoadedSet removeObject:self];
     }
 	return YES;
@@ -574,7 +574,7 @@ NSSize QSMaxIconSize;
         self.childrenLoadedDate = now;
         self.lastAccess = now;
 
-        @synchronized ([self class]) {
+        @synchronized ([QSObject class]) {
             globalLastAccess = now;
             [childLoadedSet addObject:self];
         }
@@ -769,7 +769,7 @@ NSSize QSMaxIconSize;
 - (BOOL)iconLoaded { return flags.iconLoaded;  }
 - (void)setIconLoaded:(BOOL)flag {
 	flags.iconLoaded = flag;
-    @synchronized([self class]) {
+    @synchronized([QSObject class]) {
         if (flag) {
             [iconLoadedSet addObject:self];
         } else {
@@ -870,7 +870,7 @@ NSSize QSMaxIconSize;
 	[self setIconLoaded:YES];
     NSTimeInterval now = [NSDate timeIntervalSinceReferenceDate];
 	self.lastAccess = now;
-    @synchronized ([self class]) {
+    @synchronized ([QSObject class]) {
         globalLastAccess = now;
     }
 
@@ -920,7 +920,7 @@ NSSize QSMaxIconSize;
 - (NSImage *)icon {
     NSTimeInterval now = [NSDate timeIntervalSinceReferenceDate];
 	self.lastAccess = now;
-    @synchronized ([self class]) {
+    @synchronized ([QSObject class]) {
         globalLastAccess = now;
     }
     


### PR DESCRIPTION
A small adjustment to #1927. I was occasionally getting into a situation where the interface worked normally, but none of the actions would actually do anything when executed. The console showed

```
2014/11/05 2:31:56.057 PM Quicksilver[13456]: An uncaught exception was raised
2014/11/05 2:31:56.057 PM Quicksilver[13456]: *** -[__NSPlaceholderSet initWithObjects:count:]: attempt to insert nil object from objects[335]
```

The stack trace that followed pointed to the new section where we make copies of `iconLoadedSet` and `childLoadedSet`, which was wrapped in `@synchronized (self)`. So I read the docs and discovered that this doesn’t actually protect `self` from changes. It just prevents any other section wrapped in `@synchronized (self)` from running at the same time. But we didn’t have any other sections like that. When changing the sets, we were using `@synchronized ([self class])`, so that’s what we should use here or it won’t do anything.

It was an intermittent problem, so I don’t know for sure that I’ve fixed it, but I think this is correct.

(If I’m reading it right, we could put _anything_ in parentheses, as long as it’s the same in all the places we want to lock for a particular purpose.)
