### PR TITLE
only clean up short strings

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSResourceManager.m
+++ b/Quicksilver/Code-QuickStepCore/QSResourceManager.m
@@ -64,7 +64,7 @@ QSResourceManager * QSRez;
 - (NSString *)safeImageName:(NSString *)rawName
 {
     // strings with a slash lead to a crash - issue #2002
-    if ([rawName containsString:@"/"]) {
+    if ([rawName length] <= 10 && [rawName containsString:@"/"]) {
         if (![slashNames containsObject:rawName]) {
             NSLog(@"sanitizing image name: %@", rawName);
             [slashNames addObject:rawName];


### PR DESCRIPTION
I guess passing a full path as the image name was a valid use case after all. AppleScript actions get their icons this way.

In all the crash reports, there was never an attempt to get a range outside `{0, 10}`. If I understand what’s happening, only small strings can be stored as `NSTaggedPointerString`, so there’s no need to “clean” the longer ones.

An absolute path is likely to be longer, so this indirectly works. To be 100% correct, we’d need to test `fileExistsAtPath:`, but I don’t like the idea of going to the disk that frequently. Maybe `isAbsolutePath` would work, but are we certain that doesn’t touch the disk at all?