### PR TITLE
Switch to new grabicon.com domain/API

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSObject_URLHandling.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject_URLHandling.m
@@ -39,7 +39,7 @@
         faviconScheme = @"http";
     }
     
-	NSString *favIconString = [NSString stringWithFormat:@"http://g.etfv.co/%@://%@?defaulticon=none&extension=.ico", faviconScheme, [favIconURL host]];
+	NSString *favIconString = [NSString stringWithFormat:@"http://grabicon.com/icon?domain=%@://%@&origin=quicksilverosx", faviconScheme, [favIconURL host]];
 	NSImage *favicon = [[NSImage alloc] initWithContentsOfURL:[NSURL URLWithString:favIconString]];
 	return favicon;
 }


### PR DESCRIPTION
If you've been using the web search plugin, you'll have noticed that the icons are all like this:
http://grabicon.com/icon?domain=https://example.com&size=32

That's because the API has changed slightly and we now need to provide an 'origin' parameter. Apparently if we go over our 'api limit' we won't be able to load more icons, so I've got in touch with the guys 