### PR TITLE
Sidebar items

### DIFF
--- a/Quicksilver/PlugIns-Main/Finder/Info.plist
+++ b/Quicksilver/PlugIns-Main/Finder/Info.plist
@@ -66,28 +66,6 @@
 					<key>source</key>
 					<string>QSDefaultsObjectSource</string>
 				</dict>
-				<dict>
-					<key>ID</key>
-					<string>QSPresetFinderToolbarItems</string>
-					<key>name</key>
-					<string>Finder Toolbar Items</string>
-					<key>settings</key>
-					<dict>
-						<key>bundle</key>
-						<string>com.apple.finder</string>
-						<key>keypath</key>
-						<array>
-							<string>NSToolbar Configuration Browser</string>
-							<string>TB Item Plists</string>
-							<string>*</string>
-							<string>_CFURLAliasData</string>
-						</array>
-						<key>type</key>
-						<integer>3</integer>
-					</dict>
-					<key>source</key>
-					<string>QSDefaultsObjectSource</string>
-				</dict>
 			</array>
 			<key>icon</key>
 			<string>FinderIcon</string>

--- a/Quicksilver/PlugIns-Main/Finder/Info.plist
+++ b/Quicksilver/PlugIns-Main/Finder/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.0</string>
+	<string>1.1.0</string>
 	<key>CFBundleVersion</key>
-	<string>17A5</string>
+	<string>17A6</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2004, Blacktree, Inc.</string>
 	<key>QSPlugIn</key>

--- a/Quicksilver/PlugIns-Main/Finder/Info.plist
+++ b/Quicksilver/PlugIns-Main/Finder/Info.plist
@@ -55,8 +55,8 @@
 						<string>com.apple.sidebarlists</string>
 						<key>keypath</key>
 						<array>
-							<string>favorites</string>
-							<string>VolumesList</string>
+							<string>favoriteitems</string>
+							<string>CustomListItems</string>
 							<string>*</string>
 							<string>Alias</string>
 						</array>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/ca-ES.lproj/QSCatalogPreset.name.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/ca-ES.lproj/QSCatalogPreset.name.strings
@@ -100,8 +100,6 @@
     <string>Carpetes recents (Finder)</string>
     <key>QSPresetFinderSpecificSearchPlaces</key>
     <string>Llocs de recerca específica del Finder</string>
-    <key>QSPresetFinderToolbarItems</key>
-    <string>Elements de la barra d&apos;eines del Finder</string>
     <key>QSPresetFirefoxBookmarks</key>
     <string>Marcadors del Firefox</string>
     <key>QSPresetGlobalPrefsRecentFolders</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/cs.lproj/QSCatalogPreset.name.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/cs.lproj/QSCatalogPreset.name.strings
@@ -100,8 +100,6 @@
     <string>Poslední položky (Finder)</string>
     <key>QSPresetFinderSpecificSearchPlaces</key>
     <string>Místa hledání Finder</string>
-    <key>QSPresetFinderToolbarItems</key>
-    <string>Položky řádku nabídek Finder</string>
     <key>QSPresetFirefoxBookmarks</key>
     <string>Záložky Firefox</string>
     <key>QSPresetGlobalPrefsRecentFolders</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/de.lproj/QSCatalogPreset.name.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/de.lproj/QSCatalogPreset.name.strings
@@ -100,8 +100,6 @@
     <string>Benutzte Ordner (Finder)</string>
     <key>QSPresetFinderSpecificSearchPlaces</key>
     <string>Finder Bestimmte Suchorte</string>
-    <key>QSPresetFinderToolbarItems</key>
-    <string>Finder Symbolleistenobjekte</string>
     <key>QSPresetFirefoxBookmarks</key>
     <string>Firefox Lesezeichen</string>
     <key>QSPresetGlobalPrefsRecentFolders</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/en.lproj/QSCatalogPreset.name.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/en.lproj/QSCatalogPreset.name.strings
@@ -100,8 +100,6 @@
 	<string>Recent Folders (Finder)</string>
 	<key>QSPresetFinderSpecificSearchPlaces</key>
 	<string>Finder Specific Search Places</string>
-	<key>QSPresetFinderToolbarItems</key>
-	<string>Finder Toolbar Items</string>
 	<key>QSPresetFirefoxBookmarks</key>
 	<string>Firefox Bookmarks</string>
 	<key>QSPresetGlobalPrefsRecentFolders</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/es-ES.lproj/QSCatalogPreset.name.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/es-ES.lproj/QSCatalogPreset.name.strings
@@ -100,8 +100,6 @@
     <string>Carpetas Recientes (Finder)</string>
     <key>QSPresetFinderSpecificSearchPlaces</key>
     <string>Lugares de Búsqueda Específicos del Finder</string>
-    <key>QSPresetFinderToolbarItems</key>
-    <string>Ítems de la Barra de Herramientas del Finder</string>
     <key>QSPresetFirefoxBookmarks</key>
     <string>Marcadores de Firefox</string>
     <key>QSPresetGlobalPrefsRecentFolders</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/es-MX.lproj/QSCatalogPreset.name.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/es-MX.lproj/QSCatalogPreset.name.strings
@@ -100,8 +100,6 @@
 	<string>Recent Folders (Finder)</string>
 	<key>QSPresetFinderSpecificSearchPlaces</key>
 	<string>Finder Specific Search Places</string>
-	<key>QSPresetFinderToolbarItems</key>
-	<string>Finder Toolbar Items</string>
 	<key>QSPresetFirefoxBookmarks</key>
 	<string>Firefox Bookmarks</string>
 	<key>QSPresetGlobalPrefsRecentFolders</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/es.lproj/QSCatalogPreset.name.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/es.lproj/QSCatalogPreset.name.strings
@@ -100,8 +100,6 @@
     <string>Carpetas Recientes (Finder)</string>
     <key>QSPresetFinderSpecificSearchPlaces</key>
     <string>Lugares de Búsqueda Específicos del Finder</string>
-    <key>QSPresetFinderToolbarItems</key>
-    <string>Ítems de la Barra de Herramientas del Finder</string>
     <key>QSPresetFirefoxBookmarks</key>
     <string>Marcadores de Firefox</string>
     <key>QSPresetGlobalPrefsRecentFolders</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/et.lproj/QSCatalogPreset.name.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/et.lproj/QSCatalogPreset.name.strings
@@ -100,8 +100,6 @@
 	<string>Recent Folders (Finder)</string>
 	<key>QSPresetFinderSpecificSearchPlaces</key>
 	<string>Finder Specific Search Places</string>
-	<key>QSPresetFinderToolbarItems</key>
-	<string>Finder Toolbar Items</string>
 	<key>QSPresetFirefoxBookmarks</key>
 	<string>Firefox Bookmarks</string>
 	<key>QSPresetGlobalPrefsRecentFolders</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/fi.lproj/QSCatalogPreset.name.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/fi.lproj/QSCatalogPreset.name.strings
@@ -100,8 +100,6 @@
 	<string>Recent Folders (Finder)</string>
 	<key>QSPresetFinderSpecificSearchPlaces</key>
 	<string>Finder Specific Search Places</string>
-	<key>QSPresetFinderToolbarItems</key>
-	<string>Finder Toolbar Items</string>
 	<key>QSPresetFirefoxBookmarks</key>
 	<string>Firefox Bookmarks</string>
 	<key>QSPresetGlobalPrefsRecentFolders</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/fr.lproj/QSCatalogPreset.name.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/fr.lproj/QSCatalogPreset.name.strings
@@ -100,8 +100,6 @@
     <string>Dossiers récents (Finder)</string>
     <key>QSPresetFinderSpecificSearchPlaces</key>
     <string>Emplacements spécifiques de recherche du Finder</string>
-    <key>QSPresetFinderToolbarItems</key>
-    <string>Éléments de la barre d&apos;outils du Finder</string>
     <key>QSPresetFirefoxBookmarks</key>
     <string>Marque-pages de Firefox</string>
     <key>QSPresetGlobalPrefsRecentFolders</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/id.lproj/QSCatalogPreset.name.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/id.lproj/QSCatalogPreset.name.strings
@@ -100,8 +100,6 @@
     <string>Folder Terakhir (Finder)</string>
     <key>QSPresetFinderSpecificSearchPlaces</key>
     <string>Tempat Pencarian Khusus Finder</string>
-    <key>QSPresetFinderToolbarItems</key>
-    <string>Butir Toolbar Finder</string>
     <key>QSPresetFirefoxBookmarks</key>
     <string>Penanda Firefox</string>
     <key>QSPresetGlobalPrefsRecentFolders</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/it.lproj/QSCatalogPreset.name.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/it.lproj/QSCatalogPreset.name.strings
@@ -100,8 +100,6 @@
     <string>Cartelle Recenti (Finder)</string>
     <key>QSPresetFinderSpecificSearchPlaces</key>
     <string>Posti Specifici di Ricerca Finder</string>
-    <key>QSPresetFinderToolbarItems</key>
-    <string>Elementi Barra Strumenti Finder</string>
     <key>QSPresetFirefoxBookmarks</key>
     <string>Segnalibri Firefox</string>
     <key>QSPresetGlobalPrefsRecentFolders</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/ja.lproj/QSCatalogPreset.name.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/ja.lproj/QSCatalogPreset.name.strings
@@ -100,8 +100,6 @@
 	<string>Recent Folders (Finder)</string>
 	<key>QSPresetFinderSpecificSearchPlaces</key>
 	<string>Finder Specific Search Places</string>
-	<key>QSPresetFinderToolbarItems</key>
-	<string>Finder Toolbar Items</string>
 	<key>QSPresetFirefoxBookmarks</key>
 	<string>Firefox Bookmarks</string>
 	<key>QSPresetGlobalPrefsRecentFolders</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/ko.lproj/QSCatalogPreset.name.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/ko.lproj/QSCatalogPreset.name.strings
@@ -100,8 +100,6 @@
     <string>최근 폴더 (Finder)</string>
     <key>QSPresetFinderSpecificSearchPlaces</key>
     <string>Finder 한정 검색 구역</string>
-    <key>QSPresetFinderToolbarItems</key>
-    <string>Finder 도구 상자 항목</string>
     <key>QSPresetFirefoxBookmarks</key>
     <string>Firefox 책갈피</string>
     <key>QSPresetGlobalPrefsRecentFolders</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/nb-NO.lproj/QSCatalogPreset.name.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/nb-NO.lproj/QSCatalogPreset.name.strings
@@ -100,8 +100,6 @@
 	<string>Recent Folders (Finder)</string>
 	<key>QSPresetFinderSpecificSearchPlaces</key>
 	<string>Finder Specific Search Places</string>
-	<key>QSPresetFinderToolbarItems</key>
-	<string>Finder Toolbar Items</string>
 	<key>QSPresetFirefoxBookmarks</key>
 	<string>Firefox Bookmarks</string>
 	<key>QSPresetGlobalPrefsRecentFolders</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/nl.lproj/QSCatalogPreset.name.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/nl.lproj/QSCatalogPreset.name.strings
@@ -100,8 +100,6 @@
 	<string>Recent Folders (Finder)</string>
 	<key>QSPresetFinderSpecificSearchPlaces</key>
 	<string>Finder Specific Search Places</string>
-	<key>QSPresetFinderToolbarItems</key>
-	<string>Finder Toolbar Items</string>
 	<key>QSPresetFirefoxBookmarks</key>
 	<string>Firefox Bookmarks</string>
 	<key>QSPresetGlobalPrefsRecentFolders</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/pl.lproj/QSCatalogPreset.name.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/pl.lproj/QSCatalogPreset.name.strings
@@ -100,8 +100,6 @@
     <string>Ostatnie katalogi (Finder)</string>
     <key>QSPresetFinderSpecificSearchPlaces</key>
     <string>Typowe miejsca wyszukiwania Findera</string>
-    <key>QSPresetFinderToolbarItems</key>
-    <string>Rzeczy z paska narzędzi Findera</string>
     <key>QSPresetFirefoxBookmarks</key>
     <string>Zakładki Firefoxa</string>
     <key>QSPresetGlobalPrefsRecentFolders</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/pt-BR.lproj/QSCatalogPreset.name.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/pt-BR.lproj/QSCatalogPreset.name.strings
@@ -100,8 +100,6 @@
 	<string>Recent Folders (Finder)</string>
 	<key>QSPresetFinderSpecificSearchPlaces</key>
 	<string>Finder Specific Search Places</string>
-	<key>QSPresetFinderToolbarItems</key>
-	<string>Finder Toolbar Items</string>
 	<key>QSPresetFirefoxBookmarks</key>
 	<string>Firefox Bookmarks</string>
 	<key>QSPresetGlobalPrefsRecentFolders</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/ru.lproj/QSCatalogPreset.name.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/ru.lproj/QSCatalogPreset.name.strings
@@ -100,8 +100,6 @@
     <string>Последние папки (Finder)</string>
     <key>QSPresetFinderSpecificSearchPlaces</key>
     <string>Места поиска Finder</string>
-    <key>QSPresetFinderToolbarItems</key>
-    <string>Элементы тулбара Finder</string>
     <key>QSPresetFirefoxBookmarks</key>
     <string>Закладки Firefox</string>
     <key>QSPresetGlobalPrefsRecentFolders</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/sv.lproj/QSCatalogPreset.name.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/sv.lproj/QSCatalogPreset.name.strings
@@ -100,8 +100,6 @@
     <string>Senaste mappar (Finder)</string>
     <key>QSPresetFinderSpecificSearchPlaces</key>
     <string>Finderspecifika sökvägar</string>
-    <key>QSPresetFinderToolbarItems</key>
-    <string>Finders verktygsfält</string>
     <key>QSPresetFirefoxBookmarks</key>
     <string>Firefox-bokmärken</string>
     <key>QSPresetGlobalPrefsRecentFolders</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/th.lproj/QSCatalogPreset.name.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/th.lproj/QSCatalogPreset.name.strings
@@ -100,8 +100,6 @@
 	<string>Recent Folders (Finder)</string>
 	<key>QSPresetFinderSpecificSearchPlaces</key>
 	<string>Finder Specific Search Places</string>
-	<key>QSPresetFinderToolbarItems</key>
-	<string>Finder Toolbar Items</string>
 	<key>QSPresetFirefoxBookmarks</key>
 	<string>Firefox Bookmarks</string>
 	<key>QSPresetGlobalPrefsRecentFolders</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/tr.lproj/QSCatalogPreset.name.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/tr.lproj/QSCatalogPreset.name.strings
@@ -100,8 +100,6 @@
     <string>Son Klasörler (Finder)</string>
     <key>QSPresetFinderSpecificSearchPlaces</key>
     <string>Finder Belirli Arama Konumları</string>
-    <key>QSPresetFinderToolbarItems</key>
-    <string>Finder Araç Çubuğu Öğeleri</string>
     <key>QSPresetFirefoxBookmarks</key>
     <string>Firefox Yer İmleri</string>
     <key>QSPresetGlobalPrefsRecentFolders</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/zh-Hans.lproj/QSCatalogPreset.name.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/zh-Hans.lproj/QSCatalogPreset.name.strings
@@ -100,8 +100,6 @@
     <string>最近使用的文件夹(Finder)</string>
     <key>QSPresetFinderSpecificSearchPlaces</key>
     <string>Finder特定搜索位置</string>
-    <key>QSPresetFinderToolbarItems</key>
-    <string>Finder工具栏项目</string>
     <key>QSPresetFirefoxBookmarks</key>
     <string>Firefox书签</string>
     <key>QSPresetGlobalPrefsRecentFolders</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/zh-Hant.lproj/QSCatalogPreset.name.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/zh-Hant.lproj/QSCatalogPreset.name.strings
@@ -100,8 +100,6 @@
     <string>最近使用過的資料夾（Finder）</string>
     <key>QSPresetFinderSpecificSearchPlaces</key>
     <string>Finder 專屬搜尋位置</string>
-    <key>QSPresetFinderToolbarItems</key>
-    <string>Finder 工具列項目</string>
     <key>QSPresetFirefoxBookmarks</key>
     <string>Firefox 書籤</string>
     <key>QSPresetGlobalPrefsRecentFolders</key>


### PR DESCRIPTION
…thanks to a recent comment on #683.

Apple clearly can’t decide where they want to store these things.

Should we just get rid of the Toolbar Items preset? It doesn’t work either and I’m not sure if it’s even a thing you can do now.