### PR TITLE
restore the logic of catalogSetIndexPath

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSCatalogEntry.m
+++ b/Quicksilver/Code-QuickStepCore/QSCatalogEntry.m
@@ -386,7 +386,15 @@ NSString *const QSCatalogEntryInvalidatedNotification = @"QSCatalogEntryInvalida
 }
 
 - (NSIndexPath *)catalogSetIndexPath {
-    return self.catalogIndexPath;
+    NSArray *anc = self.ancestors;
+    NSUInteger i;
+    NSUInteger index;
+    NSIndexPath *p = nil;
+    for (i = 1; i < (anc.count - 1); i++) {
+        index = [[anc[i] children] indexOfObject:anc[i+1]];
+        p = (p) ? [p indexPathByAddingIndex:index] : [NSIndexPath indexPathWithIndex:index];
+    }
+    return p;
 }
 
 - (NSArray *)ancestors {


### PR DESCRIPTION
I ran across this the other day and `git bisect` led me to acf09391cc44367905d8792a93fea47305f22fb8

I had to look closely to find the problem, but those methods weren’t actually duplicates. One of the `for` loops starts at 0 and the other starts at 1. Maybe they could be consolidated into one that takes an argument, but for now, it works.