### PR TITLE
allow type-specific smart spacebar behavior

### DIFF
--- a/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
@@ -32,6 +32,7 @@
 #define pUserKeyBindingsPath QSApplicationSupportSubPath(@"KeyBindings.qskeys", NO)
 #define MAX_HISTORY_COUNT 20
 #define SEARCH_RESULT_DELAY 0.05f
+#define kQSSmartSpace @"smartspace"
 
 NSMutableDictionary *bindingsDict = nil;
 
@@ -1337,7 +1338,7 @@ NSMutableDictionary *bindingsDict = nil;
     QSAction *action = [[self actionSelector] objectValue];
     if (behavior == 7) {
         // override smart defaults with type-specific behavior (if defined)
-        NSNumber *typeBehavior = [[[QSReg tableNamed:@"QSTypeDefinitions"] objectForKey:[newSelectedObject primaryType]] objectForKey:@"smartspace"];
+        NSNumber *typeBehavior = [[[QSReg tableNamed:@"QSTypeDefinitions"] objectForKey:[newSelectedObject primaryType]] objectForKey:kQSSmartSpace];
         if (typeBehavior) {
             behavior = [typeBehavior integerValue];
         }

--- a/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
@@ -1333,8 +1333,15 @@ NSMutableDictionary *bindingsDict = nil;
 {
 	NSInteger behavior = [[NSUserDefaults standardUserDefaults] integerForKey:@"QSSearchSpaceBarBehavior"];
 
-    QSObject * newSelectedObject = [[super objectValue] resolvedObject];
+    QSObject *newSelectedObject = [[super objectValue] resolvedObject];
     QSAction *action = [[self actionSelector] objectValue];
+    if (behavior == 7) {
+        // override smart defaults with type-specific behavior (if defined)
+        NSNumber *typeBehavior = [[[QSReg tableNamed:@"QSTypeDefinitions"] objectForKey:[newSelectedObject primaryType]] objectForKey:@"smartspace"];
+        if (typeBehavior) {
+            behavior = [typeBehavior integerValue];
+        }
+    }
 
 	switch(behavior) {
 		case 1: //Normal
@@ -1376,8 +1383,6 @@ NSMutableDictionary *bindingsDict = nil;
             }
             // Show child contents but only if object isn't a URL or text file
             else if ([newSelectedObject hasChildren] &&
-                    ![[newSelectedObject primaryType] isEqualToString:QSURLType] &&
-                    ![[newSelectedObject primaryType] isEqualToString:QSSearchURLType] &&
                     !QSTypeConformsTo([newSelectedObject fileUTI], (__bridge NSString *)kUTTypePlainText))
             {
                 [self moveRight:sender];

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/QSCorePlugIn-Info.plist
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/QSCorePlugIn-Info.plist
@@ -2069,6 +2069,8 @@
 				<string>DefaultBookmarkIcon</string>
 				<key>name</key>
 				<string>URLs</string>
+				<key>smartspace</key>
+				<integer>6</integer>
 			</dict>
 			<key>qs.process</key>
 			<dict>


### PR DESCRIPTION
A small enhancement to address some of the concerns raised in the discussion on #925.

Basically, for any type in `QSTypeDefinitions`, in addition to the name and icon, you can also specify an integer for one of the existing spacebar behaviors.

This made the special-case code for URLs unnecessary, so I removed it. I’ve added the necessary entry for URLs to the plist in the core plug-in. If this is merged, I’ll also add something for search URLs to the web search plug-ins, and iTunes tracks in that plug-in.

I’ll document the new key and its possible values in the plug-in ref, too.