### PR TITLE
Fix typing / quickly. Fixes #2077

### DIFF
--- a/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
@@ -1158,15 +1158,12 @@ NSMutableDictionary *bindingsDict = nil;
 	
 	NSEvent *upEvent = [NSApp nextEventMatchingMask:NSKeyUpMask untilDate:[NSDate dateWithTimeIntervalSinceNow:0.5] inMode:NSDefaultRunLoopMode dequeue:YES];
 	
-	// Is there a key up from the '/' character after 0.25s
-	if ([[upEvent charactersIgnoringModifiers] isEqualToString:@"/"]) {
+	if (upEvent) {
 		[self moveRight:self];
 	// If '/' is still held down (i.e. no key up in the 0.5s passed), go to root
-	} else if(!upEvent) {
+	} else {
 		[self setObjectValue:[QSObject fileObjectWithPath:@"/"]];
 		upEvent = [NSApp nextEventMatchingMask:NSKeyUpMask untilDate:[NSDate dateWithTimeIntervalSinceNow:0.25] inMode:NSDefaultRunLoopMode dequeue:YES];
-		if (!upEvent)
-			[self moveRight:self];
 	}
     
 	return YES;

--- a/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
@@ -1163,7 +1163,6 @@ NSMutableDictionary *bindingsDict = nil;
 	// If '/' is still held down (i.e. no key up in the 0.5s passed), go to root
 	} else {
 		[self setObjectValue:[QSObject fileObjectWithPath:@"/"]];
-		upEvent = [NSApp nextEventMatchingMask:NSKeyUpMask untilDate:[NSDate dateWithTimeIntervalSinceNow:0.25] inMode:NSDefaultRunLoopMode dequeue:YES];
 	}
     
 	return YES;


### PR DESCRIPTION
Basically if anything is typed immediately before the slash (not just a slash), then it's OK to drill down (I think).

I also got rid of one `if()` for the case where `/` is long pressed. I didn't like the fact that it would immediately drill down into 'Macintosh HD' if you held `/` for long enough. I'm happy for this to be changed back though if there's a case for it