### PR TITLE
only store “chosen” objects in history

### DIFF
--- a/Quicksilver/Code-App/QSController.h
+++ b/Quicksilver/Code-App/QSController.h
@@ -66,6 +66,7 @@
 
 - (NSString *)crashReportPath;
 - (void)showDockIcon;
+- (void)clearHistory;
 
 @end
 

--- a/Quicksilver/Code-App/QSController.m
+++ b/Quicksilver/Code-App/QSController.m
@@ -791,6 +791,11 @@ static QSController *defaultController = nil;
 /* Deprecated. It's defined in Core Plugin */
 - (id) finderProxy { return [QSReg performSelector:@selector(FSBrowserMediator)]; }
 
+- (void)clearHistory
+{
+	[[[self interfaceController] dSelector] clearHistory];
+}
+
 @end
 
 @implementation QSController (Application)

--- a/Quicksilver/Code-QuickStepCore/QSCommand.m
+++ b/Quicksilver/Code-QuickStepCore/QSCommand.m
@@ -472,7 +472,7 @@ NSTimeInterval QSTimeIntervalForString(NSString *intervalString) {
 			 remove objects selected by the comma trick before the action was run.) */
 			[controller clearObjectView:[controller dSelector]];
 			// put the result in the first pane, results list, and history
-			[[controller dSelector] performSelectorOnMainThread:@selector(setObjectValue:) withObject:returnValue waitUntilDone:YES];
+			[[controller dSelector] performSelectorOnMainThread:@selector(redisplayObjectValue:) withObject:returnValue waitUntilDone:YES];
 			[[controller dSelector] updateHistory];
 			if (actionObject) {
 				if ([actionObject isKindOfClass:[QSRankedObject class]] && [(QSRankedObject *)actionObject object]) {

--- a/Quicksilver/Code-QuickStepCore/QSCommand.m
+++ b/Quicksilver/Code-QuickStepCore/QSCommand.m
@@ -471,8 +471,9 @@ NSTimeInterval QSTimeIntervalForString(NSString *intervalString) {
 			/* (The main object would get replaced anyway. This is only done to
 			 remove objects selected by the comma trick before the action was run.) */
 			[controller clearObjectView:[controller dSelector]];
-			// put the result in the first pane and in the results list
+			// put the result in the first pane, results list, and history
 			[[controller dSelector] performSelectorOnMainThread:@selector(setObjectValue:) withObject:returnValue waitUntilDone:YES];
+			[[controller dSelector] updateHistory];
 			if (actionObject) {
 				if ([actionObject isKindOfClass:[QSRankedObject class]] && [(QSRankedObject *)actionObject object]) {
 					QSAction* rankedAction = [(QSRankedObject *)actionObject object];

--- a/Quicksilver/Code-QuickStepCore/QSObject.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject.m
@@ -83,8 +83,6 @@ NSSize QSMaxIconSize;
   }
 	if (self == anObject) return YES;
 	if (![[self identifier] isEqualToString:[anObject identifier]]) return NO;
-	if ([self primaryObject])
-		return [[self primaryObject] isEqual:[anObject primaryObject]];
 	for(NSString *key in data) {
 		if (![[data objectForKey:key] isEqual:[anObject objectForType:key]]) return NO;
 	}

--- a/Quicksilver/Code-QuickStepCore/QSObject.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject.m
@@ -82,7 +82,7 @@ NSSize QSMaxIconSize;
     anObject = [anObject object];
   }
 	if (self == anObject) return YES;
-	if (![[self identifier] isEqualToString:[anObject identifier]]) return NO;
+	if ([self identifier] && ![[self identifier] isEqualToString:[anObject identifier]]) return NO;
 	if ([self count] > 1) {
 		if ([self count] != [(QSObject *)anObject count]) {
 			return NO;

--- a/Quicksilver/Code-QuickStepCore/QSObject.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject.m
@@ -82,7 +82,7 @@ NSSize QSMaxIconSize;
     anObject = [anObject object];
   }
 	if (self == anObject) return YES;
-	if ([self identifier] && ![[self identifier] isEqualToString:[anObject identifier]]) return NO;
+	if (([self identifier] || [anObject identifier]) && ![[self identifier] isEqualToString:[anObject identifier]]) return NO;
 	if ([self count] > 1) {
 		if ([self count] != [(QSObject *)anObject count]) {
 			return NO;

--- a/Quicksilver/Code-QuickStepCore/QSObject.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject.m
@@ -83,9 +83,6 @@ NSSize QSMaxIconSize;
   }
 	if (self == anObject) return YES;
 	if (![[self identifier] isEqualToString:[anObject identifier]]) return NO;
-	for(NSString *key in data) {
-		if (![[data objectForKey:key] isEqual:[anObject objectForType:key]]) return NO;
-	}
 	if ([self count] > 1) {
 		if ([self count] != [(QSObject *)anObject count]) {
 			return NO;
@@ -94,6 +91,10 @@ NSSize QSMaxIconSize;
 		NSSet *otherObjects = [NSSet setWithArray:[anObject splitObjects]];
 		if (![myObjects isEqualToSet:otherObjects]) {
 			return NO;
+		}
+	} else {
+		for(NSString *key in data) {
+			if (![[data objectForKey:key] isEqual:[anObject objectForType:key]]) return NO;
 		}
 	}
 	return YES;

--- a/Quicksilver/Code-QuickStepCore/QSObject.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject.m
@@ -88,6 +88,18 @@ NSSize QSMaxIconSize;
 	for(NSString *key in data) {
 		if (![[data objectForKey:key] isEqual:[anObject objectForType:key]]) return NO;
 	}
+	if ([self count] > 1) {
+		if ([self count] != [(QSObject *)anObject count]) {
+			return NO;
+		}
+		NSArray *myObjects = [self splitObjects];
+		NSArray *otherObjects = [anObject splitObjects];
+		for (NSUInteger i = 0; i < [self count]; i++) {
+			if (![myObjects[i] isEqual:otherObjects[i]]) {
+				return NO;
+			}
+		}
+	}
 	return YES;
 }
 

--- a/Quicksilver/Code-QuickStepCore/QSObject.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject.m
@@ -90,12 +90,10 @@ NSSize QSMaxIconSize;
 		if ([self count] != [(QSObject *)anObject count]) {
 			return NO;
 		}
-		NSArray *myObjects = [self splitObjects];
-		NSArray *otherObjects = [anObject splitObjects];
-		for (NSUInteger i = 0; i < [self count]; i++) {
-			if (![myObjects[i] isEqual:otherObjects[i]]) {
-				return NO;
-			}
+		NSSet *myObjects = [NSSet setWithArray:[self splitObjects]];
+		NSSet *otherObjects = [NSSet setWithArray:[anObject splitObjects]];
+		if (![myObjects isEqualToSet:otherObjects]) {
+			return NO;
 		}
 	}
 	return YES;

--- a/Quicksilver/Code-QuickStepCore/QSObject_StringHandling.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject_StringHandling.m
@@ -288,6 +288,10 @@
     if ([stringValue isKindOfClass:[NSData class]]) {
         stringValue = [[NSString alloc] initWithData:stringValue encoding:NSUTF8StringEncoding];
     }
+	if ([self count] > 1) {
+		// get the string value for each object in the collection
+		stringValue = [[[self splitObjects] arrayByPerformingSelector:@selector(stringValue)] componentsJoinedByString:@"\n"];
+	}
     if (!stringValue) {
         // Backwards compatibility
         stringValue = [self objectForType:NSStringPboardType];

--- a/Quicksilver/Code-QuickStepInterface/DefaultBindings.qskeys
+++ b/Quicksilver/Code-QuickStepInterface/DefaultBindings.qskeys
@@ -48,6 +48,8 @@
 		<string>encapsulateCommand:</string>
 		<key>⌃⌘[</key>
 		<string>showHistoryObjects</string>
+		<key>⌃⌘]</key>
+		<string>explodeCombinedObject</string>
 		<key>⌃⌘D</key>
 		<string>defineMnemonic:</string>
 		<key>⌃⌥⌘D</key>

--- a/Quicksilver/Code-QuickStepInterface/DefaultBindings.qskeys
+++ b/Quicksilver/Code-QuickStepInterface/DefaultBindings.qskeys
@@ -53,7 +53,7 @@
 		<key>⌃⌥⌘D</key>
 		<string>removeMnemonic:</string>
 		<key>⌥,</key>
-		<string>uncollect:</string>
+		<string>uncollectLast:</string>
 		<key>⌥/</key>
 		<string>selectRoot:</string>
 		<key>⌥⌘G</key>

--- a/Quicksilver/Code-QuickStepInterface/DefaultBindings.qskeys
+++ b/Quicksilver/Code-QuickStepInterface/DefaultBindings.qskeys
@@ -41,6 +41,10 @@
 		<string>goBackward:</string>
 		<key>⌘]</key>
 		<string>goForward:</string>
+		<key>⌃]</key>
+		<string>goForwardInCollection:</string>
+		<key>⌃[</key>
+		<string>goBackwardInCollection:</string>
 		<key>⌘G</key>
 		<string>grabSelection:</string>
 		<key>⌃

--- a/Quicksilver/Code-QuickStepInterface/DefaultBindings.qskeys
+++ b/Quicksilver/Code-QuickStepInterface/DefaultBindings.qskeys
@@ -32,7 +32,7 @@
 		<key>⌃L</key>
 		<string>moveRight:</string>
 		<key>⌃U</key>
-		<string>delete:</string>
+		<string>clearObjectValue</string>
 		<key>;</key>
 		<string>combine:</string>
 		<key>=</key>

--- a/Quicksilver/Code-QuickStepInterface/DefaultBindings.qskeys
+++ b/Quicksilver/Code-QuickStepInterface/DefaultBindings.qskeys
@@ -1,1 +1,69 @@
-<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd"><plist version="1.0"><dict>	<key>QSSearchObjectView</key>	<dict>		<key> </key>		<string>insertSpace:</string>		<key>"</key>		<string>conditionalTransmogrify:</string>		<key>⇧</key>		<string>executeCommandAndContinue:</string>		<key>⇧ </key>		<string>insertSpace:</string>		<key>⇧/</key>		<string>moveLeft:</string>		<key>'</key>		<string>conditionalTransmogrify:</string>		<key>,</key>		<string>collect:</string>		<key>.</key>		<string>transmogrify:</string>		<key>/</key>		<string>moveRight:</string>		<key>⌃H</key>		<string>moveLeft:</string>		<key>⌃K</key>		<string>moveUp:</string>		<key>⌃J</key>		<string>moveDown:</string>		<key>⌃L</key>		<string>moveRight:</string>		<key>⌃U</key>		<string>delete:</string>		<key>;</key>		<string>combine:</string>		<key>=</key>		<string>calculate:</string>		<key>⌘[</key>		<string>goBackward:</string>		<key>⌘]</key>		<string>goForward:</string>		<key>⌘G</key>		<string>grabSelection:</string>		<key>⌃</key>		<string>encapsulateCommand:</string>		<key>⌃⌘[</key>		<string>showHistoryObjects</string>		<key>⌃⌘D</key>		<string>defineMnemonic:</string>		<key>⌃⌥⌘D</key>		<string>removeMnemonic:</string>		<key>⌥,</key>		<string>uncollect:</string>		<key>⌥/</key>		<string>selectRoot:</string>		<key>⌥⌘G</key>		<string>dropSelection:</string>		<key>⌥⌘V</key>		<string>dropClipboard:</string>        <key>⌘Y</key>        <string>togglePreviewPanel:</string>        <key>⌥⌘Y</key>        <string>togglePreviewPanelFullScreen:</string>	</dict></dict></plist>
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>QSSearchObjectView</key>
+	<dict>
+		<key> </key>
+		<string>insertSpace:</string>
+		<key>"</key>
+		<string>conditionalTransmogrify:</string>
+		<key>⇧
+</key>
+		<string>executeCommandAndContinue:</string>
+		<key>⇧ </key>
+		<string>insertSpace:</string>
+		<key>⇧/</key>
+		<string>moveLeft:</string>
+		<key>'</key>
+		<string>conditionalTransmogrify:</string>
+		<key>,</key>
+		<string>collect:</string>
+		<key>.</key>
+		<string>transmogrify:</string>
+		<key>/</key>
+		<string>moveRight:</string>
+		<key>⌃H</key>
+		<string>moveLeft:</string>
+		<key>⌃K</key>
+		<string>moveUp:</string>
+		<key>⌃J</key>
+		<string>moveDown:</string>
+		<key>⌃L</key>
+		<string>moveRight:</string>
+		<key>⌃U</key>
+		<string>delete:</string>
+		<key>;</key>
+		<string>combine:</string>
+		<key>=</key>
+		<string>calculate:</string>
+		<key>⌘[</key>
+		<string>goBackward:</string>
+		<key>⌘]</key>
+		<string>goForward:</string>
+		<key>⌘G</key>
+		<string>grabSelection:</string>
+		<key>⌃
+</key>
+		<string>encapsulateCommand:</string>
+		<key>⌃⌘[</key>
+		<string>showHistoryObjects</string>
+		<key>⌃⌘D</key>
+		<string>defineMnemonic:</string>
+		<key>⌃⌥⌘D</key>
+		<string>removeMnemonic:</string>
+		<key>⌥,</key>
+		<string>uncollect:</string>
+		<key>⌥/</key>
+		<string>selectRoot:</string>
+		<key>⌥⌘G</key>
+		<string>dropSelection:</string>
+		<key>⌥⌘V</key>
+		<string>dropClipboard:</string>
+        <key>⌘Y</key>
+        <string>togglePreviewPanel:</string>
+        <key>⌥⌘Y</key>
+        <string>togglePreviewPanelFullScreen:</string>
+	</dict>
+</dict>
+</plist>

--- a/Quicksilver/Code-QuickStepInterface/QSCollectingSearchObjectView.h
+++ b/Quicksilver/Code-QuickStepInterface/QSCollectingSearchObjectView.h
@@ -56,4 +56,16 @@
  **/
 - (void)redisplayObjectValue:(QSObject *)newObject;
 
+/**
+ Select the next object in a collection
+ @param sender the calling object (unused)
+ **/
+- (IBAction)goForwardInCollection:(id)sender;
+
+/**
+ Select the previous object in a collection
+ @param sender the calling object (unused)
+ **/
+- (IBAction)goBackwardInCollection:(id)sender;
+
 @end

--- a/Quicksilver/Code-QuickStepInterface/QSCollectingSearchObjectView.h
+++ b/Quicksilver/Code-QuickStepInterface/QSCollectingSearchObjectView.h
@@ -28,9 +28,32 @@
 - (CGFloat) collectionSpace;
 - (void)setCollectionSpace:(CGFloat)value;
 
-
+/**
+ Add the current object to the collection.
+ @param sender the calling object (unused)
+ **/
 - (IBAction)collect:(id)sender;
+/**
+ Remove the most recently selected object from the collection
+ and select the next most recent object.
+ @param sender the calling object (unused)
+ **/
 - (IBAction)uncollect:(id)sender;
+/**
+ Remove the most recently selected object from the collection,
+ but leave the current selection in place.
+ @param sender the calling object (unused)
+ **/
 - (IBAction)uncollectLast:(id)sender;
+
+/**
+ Combined objects are split and the components are added to the
+ collection, then the last object is selected. This improves the
+ appearance of combined objects when they're selected and allows
+ users to run uncollect: and uncollectLast: on the selection.
+ For a single object, acts just like selectObjectValue:
+ @param newObject the object to select
+ **/
+- (void)redisplayObjectValue:(QSObject *)newObject;
 
 @end

--- a/Quicksilver/Code-QuickStepInterface/QSCollectingSearchObjectView.h
+++ b/Quicksilver/Code-QuickStepInterface/QSCollectingSearchObjectView.h
@@ -14,7 +14,7 @@
 
 @interface QSCollectingSearchObjectView : QSSearchObjectView {
 	NSMutableArray *collection;
-	BOOL 			collecting;
+	BOOL 			collecting; // is the user actively collecting things with comma?
 	NSRectEdge		collectionEdge;
 	CGFloat			collectionSpace;
 }

--- a/Quicksilver/Code-QuickStepInterface/QSCollectingSearchObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSCollectingSearchObjectView.m
@@ -40,7 +40,7 @@
 			collectRect.origin.x += 8;
 		NSInteger i;
 		CGFloat iconSize = collectionSpace?collectionSpace:16;
-		CGFloat opacity = collecting?1.0:0.5;
+		CGFloat opacity = collecting?1.0:0.75;
 		QSObject *object;
 		for (i = 0; i<count; i++) {
 			object = [collection objectAtIndex:i];

--- a/Quicksilver/Code-QuickStepInterface/QSCollectingSearchObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSCollectingSearchObjectView.m
@@ -56,8 +56,8 @@
 	if (!collecting) collecting = YES;
 	if ([super objectValue] && ![collection containsObject:[super objectValue]]) {
 		[collection addObject:[super objectValue]];
-        [[[super controller] dSelector] updateHistory];
-        [[[super controller] dSelector] saveMnemonic];
+		[self updateHistory];
+		[self saveMnemonic];
 		[self setNeedsDisplay:YES];
 	}
 	[self setShouldResetSearchString:YES];

--- a/Quicksilver/Code-QuickStepInterface/QSCollectingSearchObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSCollectingSearchObjectView.m
@@ -199,6 +199,7 @@
 {
 	if ([newObject count] > 1) {
 		collection = [[newObject splitObjects] mutableCopy];
+		[collection makeObjectsPerformSelector:@selector(loadIcon)];
 		newObject = [collection lastObject];
 		collecting = YES;
 	} else {

--- a/Quicksilver/Code-QuickStepInterface/QSCollectingSearchObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSCollectingSearchObjectView.m
@@ -102,7 +102,7 @@
 }
 - (void)deleteBackward:(id)sender {
 	if ([collection count] && ![partialString length]) {
-		[self uncollectLast:sender];
+		[self uncollect:sender];
 	} else {
 		[super deleteBackward:sender];
     }

--- a/Quicksilver/Code-QuickStepInterface/QSCollectingSearchObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSCollectingSearchObjectView.m
@@ -101,6 +101,25 @@
 - (BOOL)objectIsInCollection:(QSObject *)thisObject {
 	return [collection containsObject:thisObject];
 }
+- (void)explodeCombinedObject
+{
+	QSObject *selected = [super objectValue];
+	NSMutableArray *components;
+	if ([collection count]) {
+		components = [collection mutableCopy];
+	} else {
+		components = [[selected splitObjects] mutableCopy];
+		selected = nil;
+	}
+	if (selected && ![components containsObject:selected]) {
+		[components addObject:selected];
+	}
+	if ([components count] <= 1) {
+		NSBeep();
+		return;
+	}
+	[[self controller] showArray:components];
+}
 - (void)deleteBackward:(id)sender {
 	if ([collection count] && ![partialString length]) {
 		[self uncollect:sender];

--- a/Quicksilver/Code-QuickStepInterface/QSCollectingSearchObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSCollectingSearchObjectView.m
@@ -134,6 +134,18 @@
     
 	[super setObjectValue:newObject];
 }
+- (void)redisplayObjectValue:(QSObject *)newObject
+{
+	if ([newObject count] > 1) {
+		collection = [[newObject splitObjects] mutableCopy];
+		newObject = [collection lastObject];
+		[collection removeObject:newObject];
+		collecting = YES;
+	} else {
+		collecting = NO;
+	}
+	[self selectObjectValue:newObject];
+}
 - (NSRectEdge)collectionEdge {
 	return collectionEdge;
 }

--- a/Quicksilver/Code-QuickStepInterface/QSCollectingSearchObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSCollectingSearchObjectView.m
@@ -63,10 +63,17 @@
 	[self setShouldResetSearchString:YES];
 }
 - (IBAction)uncollect:(id)sender { //Removes an object to a collection
-	if ([collection count])
+	NSInteger position = -1;
+	if ([collection count]) {
+		position = [collection indexOfObject:[super objectValue]] - 1;
 		[collection removeObject:[super objectValue]];
+	}
 	if ([collection count] <= 1) collecting = NO;
-	[self selectObjectValue:[collection lastObject]];
+	if (position >= 0) {
+		[self selectObjectValue:[collection objectAtIndex:position]];
+	} else {
+		[self selectObjectValue:[collection lastObject]];
+	}
 	[self clearSearch];
 	[self setNeedsDisplay:YES];
 }

--- a/Quicksilver/Code-QuickStepInterface/QSCollectingSearchObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSCollectingSearchObjectView.m
@@ -53,7 +53,7 @@
 	}
 }
 - (IBAction)collect:(id)sender { //Adds additional objects to a collection
-	if (!collecting) collecting = YES;
+	collecting = YES;
 	if ([super objectValue] && ![collection containsObject:[super objectValue]]) {
 		[collection addObject:[super objectValue]];
 		[self updateHistory];
@@ -68,11 +68,14 @@
 		position = [collection indexOfObject:[super objectValue]] - 1;
 		[collection removeObject:[super objectValue]];
 	}
-	if ([collection count] <= 1) collecting = NO;
 	if (position >= 0) {
 		[self selectObjectValue:[collection objectAtIndex:position]];
 	} else {
 		[self selectObjectValue:[collection lastObject]];
+	}
+	if ([collection count] <= 1) {
+		// stop collecting if there's only one object
+		[self emptyCollection:nil];
 	}
 	[self clearSearch];
 	[self setNeedsDisplay:YES];
@@ -80,8 +83,10 @@
 - (IBAction)uncollectLast:(id)sender { //Removes an object to a collection
 	if ([collection count])
 		[collection removeLastObject];
-	if ([collection count] <= 1)
-		collecting = NO;
+	if ([collection count] <= 1) {
+		// stop collecting if there's only one object
+		[self emptyCollection:nil];
+	}
 	[self setNeedsDisplay:YES];
 	//if ([[resultController window] isVisible])
 	//	[resultController->resultTable setNeedsDisplay:YES];}
@@ -101,7 +106,6 @@
 		position++;
 	}
 	// prepare the state of the view
-	collecting = YES;
 	[self clearSearch];
 	// change the selection
 	QSObject *newSelected = [collection objectAtIndex:position];
@@ -122,7 +126,6 @@
 		position--;
 	}
 	// prepare the state of the view
-	collecting = YES;
 	[self clearSearch];
 	// change the selection
 	QSObject *newSelected = [collection objectAtIndex:position];
@@ -139,7 +142,6 @@
 - (IBAction)combine:(id)sender { //Resolve a collection as a single object
 	[self setObjectValue:[self objectValue]];
 	[self emptyCollection:sender];
-	collecting = NO;
 }
 - (id)objectValue {
 	if ([collection count])
@@ -208,10 +210,10 @@
 		collection = [[newObject splitObjects] mutableCopy];
 		[collection makeObjectsPerformSelector:@selector(loadIcon)];
 		newObject = [collection lastObject];
-		collecting = YES;
 	} else {
-		collecting = NO;
+		[self emptyCollection:nil];
 	}
+	collecting = NO;
 	[self selectObjectValue:newObject];
 }
 - (NSRectEdge)collectionEdge {

--- a/Quicksilver/Code-QuickStepInterface/QSCollectingSearchObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSCollectingSearchObjectView.m
@@ -65,14 +65,14 @@
 - (IBAction)uncollect:(id)sender { //Removes an object to a collection
 	if ([collection count])
 		[collection removeObject:[super objectValue]];
-	if (![collection count]) collecting = NO;
+	if ([collection count] <= 1) collecting = NO;
 	[self selectObjectValue:[collection lastObject]];
 	[self setNeedsDisplay:YES];
 }
 - (IBAction)uncollectLast:(id)sender { //Removes an object to a collection
 	if ([collection count])
 		[collection removeLastObject];
-	if (![collection count])
+	if ([collection count] <= 1)
 		collecting = NO;
 	[self setNeedsDisplay:YES];
 	//if ([[resultController window] isVisible])

--- a/Quicksilver/Code-QuickStepInterface/QSCollectingSearchObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSCollectingSearchObjectView.m
@@ -200,7 +200,6 @@
 	if ([newObject count] > 1) {
 		collection = [[newObject splitObjects] mutableCopy];
 		newObject = [collection lastObject];
-		[collection removeObject:newObject];
 		collecting = YES;
 	} else {
 		collecting = NO;

--- a/Quicksilver/Code-QuickStepInterface/QSCollectingSearchObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSCollectingSearchObjectView.m
@@ -67,6 +67,7 @@
 		[collection removeObject:[super objectValue]];
 	if ([collection count] <= 1) collecting = NO;
 	[self selectObjectValue:[collection lastObject]];
+	[self clearSearch];
 	[self setNeedsDisplay:YES];
 }
 - (IBAction)uncollectLast:(id)sender { //Removes an object to a collection

--- a/Quicksilver/Code-QuickStepInterface/QSCollectingSearchObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSCollectingSearchObjectView.m
@@ -56,6 +56,7 @@
 	if (!collecting) collecting = YES;
 	if ([super objectValue] && ![collection containsObject:[super objectValue]]) {
 		[collection addObject:[super objectValue]];
+        [[[super controller] dSelector] updateHistory];
         [[[super controller] dSelector] saveMnemonic];
 		[self setNeedsDisplay:YES];
 	}

--- a/Quicksilver/Code-QuickStepInterface/QSCollectingSearchObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSCollectingSearchObjectView.m
@@ -52,6 +52,13 @@
 		[super drawRect:rect];
 	}
 }
+- (void)insertText:(id)aString replacementRange:(NSRange)replacementRange
+{
+	if (!collecting && ![partialString length]) {
+		[self emptyCollection:nil];
+	}
+	[super insertText:aString replacementRange:replacementRange];
+}
 - (IBAction)collect:(id)sender { //Adds additional objects to a collection
 	collecting = YES;
 	if ([super objectValue] && ![collection containsObject:[super objectValue]]) {
@@ -181,28 +188,6 @@
 - (void)reset:(id)sender {
 	collecting = NO;
 	[super reset:sender];
-}
-- (void)selectObjectValue:( QSObject *)newObject {
-	if (!collecting)
-		[self emptyCollection:nil];
-	[super selectObjectValue:newObject];
-}
-- (void)setObjectValue:(QSBasicObject *)newObject {
-    if (newObject == [self objectValue]) {
-        return;
-    }
-	if (!collecting) {
-        [self emptyCollection:self];
-    }
-    // If the new object is 'nil' (i.e. the pane has been cleared) then also clear the underlying text editor (for the 1st pane only)
-    if (!newObject && self == [[super controller] dSelector]) {
-        NSTextView *editor = (NSTextView *)[[self window] fieldEditor:NO forObject: self];
-        if (editor) {
-            [editor setString:@""];
-        }
-    }
-    
-	[super setObjectValue:newObject];
 }
 - (void)redisplayObjectValue:(QSObject *)newObject
 {

--- a/Quicksilver/Code-QuickStepInterface/QSCollectingSearchObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSCollectingSearchObjectView.m
@@ -66,6 +66,7 @@
 	if ([collection count])
 		[collection removeObject:[super objectValue]];
 	if (![collection count]) collecting = NO;
+	[self selectObjectValue:[collection lastObject]];
 	[self setNeedsDisplay:YES];
 }
 - (IBAction)uncollectLast:(id)sender { //Removes an object to a collection

--- a/Quicksilver/Code-QuickStepInterface/QSCollectingSearchObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSCollectingSearchObjectView.m
@@ -79,6 +79,48 @@
 	//if ([[resultController window] isVisible])
 	//	[resultController->resultTable setNeedsDisplay:YES];}
 }
+- (IBAction)goForwardInCollection:(id)sender
+{
+	if ([collection count] <= 1) {
+		return;
+	}
+	QSObject *selected = [super objectValue];
+	NSUInteger position = [collection indexOfObject:selected];
+	if (position == [collection count] - 1 || position == NSNotFound) {
+		// end of the list or not in list at all, wrap to beginning
+		position = 0;
+	} else {
+		// go forward one
+		position++;
+	}
+	// prepare the state of the view
+	collecting = YES;
+	[self clearSearch];
+	// change the selection
+	QSObject *newSelected = [collection objectAtIndex:position];
+	[self selectObjectValue:newSelected];
+}
+- (IBAction)goBackwardInCollection:(id)sender
+{
+	if ([collection count] <= 1) {
+		return;
+	}
+	QSObject *selected = [super objectValue];
+	NSUInteger position = [collection indexOfObject:selected];
+	if (position == 0 || position == NSNotFound) {
+		// beginning of the list or not in list at all, wrap to end
+		position = [collection count] - 1;
+	} else {
+		// go back one
+		position--;
+	}
+	// prepare the state of the view
+	collecting = YES;
+	[self clearSearch];
+	// change the selection
+	QSObject *newSelected = [collection objectAtIndex:position];
+	[self selectObjectValue:newSelected];
+}
 - (void)clearObjectValue {
 	[self emptyCollection:nil];
 	[super clearObjectValue];

--- a/Quicksilver/Code-QuickStepInterface/QSInterfaceController.m
+++ b/Quicksilver/Code-QuickStepInterface/QSInterfaceController.m
@@ -107,6 +107,10 @@
 
 	[aSelector setSearchMode:SearchFilter];
 	[aSelector setAllowNonActions:NO];
+	// only store history for the first pane
+	dSelector.recordsHistory = YES;
+	aSelector.recordsHistory = NO;
+	iSelector.recordsHistory = NO;
 
 	[self hideIndirectSelector:nil];
 

--- a/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.h
+++ b/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.h
@@ -29,9 +29,6 @@ typedef NS_ENUM(NSUInteger, QSSearchMode) {
 
 	BOOL validSearch;
 
-    BOOL browsingHistory;
-
-    
 	NSTimer *resetTimer;
 	NSTimer *searchTimer;
 	NSTimer *resultTimer;

--- a/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.h
+++ b/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.h
@@ -95,7 +95,23 @@ typedef NS_ENUM(NSUInteger, QSSearchMode) {
 
 - (void)clearObjectValue;
 - (void)moveSelectionBy:(NSInteger)d;
+/**
+ Resets the current state of the view, then populates the view with
+ a single object. Overrides the method from the superclass.
+ @param newObject the object to select
+ **/
+- (void)setObjectValue:(QSBasicObject *)newObject;
+/**
+ Set the currently selected object. If the object was not previously
+ selected, posts a SearchObjectChanged notification.
+ @param newObject the object to select
+ **/
 - (void)selectObjectValue:(id)newObject ;
+/**
+ Identical to selectObjectValue: in this class. See the interface for
+ QSCollectingSearchObjectView, where this does something useful.
+ @param newObject the object to select
+ **/
 - (void)redisplayObjectValue:(QSObject *)newObject;
 - (void)pageScroll:(NSInteger)direction;
 
@@ -115,6 +131,11 @@ typedef NS_ENUM(NSUInteger, QSSearchMode) {
 
 - (IBAction)toggleResultView:sender;
 - (void)selectIndex:(NSInteger)index;
+/**
+ Select an object from the result array. If the object passed in
+ doesn't exist in the results, nothing happens.
+ @param obj the object to select
+ **/
 - (void)selectObject:(QSBasicObject *)obj;
 - (void)objectIconModified:(NSNotification *)notif;
 - (void)resetString; // update the string on screen when the search is cleared
@@ -205,10 +226,35 @@ typedef NS_ENUM(NSUInteger, QSSearchMode) {
 
 
 @interface QSSearchObjectView (History)
+/**
+ Go forward in the history of used objects
+ @param sender the calling object (unused)
+ **/
 - (void)goForward:(id)sender;
+/**
+ Go backward in the history of used objects
+ @param sender the calling object (unused)
+ **/
 - (void)goBackward:(id)sender;
+/**
+ Add the currently selected object to the history of used objects.
+ If the object is already present in the history, move it to the
+ most recent position. Combined objects are kept in history as-is.
+ 
+ This method also adds each selected object to the Recent Objects
+ catalog entry. Combined objects are split and added individually.
+ **/
 - (void)updateHistory;
+/**
+ Empty the history of used objects.
+ **/
 - (void)clearHistory;
+/**
+ Searches through a QSCollectingSearchObjectView's collection for
+ an object. Always returns NO in a plain QSSearchObjectView.
+ @param thisObject the object to look for
+ @returns YES if the object is in the collection. NO if not.
+ **/
 - (BOOL)objectIsInCollection:(QSObject *)thisObject;
 @end
 

--- a/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.h
+++ b/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.h
@@ -256,6 +256,12 @@ typedef NS_ENUM(NSUInteger, QSSearchMode) {
  @returns YES if the object is in the collection. NO if not.
  **/
 - (BOOL)objectIsInCollection:(QSObject *)thisObject;
+/**
+ Separate a combined object and put the components in the result
+ array. Allows users to view and manage selections. Does nothing
+ in a plain QSSearchObjectView.
+ **/
+- (void)explodeCombinedObject;
 @end
 
 

--- a/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.h
+++ b/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.h
@@ -96,6 +96,7 @@ typedef NS_ENUM(NSUInteger, QSSearchMode) {
 - (void)clearObjectValue;
 - (void)moveSelectionBy:(NSInteger)d;
 - (void)selectObjectValue:(id)newObject ;
+- (void)redisplayObjectValue:(QSObject *)newObject;
 - (void)pageScroll:(NSInteger)direction;
 
 - (NSMutableArray *)sourceArray;

--- a/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.h
+++ b/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.h
@@ -53,7 +53,6 @@ typedef NS_ENUM(NSUInteger, QSSearchMode) {
 	BOOL vFlip;
 	NSText *currentEditor;
 
-	BOOL 			recordsHistory; //ACC
 	NSMutableArray *historyArray;
 	NSInteger 			historyIndex;
 	NSMutableArray *parentStack; // The parents for the current browse session
@@ -88,6 +87,7 @@ typedef NS_ENUM(NSUInteger, QSSearchMode) {
 }
 
 @property (assign) BOOL updatesSilently;
+@property (assign) BOOL recordsHistory;
 @property (strong) QSResultController *resultController;
 @property (strong) QSAction *alternateActionCounterpart;
 @property (strong) NSTextView *textModeEditor;

--- a/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
@@ -563,6 +563,11 @@ NSMutableDictionary *bindingsDict = nil;
 	[[NSNotificationCenter defaultCenter] postNotificationName:@"SearchObjectChanged" object:self];
 }
 
+- (void)redisplayObjectValue:(QSObject *)newObject
+{
+	[self selectObjectValue:newObject];
+}
+
 - (void)clearAll {
     [self clearObjectValue];
 	[self clearHistory];
@@ -1420,7 +1425,7 @@ NSMutableDictionary *bindingsDict = nil;
 	if (!allowNonActions) return;
 	QSObject *newSelection = [self externalSelection];
     
-	[self setObjectValue:newSelection];
+	[self redisplayObjectValue:newSelection];
 }
 
 - (IBAction)dropSelection:(id)sender {
@@ -1640,7 +1645,7 @@ NSMutableDictionary *bindingsDict = nil;
 	[self setSourceArray:[state objectForKey:@"sourceArray"]];
 	[self setResultArray:[state objectForKey:@"resultArray"]];
 	[self setVisibleString:[state objectForKey:@"visibleString"]];
-	[self selectObjectValue:[state objectForKey:@"selection"]];
+	[self redisplayObjectValue:[state objectForKey:@"selection"]];
 }
 
 

--- a/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
@@ -1842,6 +1842,7 @@ NSMutableDictionary *bindingsDict = nil;
         browsing = YES;
         
         [self clearSearch];
+		historyIndex = -1;
         NSInteger defaultMode = [[NSUserDefaults standardUserDefaults] integerForKey:kBrowseMode];
         [self setSearchMode:(defaultMode ? defaultMode : SearchFilter)];
         [self setResultArray:[newObjects mutableCopy]];

--- a/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
@@ -1655,6 +1655,7 @@ NSMutableDictionary *bindingsDict = nil;
 	[self setSourceArray:[state objectForKey:@"sourceArray"]];
 	[self setResultArray:[state objectForKey:@"resultArray"]];
 	[self setVisibleString:[state objectForKey:@"visibleString"]];
+	[self setMatchedString:[state objectForKey:@"visibleString"]];
 	[self redisplayObjectValue:[state objectForKey:@"selection"]];
 }
 
@@ -1669,7 +1670,6 @@ NSMutableDictionary *bindingsDict = nil;
 #ifdef DEBUG
 	if (VERBOSE) NSLog(@"select in history %ld %@", (long)i, [historyArray valueForKeyPath:@"selection.displayName"]);
 #endif
-	[self setMatchedString:nil];
 	if (i<(NSInteger)[(NSArray *)historyArray count])
 		[self setHistoryState:[historyArray objectAtIndex:i]];
 }

--- a/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
@@ -1501,7 +1501,7 @@ NSMutableDictionary *bindingsDict = nil;
 }
 
 - (void)selectAll:(id)sender {
-	[self setObjectValue:[QSObject objectByMergingObjects:resultArray]];
+	[self redisplayObjectValue:[QSObject objectByMergingObjects:resultArray]];
 }
 
 - (void)insertTab:(id)sender {

--- a/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
@@ -1676,7 +1676,7 @@ NSMutableDictionary *bindingsDict = nil;
     historyIndex = -1;
 	if (state) {
 		// if object is already in history, make it most recent
-		NSIndexSet *present = [historyArray indexesOfObjectsPassingTest:^BOOL(NSDictionary *historyObject, NSUInteger idx, BOOL * _Nonnull stop) {
+		NSIndexSet *present = [historyArray indexesOfObjectsPassingTest:^BOOL(NSDictionary *historyObject, NSUInteger idx, BOOL *stop) {
 			return ([objectValue isEqual:[historyObject objectForKey:@"selection"]]);
 		}];
 		[historyArray removeObjectsAtIndexes:present];

--- a/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
@@ -1673,6 +1673,11 @@ NSMutableDictionary *bindingsDict = nil;
 - (void)updateHistory {
 	if (!recordsHistory) return;
     
+    // only store history for the first pane
+    if (self != [self directSelector]) {
+        return;
+    }
+    
     // Only alter the history array if we're not browsing the history
     if (browsingHistory) {
         return;

--- a/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
@@ -1569,6 +1569,7 @@ NSMutableDictionary *bindingsDict = nil;
 }
 - (void)insertText:(id)aString replacementRange:(NSRange)replacementRange {
 	if (![partialString length]) {
+		historyIndex = -1;
 		[self setSearchArray:sourceArray];
 	}
 	[partialString appendString:aString];
@@ -1617,6 +1618,7 @@ NSMutableDictionary *bindingsDict = nil;
 }
 @end
 
+#pragma mark History
 @implementation QSSearchObjectView (History)
 - (void)showHistoryObjects {
 	NSMutableArray *array = [historyArray valueForKey:@"selection"];
@@ -1673,7 +1675,7 @@ NSMutableDictionary *bindingsDict = nil;
 	
     NSDictionary *state = [self historyState];
 
-    historyIndex = -1;
+    historyIndex = 0;
 	if (state) {
 		// if object is already in history, make it most recent
 		NSIndexSet *present = [historyArray indexesOfObjectsPassingTest:^BOOL(NSDictionary *historyObject, NSUInteger idx, BOOL *stop) {

--- a/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
@@ -1452,7 +1452,7 @@ NSMutableDictionary *bindingsDict = nil;
 #pragma mark NSResponder Key Bindings
 - (void)deleteBackward:(id)sender {
     if(defaultBool(kDoubleDeleteClearsObject) && [self matchedString] == nil) {
-        
+		historyIndex = -1;
         [super delete:sender];
     } else {
         [self clearSearch];

--- a/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
@@ -1665,9 +1665,10 @@ NSMutableDictionary *bindingsDict = nil;
 - (void)updateHistory {
 	if (!self.recordsHistory) return;
 	
-    id objectValue = [[[self objectValue] splitObjects] lastObject];
-	if (objectValue) {
-       [QSHist addObject:objectValue];
+    id objectValue = [self objectValue];
+	QSObject *lastObjectValue = [[objectValue splitObjects] lastObject];
+	if (lastObjectValue) {
+       [QSHist addObject:lastObjectValue];
     }
 	
     NSDictionary *state = [self historyState];

--- a/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
@@ -557,7 +557,9 @@ NSMutableDictionary *bindingsDict = nil;
 }
 
 - (void)setObjectValue:(QSBasicObject *)newObject {
-    
+	if (newObject == [self objectValue]) {
+		return;
+	}
     [self hideResultView:self];
     [self clearSearch];
     [parentStack removeAllObjects];

--- a/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
@@ -42,7 +42,7 @@ NSMutableDictionary *bindingsDict = nil;
 
 + (void)initialize {
     if( bindingsDict == nil ) {
-        NSDictionary *defaultBindings = [[NSMutableDictionary alloc] initWithContentsOfFile:[[NSBundle bundleForClass:[QSSearchObjectView class]] pathForResource:@"DefaultBindings" ofType:@"qskeys"]];
+        NSDictionary *defaultBindings = [[NSDictionary alloc] initWithContentsOfFile:[[NSBundle bundleForClass:[QSSearchObjectView class]] pathForResource:@"DefaultBindings" ofType:@"qskeys"]];
         bindingsDict = [[NSMutableDictionary alloc] initWithDictionary:[defaultBindings objectForKey:@"QSSearchObjectView"]];
         [bindingsDict addEntriesFromDictionary:[[NSDictionary dictionaryWithContentsOfFile:pUserKeyBindingsPath] objectForKey:@"QSSearchObjectView"]];
 		// replace \n with \r for compatibility with NDKeyboardLayout

--- a/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
@@ -1639,7 +1639,7 @@ NSMutableDictionary *bindingsDict = nil;
 	[self setSourceArray:[state objectForKey:@"sourceArray"]];
 	[self setResultArray:[state objectForKey:@"resultArray"]];
 	[self setVisibleString:[state objectForKey:@"visibleString"]];
-	[self selectObject:[state objectForKey:@"selection"]];
+	[self selectObjectValue:[state objectForKey:@"selection"]];
 }
 
 

--- a/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
@@ -1720,6 +1720,10 @@ NSMutableDictionary *bindingsDict = nil;
 	return NO;
 }
 
+- (void)explodeCombinedObject
+{
+	return;
+}
 
 @end
 

--- a/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
@@ -1622,8 +1622,7 @@ NSMutableDictionary *bindingsDict = nil;
 @implementation QSSearchObjectView (History)
 - (void)showHistoryObjects {
 	NSMutableArray *array = [historyArray valueForKey:@"selection"];
-	[self setSourceArray:array];
-    [self setResultArray:array];
+	[[self controller] showArray:array];
 }
 
 - (NSDictionary *)historyState {

--- a/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
@@ -45,6 +45,14 @@ NSMutableDictionary *bindingsDict = nil;
         NSDictionary *defaultBindings = [[NSMutableDictionary alloc] initWithContentsOfFile:[[NSBundle bundleForClass:[QSSearchObjectView class]] pathForResource:@"DefaultBindings" ofType:@"qskeys"]];
         bindingsDict = [[NSMutableDictionary alloc] initWithDictionary:[defaultBindings objectForKey:@"QSSearchObjectView"]];
         [bindingsDict addEntriesFromDictionary:[[NSDictionary dictionaryWithContentsOfFile:pUserKeyBindingsPath] objectForKey:@"QSSearchObjectView"]];
+		// replace \n with \r for compatibility with NDKeyboardLayout
+		for (NSString *key in [bindingsDict allKeys]) {
+			if ([key containsString:@"\n"]) {
+				NSString *newKey = [key stringByReplacingOccurrencesOfString:@"\n" withString:@"\r"];
+				bindingsDict[newKey] = bindingsDict[key];
+				[bindingsDict removeObjectForKey:key];
+			}
+		}
     }
 }
 #pragma mark -

--- a/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
@@ -1572,8 +1572,6 @@ NSMutableDictionary *bindingsDict = nil;
 }
 - (void)insertText:(id)aString replacementRange:(NSRange)replacementRange {
 	if (![partialString length]) {
-		[self updateHistory];
-		[self saveMnemonic];
 		[self setSearchArray:sourceArray];
 	}
 	[partialString appendString:aString];
@@ -1848,8 +1846,6 @@ NSMutableDictionary *bindingsDict = nil;
     if ([newObjects count]) {
         browsing = YES;
         
-        [self updateHistory];
-        [self saveMnemonic];
         [self clearSearch];
         NSInteger defaultMode = [[NSUserDefaults standardUserDefaults] integerForKey:kBrowseMode];
         [self setSearchMode:(defaultMode ? defaultMode : SearchFilter)];

--- a/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
@@ -63,7 +63,7 @@ NSMutableDictionary *bindingsDict = nil;
 	sourceArray = nil;
 	searchArray = nil;
 	resultArray = nil;
-	recordsHistory = YES;
+	self.recordsHistory = YES;
 	shouldResetSearchArray = YES;
 	allowNonActions = YES;
 	allowText = YES;
@@ -346,7 +346,7 @@ NSMutableDictionary *bindingsDict = nil;
 - (BOOL)allowNonActions { return allowNonActions;  }
 - (void)setAllowNonActions:(BOOL)flag {
 	allowNonActions = flag;
-	recordsHistory = flag;
+	self.recordsHistory = flag;
 }
 
 - (void)setResultsPadding:(CGFloat)aResultsPadding { resultsPadding = aResultsPadding; }
@@ -1668,19 +1668,12 @@ NSMutableDictionary *bindingsDict = nil;
 }
 
 - (void)updateHistory {
-	if (!recordsHistory) return;
-    
-    // only store history for the first pane
-    if (self != [self directSelector]) {
-        return;
-    }
-    
+	if (!self.recordsHistory) return;
+	
     // Only alter the history array if we're not browsing the history
     if (browsingHistory) {
         return;
     }
-	// [NSDictionary dictionaryWithObjectsAndKeys:[self objectValue] , @"object", nil];
-	//
 
     id objectValue = [[[self objectValue] splitObjects] lastObject];
 	if (objectValue) {

--- a/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
@@ -1682,7 +1682,7 @@ NSMutableDictionary *bindingsDict = nil;
 	// [NSDictionary dictionaryWithObjectsAndKeys:[self objectValue] , @"object", nil];
 	//
 
-    id objectValue = [self objectValue];
+    id objectValue = [[[self objectValue] splitObjects] lastObject];
 	if (objectValue) {
        [QSHist addObject:objectValue];
     }

--- a/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
@@ -558,7 +558,6 @@ NSMutableDictionary *bindingsDict = nil;
 }
 
 - (void)clearObjectValue {
-	[self updateHistory];
     browsingHistory = NO;
 	[super setObjectValue:nil];
 	selection--;
@@ -601,7 +600,6 @@ NSMutableDictionary *bindingsDict = nil;
 
 - (void)selectObject:(QSBasicObject *)obj {
 	NSInteger index = 0;
-	//[self updateHistory];
 	if (obj) {
 		index = (NSInteger)[resultArray indexOfObject:obj];
 		//NSLog(@"index %d %@", index, obj);
@@ -970,10 +968,6 @@ NSMutableDictionary *bindingsDict = nil;
 }
 
 - (BOOL)resignFirstResponder {  
-    
-    if ([self isEqual:[self directSelector]] && [self objectValue]) {
-        [self updateHistory];
-    }
 	[resultTimer invalidate];
 	[self hideResultView:self];
 	[self setShouldResetSearchString:YES];
@@ -1323,6 +1317,8 @@ NSMutableDictionary *bindingsDict = nil;
 }
 
 - (IBAction)shortCircuit:(id)sender {
+	[self updateHistory];
+	[self saveMnemonic];
 	[[self controller] shortCircuit:self];
 	[resultTimer invalidate];
 }
@@ -1577,6 +1573,7 @@ NSMutableDictionary *bindingsDict = nil;
 - (void)insertText:(id)aString replacementRange:(NSRange)replacementRange {
 	if (![partialString length]) {
 		[self updateHistory];
+		[self saveMnemonic];
 		[self setSearchArray:sourceArray];
 	}
 	[partialString appendString:aString];
@@ -1755,8 +1752,9 @@ NSMutableDictionary *bindingsDict = nil;
 
 }
 - (void)moveRight:(id)sender {
+	[self updateHistory];
+	[self saveMnemonic];
 	[self browse:1];
-
 }
 - (void)moveLeft:(id)sender {
 	[self browse:-1];
@@ -1928,6 +1926,8 @@ NSMutableDictionary *bindingsDict = nil;
             // makeKeyAndOrderFront closes the QS interface. This way, the interface stays open behind the preview panel
             [[QLPreviewPanel sharedPreviewPanel] orderFront:nil];
             [[QLPreviewPanel sharedPreviewPanel] makeKeyWindow];
+            [self updateHistory];
+            [self saveMnemonic];
         }
         else {
             NSBeep();

--- a/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
@@ -1673,14 +1673,14 @@ NSMutableDictionary *bindingsDict = nil;
     NSDictionary *state = [self historyState];
 
     historyIndex = -1;
-    if (state) {
-        // Do not add the object to the history if it is already the 1st object
-        if (![historyArray count]
-			|| ![objectValue isEqual:[[historyArray objectAtIndex:0] objectForKey:@"selection"]]
-			) {
-				[historyArray insertObject:state atIndex:0];
-        }
-    }
+	if (state) {
+		// if object is already in history, make it most recent
+		NSIndexSet *present = [historyArray indexesOfObjectsPassingTest:^BOOL(NSDictionary *historyObject, NSUInteger idx, BOOL * _Nonnull stop) {
+			return ([objectValue isEqual:[historyObject objectForKey:@"selection"]]);
+		}];
+		[historyArray removeObjectsAtIndexes:present];
+		[historyArray insertObject:state atIndex:0];
+	}
 
 	if ([historyArray count] >MAX_HISTORY_COUNT) [historyArray removeLastObject];
 //	if (VERBOSE) NSLog(@"history %d items", [historyArray count]);

--- a/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
@@ -1668,7 +1668,8 @@ NSMutableDictionary *bindingsDict = nil;
 	if (!self.recordsHistory) return;
 	
     id objectValue = [self objectValue];
-	QSObject *lastObjectValue = [[objectValue splitObjects] lastObject];
+	// add synonyms to recent objects untouched, split/resolve everything else
+	QSObject *lastObjectValue = [objectValue isProxyObject] && [objectValue objectForMeta:@"target"] ? objectValue : [[objectValue splitObjects] lastObject];
 	if (lastObjectValue) {
        [QSHist addObject:lastObjectValue];
     }

--- a/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
@@ -558,7 +558,6 @@ NSMutableDictionary *bindingsDict = nil;
 }
 
 - (void)clearObjectValue {
-    browsingHistory = NO;
 	[super setObjectValue:nil];
 	selection--;
 	[[NSNotificationCenter defaultCenter] postNotificationName:@"SearchObjectChanged" object:self];
@@ -644,7 +643,6 @@ NSMutableDictionary *bindingsDict = nil;
 - (void)clearSearch {
 	[resetTimer invalidate];
 	[resultTimer invalidate];
-    browsingHistory = NO;
 	[self resetString];
 	[partialString setString:@""];
     
@@ -1475,7 +1473,6 @@ NSMutableDictionary *bindingsDict = nil;
 	if ([[resultController window] isVisible]) {
 		[self hideResultView:self];
 	}
-    browsingHistory = NO;
 	if (browsing) {
 		browsing = NO;
 		[self setSearchMode:SearchFilterAll];
@@ -1668,24 +1665,20 @@ NSMutableDictionary *bindingsDict = nil;
 - (void)updateHistory {
 	if (!self.recordsHistory) return;
 	
-    // Only alter the history array if we're not browsing the history
-    if (browsingHistory) {
-        return;
-    }
-
     id objectValue = [[[self objectValue] splitObjects] lastObject];
 	if (objectValue) {
        [QSHist addObject:objectValue];
     }
-    
+	
     NSDictionary *state = [self historyState];
 
     historyIndex = -1;
     if (state) {
         // Do not add the object to the history if it is already the 1st object
-        if (![historyArray count] || 
-                     ([historyArray count] && ![objectValue isEqual:[[historyArray objectAtIndex:0] objectForKey:@"selection"]])) {
-            [historyArray insertObject:state atIndex:0];
+        if (![historyArray count]
+			|| ![objectValue isEqual:[[historyArray objectAtIndex:0] objectForKey:@"selection"]]
+			) {
+				[historyArray insertObject:state atIndex:0];
         }
     }
 
@@ -1697,9 +1690,6 @@ NSMutableDictionary *bindingsDict = nil;
 #ifdef DEBUG
 	if (VERBOSE) NSLog(@"goForward");
 #endif
-    if (!browsingHistory) {
-        browsingHistory = YES;
-    }
 	if (historyIndex>0) {
 		[self switchToHistoryState:--historyIndex];
 	} else {
@@ -1711,13 +1701,6 @@ NSMutableDictionary *bindingsDict = nil;
 	if (VERBOSE) NSLog(@"goBackward");
 #endif
     
-    // Ensure the last object (most recent) is set before we start browsing
-    if (!browsingHistory) {
-        [self updateHistory];
-        historyIndex = 0;
-        browsingHistory = YES;
-    }
-
 	if (historyIndex+1<(NSInteger)[historyArray count]) {
 		[self switchToHistoryState:++historyIndex];
 	} else {

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Code/QSObjectActions.m
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Code/QSObjectActions.m
@@ -50,7 +50,7 @@
 - (QSObject *)selectObjectInCommandWindow:(QSObject *)dObject {
 	QSInterfaceController *controller = [(QSController *)[NSApp delegate] interfaceController];
 
-	[controller selectObject:[dObject resolvedObject]];
+	[[controller dSelector] redisplayObjectValue:[dObject resolvedObject]];
 	[controller actionActivate:self];
 
 	return nil;

--- a/Quicksilver/PropertyLists/QSRegistration.plist
+++ b/Quicksilver/PropertyLists/QSRegistration.plist
@@ -154,6 +154,17 @@
 			<key>runInMainThread</key>
 			<true/>
 		</dict>
+		<key>QSClearHistory</key>
+		<dict>
+			<key>actionClass</key>
+			<string>QSController</string>
+			<key>actionSelector</key>
+			<string>clearHistory</string>
+			<key>icon</key>
+			<string>Quicksilver</string>
+			<key>name</key>
+			<string>Clear Quicksilver History</string>
+		</dict>
 	</dict>
 	<key>QSInternalURLHandlers</key>
 	<dict>

--- a/Quicksilver/Quicksilver.xcodeproj/project.pbxproj
+++ b/Quicksilver/Quicksilver.xcodeproj/project.pbxproj
@@ -2250,7 +2250,7 @@
 		E1E5FBCD07B20DD20044D6EF /* QSVoyeur.m */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.objc; path = QSVoyeur.m; sourceTree = "<group>"; usesTabs = 1; };
 		E1E5FC4807B20E4C0044D6EF /* BLTRResizeView.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; path = BLTRResizeView.h; sourceTree = "<group>"; usesTabs = 1; };
 		E1E5FC4907B20E4C0044D6EF /* BLTRResizeView.m */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.objc; path = BLTRResizeView.m; sourceTree = "<group>"; usesTabs = 1; };
-		E1E5FC4A07B20E4C0044D6EF /* DefaultBindings.qskeys */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = DefaultBindings.qskeys; sourceTree = "<group>"; };
+		E1E5FC4A07B20E4C0044D6EF /* DefaultBindings.qskeys */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; lineEnding = 0; path = DefaultBindings.qskeys; sourceTree = "<group>"; };
 		E1E5FC4D07B20E4D0044D6EF /* QSBackgroundView.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; path = QSBackgroundView.h; sourceTree = "<group>"; usesTabs = 1; };
 		E1E5FC4E07B20E4D0044D6EF /* QSBackgroundView.m */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.objc; path = QSBackgroundView.m; sourceTree = "<group>"; usesTabs = 1; };
 		E1E5FC4F07B20E4D0044D6EF /* QSBezelBackgroundView.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; path = QSBezelBackgroundView.h; sourceTree = "<group>"; usesTabs = 1; };

--- a/Quicksilver/Tests/Tests-QSCore/TestQSObject.m
+++ b/Quicksilver/Tests/Tests-QSCore/TestQSObject.m
@@ -181,4 +181,47 @@
 //    STAssertNil([object objectForCache:cacheKey], nil);
 }
 
+- (void)testEquality
+{
+	// tests for -[QSObject isEqual:]
+	QSObject *one = [QSObject objectWithName:@"one"];
+	QSObject *otherOne = one;
+	QSObject *two = [QSObject objectWithName:@"two"];
+	// literally the same object
+	XCTAssertEqual(one, otherOne);
+	XCTAssertEqualObjects(one, otherOne);
+	// unequal objects
+	XCTAssertNotEqualObjects(one, two);
+	// same identifier and data
+	QSObject *data1 = [QSObject objectWithName:@"Data 1"];
+	QSObject *data2 = [QSObject objectWithName:@"Data 2"];
+	// setIdentifier will enforce uniqueness, so bypass it
+	data1.identifier = @"isEqualTest";
+	data2.identifier = @"isEqualTest";
+	[data1 setObject:@"string data" forType:QSTextType];
+	[data2 setObject:@"string data" forType:QSTextType];
+	[data1 setPrimaryType:QSTextType];
+	[data2 setPrimaryType:QSTextType];
+	[data1 setObject:@"/System/Library" forType:QSFilePathType];
+	[data2 setObject:@"/System/Library" forType:QSFilePathType];
+	// make sure they aren't literally the same object
+	// otherwise, the next test would be pointless
+	XCTAssertNotEqual(data1, data2);
+	XCTAssertEqualObjects(data1, data2);
+	// mismatched data
+	[data1 setObject:@"https://qsapp.com/" forType:QSURLType];
+	[data2 setObject:@"https://qsapp.com/download.php" forType:QSURLType];
+	XCTAssertNotEqualObjects(data1, data2);
+	// combined objects
+	NSArray *multipleObjects = @[one, two];
+	QSObject *combined1 = [QSObject objectByMergingObjects:multipleObjects];
+	QSObject *combined2 = [QSObject objectByMergingObjects:multipleObjects];
+	combined1.identifier = @"isEqualTest";
+	combined2.identifier = @"isEqualTest";
+	// make sure they aren't literally the same object
+	// otherwise, the next test would be pointless
+	XCTAssertNotEqual(combined1, combined2);
+	XCTAssertEqualObjects(combined1, combined2);
+}
+
 @end

--- a/Quicksilver/Tests/Tests-QSCore/TestQSObject.m
+++ b/Quicksilver/Tests/Tests-QSCore/TestQSObject.m
@@ -230,6 +230,7 @@
 	XCTAssertNotEqualObjects(combined1, combined3);
 	QSObject *data4 = [QSObject URLObjectWithURL:@"https://apple.com/" title:@"Apple"];
 	QSObject *combined4 = [QSObject objectByMergingObjects:@[data1, data2, data4]];
+	combined4.identifier = @"isEqualTest";
 	XCTAssertNotEqualObjects(combined3, combined4);
 }
 

--- a/Quicksilver/Tests/Tests-QSCore/TestQSObject.m
+++ b/Quicksilver/Tests/Tests-QSCore/TestQSObject.m
@@ -217,7 +217,7 @@
 	[data2 setObject:nil forType:QSURLType];
 	NSArray *multipleObjects = @[data1, data2];
 	QSObject *combined1 = [QSObject objectByMergingObjects:multipleObjects];
-	QSObject *combined2 = [QSObject objectByMergingObjects:multipleObjects];
+	QSObject *combined2 = [QSObject objectByMergingObjects:[multipleObjects copy]];
 	combined1.identifier = @"isEqualTest";
 	combined2.identifier = @"isEqualTest";
 	// make sure they aren't literally the same object

--- a/Quicksilver/Tests/Tests-QSCore/TestQSObject.m
+++ b/Quicksilver/Tests/Tests-QSCore/TestQSObject.m
@@ -235,6 +235,9 @@
 	QSObject *combined5 = [QSObject objectByMergingObjects:@[data1, data2, data4] withObject:data2];
 	combined5.identifier = @"isEqualTest";
 	XCTAssertEqualObjects(combined4, combined5);
+	QSObject *combined6 = [QSObject objectByMergingObjects:@[data1, data2] withObject:data4];
+	combined6.identifier = @"isEqualTest";
+	XCTAssertEqualObjects(combined4, combined6);
 }
 
 @end

--- a/Quicksilver/Tests/Tests-QSCore/TestQSObject.m
+++ b/Quicksilver/Tests/Tests-QSCore/TestQSObject.m
@@ -232,6 +232,9 @@
 	QSObject *combined4 = [QSObject objectByMergingObjects:@[data1, data2, data4]];
 	combined4.identifier = @"isEqualTest";
 	XCTAssertNotEqualObjects(combined3, combined4);
+	QSObject *combined5 = [QSObject objectByMergingObjects:@[data1, data2, data4] withObject:data2];
+	combined5.identifier = @"isEqualTest";
+	XCTAssertEqualObjects(combined4, combined5);
 }
 
 @end

--- a/Quicksilver/Tests/Tests-QSCore/TestQSObject.m
+++ b/Quicksilver/Tests/Tests-QSCore/TestQSObject.m
@@ -213,7 +213,9 @@
 	[data2 setObject:@"https://qsapp.com/download.php" forType:QSURLType];
 	XCTAssertNotEqualObjects(data1, data2);
 	// combined objects
-	NSArray *multipleObjects = @[one, two];
+	[data1 setObject:nil forType:QSURLType];
+	[data1 setObject:nil forType:QSURLType];
+	NSArray *multipleObjects = @[data1, data2];
 	QSObject *combined1 = [QSObject objectByMergingObjects:multipleObjects];
 	QSObject *combined2 = [QSObject objectByMergingObjects:multipleObjects];
 	combined1.identifier = @"isEqualTest";
@@ -222,6 +224,13 @@
 	// otherwise, the next test would be pointless
 	XCTAssertNotEqual(combined1, combined2);
 	XCTAssertEqualObjects(combined1, combined2);
+	QSObject *data3 = [QSObject URLObjectWithURL:@"https://qsapp.com/" title:@"QS"];
+	QSObject *combined3 = [QSObject objectByMergingObjects:@[data1, data2, data3]];
+	combined3.identifier = @"isEqualTest";
+	XCTAssertNotEqualObjects(combined1, combined3);
+	QSObject *data4 = [QSObject URLObjectWithURL:@"https://apple.com/" title:@"Apple"];
+	QSObject *combined4 = [QSObject objectByMergingObjects:@[data1, data2, data4]];
+	XCTAssertNotEqualObjects(combined3, combined4);
 }
 
 @end

--- a/Quicksilver/Tests/Tests-QSCore/TestQSObject.m
+++ b/Quicksilver/Tests/Tests-QSCore/TestQSObject.m
@@ -191,7 +191,7 @@
 	XCTAssertEqual(one, otherOne);
 	XCTAssertEqualObjects(one, otherOne);
 	// unequal objects
-	XCTAssertNotEqualObjects(one, two);
+	XCTAssertNotEqual(one, two);
 	// same identifier and data
 	QSObject *data1 = [QSObject objectWithName:@"Data 1"];
 	QSObject *data2 = [QSObject objectWithName:@"Data 2"];
@@ -214,7 +214,7 @@
 	XCTAssertNotEqualObjects(data1, data2);
 	// combined objects
 	[data1 setObject:nil forType:QSURLType];
-	[data1 setObject:nil forType:QSURLType];
+	[data2 setObject:nil forType:QSURLType];
 	NSArray *multipleObjects = @[data1, data2];
 	QSObject *combined1 = [QSObject objectByMergingObjects:multipleObjects];
 	QSObject *combined2 = [QSObject objectByMergingObjects:multipleObjects];


### PR DESCRIPTION
That is, when a user does something to explicitly say “this is the thing I was searching for”, add it to the history and save the mnemonic used. (I’m thinking there’s never a reason to do one without the other in the first pane, so they’re married now. :wedding:)

I’ve added the two methods to some additional areas that indicate user acknowledgment of a match, like `shortCircuit`, `moveRight`, and Quick Look. I added them to `insertTab` too, but changed my mind. If you *did* find the thing you want and are tabbing to select a different action, you’re probably about to execute the command, which will take care of things.

I’d consider a hidden pref that makes the history act more like it did before, where just typing random characters adds things to history whether or not you find the result meaningful, but I’m not sure why you’d want that. :smiley:

This should also fix #2090 by not updating the history when the user is typing.