### PR TITLE
Modern aliases

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSObject_FileHandling.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject_FileHandling.m
@@ -682,15 +682,15 @@ NSArray *recentDocumentsForBundle(NSString *bundleIdentifier) {
     if (!path) {
         return nil;
     }
-    
-    NSURL *fileURL = [NSURL fileURLWithPath:[path stringByResolvingSymlinksInPath]];
+
+    NSURL *fileURL = [NSURL fileURLWithPath:path];
     NSError *err = nil;
     
     // Note: NSURLLocalizedLabelKey gives a localized string of the Finder label (tag in 10.9+). E.g. Red / Rouge
     dict = [fileURL resourceValuesForKeys:@[NSURLTypeIdentifierKey, NSURLIsDirectoryKey, NSURLIsAliasFileKey, NSURLIsPackageKey, NSURLLocalizedLabelKey, NSURLLocalizedNameKey, NSURLVolumeURLKey, NSURLIsExecutableKey, NSURLIsWritableKey, NSURLLabelColorKey] error:&err];
     NSMutableDictionary *mutableDict = [dict mutableCopy];
 
-    if (err) {
+    if (!dict) {
         // The file is either a socket or fifo. Not much information is available on these files
         LSItemInfoRecord record;
         OSStatus status = LSCopyItemInfoForURL((__bridge CFURLRef)[NSURL fileURLWithPath:path], kLSRequestAllInfo, &record);

--- a/Quicksilver/Code-QuickStepCore/QSObject_FileHandling.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject_FileHandling.m
@@ -161,9 +161,14 @@ NSArray *recentDocumentsForBundle(NSString *bundleIdentifier) {
                 return @"iCloud";
             } else {
                 NSString *pathDetails = [path stringByAbbreviatingWithTildeInPath];
-                if (UTTypeConformsTo((__bridge CFStringRef)[object fileUTI], kUTTypeResolvable)) {
-                    NSString *extraInfo = [[object fileUTI] isEqualToString:(__bridge NSString *)kUTTypeSymLink] ? NSLocalizedString(@"symlink", @"Extra details shown for symlink files, in the UI") : NSLocalizedString(@"alias", @"Extra details shown for alias files, in the UI");
-                    pathDetails = [pathDetails stringByAppendingFormat:@" (%@)", extraInfo];
+                if (QSTypeConformsTo([object fileUTI], (NSString *)kUTTypeSymLink)) {
+                    pathDetails = [[path stringByResolvingSymlinksInPath] stringByAbbreviatingWithTildeInPath];
+                } else if ([object isAlias]) {
+                    NSURL *fileURL = [NSURL fileURLWithPath:path];
+                    NSURL *resolvedURL = [NSURL URLByResolvingBookmarkAtURL:fileURL
+                                                                    options:NSURLBookmarkResolutionWithoutUI | NSURLBookmarkResolutionWithoutMounting bookmarkDataIsStale:NULL
+                                                                      error:NULL];
+                    pathDetails = [resolvedURL path];
                 }
                 return pathDetails;
             }

--- a/Quicksilver/Code-QuickStepFoundation/NSURL_BLTRExtensions.h
+++ b/Quicksilver/Code-QuickStepFoundation/NSURL_BLTRExtensions.h
@@ -27,3 +27,9 @@
 - (NSURL *)URLByReallyResolvingSymlinksInPath;
 
 @end
+
+@interface NSURL (QSBookmarkHelpers)
++ (instancetype)URLByResolvingBookmarkAtURL:(NSURL *)bookmarkURL options:(NSURLBookmarkResolutionOptions)options bookmarkDataIsStale:(BOOL *)isStale error:(NSError **)error;
+- (BOOL)writeBookmarkToURL:(NSURL *)destinationURL options:(NSURLBookmarkFileCreationOptions)options error:(NSError **)error;
+- (NSData *)bookmarkData;
+@end

--- a/Quicksilver/Code-QuickStepFoundation/NSURL_BLTRExtensions.m
+++ b/Quicksilver/Code-QuickStepFoundation/NSURL_BLTRExtensions.m
@@ -100,3 +100,31 @@ NSString *QSPasswordForHostUserType(NSString *host, NSString *user, SecProtocolT
 }
 
 @end
+
+@implementation NSURL (QSBookmarkHelpers)
++ (instancetype)URLByResolvingBookmarkAtURL:(NSURL *)bookmarkURL options:(NSURLBookmarkResolutionOptions)options bookmarkDataIsStale:(BOOL *)isStale error:(NSError **)error {
+
+    NSData *bookmarkData = [[self class] bookmarkDataWithContentsOfURL:bookmarkURL error:error];
+    if (!bookmarkData) return nil;
+
+    return [self URLByResolvingBookmarkData:bookmarkData options:options relativeToURL:nil bookmarkDataIsStale:isStale error:error];
+}
+
+- (BOOL)writeBookmarkToURL:(NSURL *)destinationURL options:(NSURLBookmarkFileCreationOptions)options error:(NSError **)error {
+    NSData *bookmarkData = [self bookmarkDataWithOptions:NSURLBookmarkCreationSuitableForBookmarkFile|options
+                          includingResourceValuesForKeys:nil
+                                           relativeToURL:nil
+                                                   error:error];
+    if (bookmarkData == nil) {
+        return NO;
+    }
+    return [NSURL writeBookmarkData:bookmarkData toURL:destinationURL options:options error:error];
+}
+
+- (NSData *)bookmarkData {
+    return [self bookmarkDataWithOptions:NSURLBookmarkCreationSuitableForBookmarkFile
+          includingResourceValuesForKeys:nil
+                           relativeToURL:nil
+                                   error:NULL];
+}
+@end

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Code/QSDirectoryParser.m
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Code/QSDirectoryParser.m
@@ -76,10 +76,10 @@
             targetURL = [theURL URLByReallyResolvingSymlinksInPath];
         } else if ([resources[NSURLIsAliasFileKey] boolValue]) {
             BOOL stale = NO;
-            NSURL *targetURL = [NSURL URLByResolvingBookmarkAtURL:theURL
-                                                          options:NSURLBookmarkResolutionWithoutUI | NSURLBookmarkResolutionWithoutMounting
-                                              bookmarkDataIsStale:&stale
-                                                            error:&err];
+            targetURL = [NSURL URLByResolvingBookmarkAtURL:theURL
+                                                   options:NSURLBookmarkResolutionWithoutUI | NSURLBookmarkResolutionWithoutMounting
+                                       bookmarkDataIsStale:&stale
+                                                     error:&err];
             if (!targetURL) {
                 NSLog(@"Error resolving %@alias at %@: %@", (stale ? @"stale " : @""), theURL, err);
             }


### PR DESCRIPTION
Sorry for the name, *you* know that's a hard problem ;-).

This resurrects the switch to NSURL bookmarks I tried to do (#2075), since I wanted to fix the class of network-alias-stalls bugs we have and the main QS method we had actually doesn't handle all the bells and whistles of bookmark resolution. Maybe I should have added a comment on `-[NSFileManager resolveAliasAtPath:]` and friends but, well, I didn't. Consider yourselves warned :smirk:.

This one fixes the issue Rob had with the hundreds of warning messages had because *symlinks*. Since I wasn't keen on basing the new resolver because of [shaky grounds](http://digitalleaves.com/blog/2013/09/nsurl-files-equality-comparison-and-equivalency/), I preferred to keep the symlink-checking separate.

There's also a fix for `-infoRec` returning the symlink target info instead of the symlink itself, which makes symlink actually "invisible" (and non-working, it would seem — at least here, current `master` doesn't allow me to right-arrow into a symlink because the code passes a symlink path to some directory-parsing code). I wonder how you guys feel about that, especially in light of #1897, #1485, and the broken test ;-).

The icing on the cake is that "resolvables" show their target path instead of theirs.

Based on the deprecation cleanup branch ~~for motivation~~ so the diff is cleaner.