### PR TITLE
Notification rewrite

### DIFF
--- a/Quicksilver/Code-App/QSController.m
+++ b/Quicksilver/Code-App/QSController.m
@@ -644,10 +644,16 @@ static QSController *defaultController = nil;
 /** Turn off "you have previously used a newer version" popup for DEBUG builds **/
 #ifndef DEBUG
 			[NSApp activateIgnoringOtherApps:YES];
-			NSInteger selection = NSRunInformationalAlertPanel(NSLocalizedString(@"This is an old version of Quicksilver",nil), NSLocalizedString(@"You have previously used a newer version. Perhaps you have duplicate copies?",nil), NSLocalizedString(@"Reveal this copy",nil), NSLocalizedString(@"Ignore",nil), nil);
-			if (selection == 1)
-				[[NSWorkspace sharedWorkspace] selectFile:[[NSBundle mainBundle] bundlePath] inFileViewerRootedAtPath:@""];
 #endif
+            [[QSAlertManager defaultManager] beginAlertWithTitle:NSLocalizedString(@"This is an old version of Quicksilver",nil)
+                                                         message:NSLocalizedString(@"You have previously used a newer version. Perhaps you have duplicate copies?",nil)
+                                                         buttons:@[NSLocalizedString(@"Reveal this copy",nil), NSLocalizedString(@"Ignore",nil)]
+                                                           style:NSInformationalAlertStyle
+                                                        onWindow:nil
+                                               completionHandler:^(QSAlertResponse response) {
+                                                   if (response == QSAlertResponseOK)
+                                                       [[NSWorkspace sharedWorkspace] selectFile:[[NSBundle mainBundle] bundlePath] inFileViewerRootedAtPath:@""];
+                                               }];
             versionChanged = YES;
             break;
         }
@@ -657,11 +663,19 @@ static QSController *defaultController = nil;
 			if (shouldInstall) {
 				//New version in new location.
 				[NSApp activateIgnoringOtherApps:YES];
-				NSInteger selection = NSRunAlertPanel(NSLocalizedString(@"Would you like to install Quicksilver?",nil), NSLocalizedString(@"Quicksilver was launched from a download location.\rWould you like to copy Quicksilver to your applications folder?",nil), NSLocalizedString(@"Install in \"Applications\"",nil), NSLocalizedString(@"Quit",nil), NSLocalizedString(@"Choose Location...",nil));
+
+                NSAlert *alert = [NSAlert alertWithMessageText:NSLocalizedString(@"Would you like to install Quicksilver?",nil)
+                                                 defaultButton:NSLocalizedString(@"Install in \"Applications\"",nil)
+                                               alternateButton:NSLocalizedString(@"Quit",nil)
+                                                   otherButton:NSLocalizedString(@"Choose Location...",nil)
+                                     informativeTextWithFormat:@"%@", NSLocalizedString(@"Quicksilver was launched from a download location.\rWould you like to copy Quicksilver to your applications folder?",nil)];
+
+                QSAlertResponse response = [[QSAlertManager defaultManager] runAlert:alert onWindow:nil];
+
 				NSString *installPath = nil;
-				if (selection == 1) {
+				if (response == QSAlertResponseFirst) {
 					installPath = @"/Applications";
-				} else if (selection == -1) {
+				} else if (response == QSAlertResponseThird) {
 					NSOpenPanel *openPanel = [NSOpenPanel openPanel];
 					[openPanel setCanChooseDirectories:YES];
 					[openPanel setCanChooseFiles:NO];

--- a/Quicksilver/Code-App/QSSetupAssistant.m
+++ b/Quicksilver/Code-App/QSSetupAssistant.m
@@ -122,15 +122,18 @@
 
 - (BOOL)windowShouldClose:(id)sender {
 	if (!defaultBool(@"QSAgreementAccepted") ) {
-		[[NSAlert alertWithMessageText:@"Cancel Setup" defaultButton:@"Quit" alternateButton:@"Cancel" otherButton:nil informativeTextWithFormat:@"Would you like to stop setup and quit Quicksilver?"] beginSheetModalForWindow:[self window] modalDelegate:self didEndSelector:@selector(alertDidEnd:returnCode:contextInfo:) contextInfo:nil];
+        [[QSAlertManager defaultManager] beginAlertWithTitle:NSLocalizedString(@"Cancel Setup", @"Setup assistant - Cancel alert title")
+                                                     message:NSLocalizedString(@"Would you like to stop setup and quit Quicksilver?", @"Setup assistant - Cancel alert message")
+                                                     buttons:@[NSLocalizedString(@"Quit", nil), NSLocalizedString(@"Cancel", nil)]
+                                                       style:NSInformationalAlertStyle
+                                                    onWindow:[self window]
+                                           completionHandler:^(QSAlertResponse response) {
+                                               if (response == QSAlertResponseOK)
+                                                   [NSApp terminate:self];
+                                           }];
 		return NO;
 	}
 	return YES;
-}
-- (void)alertDidEnd:(NSAlert *)alert returnCode:(NSInteger)returnCode contextInfo:(void *)contextInfo {
-	[[alert window] close];
-	if (returnCode)
-		[NSApp terminate:self];
 }
 
 - (void)catalogIndexingFinished:(id)notif {

--- a/Quicksilver/Code-QuickStepCore/QSAlertManager.h
+++ b/Quicksilver/Code-QuickStepCore/QSAlertManager.h
@@ -1,13 +1,51 @@
 #import <Foundation/Foundation.h>
 
-NSInteger QSRunSheet(id panel, NSWindow *attachToWin, NSString *title, NSString *msg, NSString *defaultButton, NSString *alternateButton, NSString *otherButton);
-NSInteger QSRunAlertSheet(NSWindow *attachToWin, NSString *title, NSString *msg, NSString *defaultButton, NSString *alternateButton, NSString *otherButton);
-NSInteger QSRunInformationalAlertSheet(NSWindow *attachToWin, NSString *title, NSString *msg, NSString *defaultButton, NSString *alternateButton, NSString *otherButton);
-NSInteger QSRunCriticalAlertSheet(NSWindow *attachToWin, NSString *title, NSString *msg, NSString *defaultButton, NSString *alternateButton, NSString *otherButton);
+#define QSAlert [QSAlertManager defaultManager]
 
-@interface QSAlertManager : NSObject {
-	NSInteger returnCode;
-}
-- (void)sheetDidEnd:(NSWindow *)sheet returnCode:(NSInteger)returnCode contextInfo:(void *)contextInfo;
-- (NSInteger) returnCode;
+NSInteger QSRunSheet(id panel, NSWindow *attachToWin, NSString *title, NSString *msg, NSString *defaultButton, NSString *alternateButton, NSString *otherButton) QS_DEPRECATED;
+NSInteger QSRunAlertSheet(NSWindow *attachToWin, NSString *title, NSString *msg, NSString *defaultButton, NSString *alternateButton, NSString *otherButton) QS_DEPRECATED;
+NSInteger QSRunInformationalAlertSheet(NSWindow *attachToWin, NSString *title, NSString *msg, NSString *defaultButton, NSString *alternateButton, NSString *otherButton) QS_DEPRECATED;
+NSInteger QSRunCriticalAlertSheet(NSWindow *attachToWin, NSString *title, NSString *msg, NSString *defaultButton, NSString *alternateButton, NSString *otherButton) QS_DEPRECATED;
+
+@interface QSAlertManager : NSObject
+
+/**
+ *  Our singleton
+ *
+ *  @return The default alert manager.
+ */
++ (instancetype)defaultManager;
+
+/**
+ *  Display an alert asynchronously.
+ *
+ *  @param alert   Mandatory, the alert to display.
+ *  @param window  An (optional) window to which the alert will be attached.
+ *  @param handler The completion block to call.
+ */
+- (void)beginAlert:(NSAlert *)alert onWindow:(NSWindow *)window completionHandler:(void (^)(NSModalResponse response))handler;
+
+/**
+ *  Display an alert synchronously
+ *
+ *  @param alert  Mandatory, the alert to display.
+ *  @param window An (optional) window to which the alert will be attached.
+ *
+ *  @return The button that was used to dismiss the alert.
+ */
+- (NSModalResponse)runAlert:(NSAlert *)alert onWindow:(NSWindow *)window;
+
+/**
+ *  Display an alert synchronously (and conveniently)
+ *
+ *  @param title   The title of the alert.
+ *  @param message The title of the alert.
+ *  @param buttons An array containing the names of the buttons.
+ *  @param style   The alert style to use.
+ *  @param window  An (optional) window to which the alert will be attached.
+ *
+ *  @return The button that was used to dismiss the alert.
+ */
+- (NSModalResponse)runAlertWithTitle:(NSString *)title message:(NSString *)message buttons:(NSArray *)buttons style:(NSAlertStyle)style attachToWindow:(NSWindow *)window;
+
 @end

--- a/Quicksilver/Code-QuickStepCore/QSAlertManager.h
+++ b/Quicksilver/Code-QuickStepCore/QSAlertManager.h
@@ -63,4 +63,19 @@ typedef void (^QSAlertHandler)(QSAlertResponse);
  */
 - (QSAlertResponse)runAlertWithTitle:(NSString *)title message:(NSString *)message buttons:(NSArray *)buttons style:(NSAlertStyle)style attachToWindow:(NSWindow *)window;
 
+/**
+ * Display a notification
+ *
+ * Note that (<=10.9) there can only be 2 buttons on a notification, the second always dismiss the notification without informing the caller.
+ * Clicking the notification will give you QSAlertResponseFirst, the button will be QSAlertResponseSecond. The rest is ignored.
+ */
+- (void)notifyWithNotification:(NSUserNotification *)notif completionHandler:(QSAlertHandler)handler;
+
+/**
+ * Create a notification from the given parameters and display it.
+ *
+ * @see notifyWithNotification:completionHandler:
+ */
+- (void)notifyWithTitle:(NSString *)title message:(NSString *)message buttons:(NSArray *)buttons completionHandler:(QSAlertHandler)handler;
+
 @end

--- a/Quicksilver/Code-QuickStepCore/QSAlertManager.h
+++ b/Quicksilver/Code-QuickStepCore/QSAlertManager.h
@@ -7,6 +7,19 @@ NSInteger QSRunAlertSheet(NSWindow *attachToWin, NSString *title, NSString *msg,
 NSInteger QSRunInformationalAlertSheet(NSWindow *attachToWin, NSString *title, NSString *msg, NSString *defaultButton, NSString *alternateButton, NSString *otherButton) QS_DEPRECATED;
 NSInteger QSRunCriticalAlertSheet(NSWindow *attachToWin, NSString *title, NSString *msg, NSString *defaultButton, NSString *alternateButton, NSString *otherButton) QS_DEPRECATED;
 
+typedef NS_ENUM(NSInteger, QSAlertResponse) {
+    QSAlertResponseOK = 0,
+    QSAlertResponseCancel = 1,
+
+    QSAlertResponseFirst = 0,
+    QSAlertResponseSecond = 1,
+    QSAlertResponseThird = 2,
+    /* Other button indexes can be returned */
+};
+
+
+typedef void (^QSAlertHandler)(QSAlertResponse);
+
 @interface QSAlertManager : NSObject
 
 /**
@@ -23,7 +36,9 @@ NSInteger QSRunCriticalAlertSheet(NSWindow *attachToWin, NSString *title, NSStri
  *  @param window  An (optional) window to which the alert will be attached.
  *  @param handler The completion block to call.
  */
-- (void)beginAlert:(NSAlert *)alert onWindow:(NSWindow *)window completionHandler:(void (^)(NSModalResponse response))handler;
+- (void)beginAlert:(NSAlert *)alert onWindow:(NSWindow *)window completionHandler:(QSAlertHandler)handler;
+
+- (void)beginAlertWithTitle:(NSString *)title message:(NSString *)message buttons:(NSArray *)buttons style:(NSAlertStyle)style onWindow:(NSWindow *)window completionHandler:(QSAlertHandler)handler;
 
 /**
  *  Display an alert synchronously
@@ -33,7 +48,7 @@ NSInteger QSRunCriticalAlertSheet(NSWindow *attachToWin, NSString *title, NSStri
  *
  *  @return The button that was used to dismiss the alert.
  */
-- (NSModalResponse)runAlert:(NSAlert *)alert onWindow:(NSWindow *)window;
+- (QSAlertResponse)runAlert:(NSAlert *)alert onWindow:(NSWindow *)window;
 
 /**
  *  Display an alert synchronously (and conveniently)
@@ -46,6 +61,6 @@ NSInteger QSRunCriticalAlertSheet(NSWindow *attachToWin, NSString *title, NSStri
  *
  *  @return The button that was used to dismiss the alert.
  */
-- (NSModalResponse)runAlertWithTitle:(NSString *)title message:(NSString *)message buttons:(NSArray *)buttons style:(NSAlertStyle)style attachToWindow:(NSWindow *)window;
+- (QSAlertResponse)runAlertWithTitle:(NSString *)title message:(NSString *)message buttons:(NSArray *)buttons style:(NSAlertStyle)style attachToWindow:(NSWindow *)window;
 
 @end

--- a/Quicksilver/Code-QuickStepCore/QSAlertManager.m
+++ b/Quicksilver/Code-QuickStepCore/QSAlertManager.m
@@ -171,9 +171,13 @@
             break;
 
         case NSUserNotificationActivationTypeActionButtonClicked:
-            response = QSAlertResponseSecond;
+            response = QSAlertResponseOK;
             break;
 
+		case NSUserNotificationActivationTypeAdditionalActionClicked:
+			response = QSAlertResponseCancel;
+			break;
+			
         default:
             break;
     }

--- a/Quicksilver/Code-QuickStepCore/QSAlertManager.m
+++ b/Quicksilver/Code-QuickStepCore/QSAlertManager.m
@@ -178,7 +178,7 @@
             break;
     }
 
-    if (!handler) handler(response);
+    if (handler) handler(response);
 
     [self.notificationHandlers removeObjectForKey:notification.identifier];
 }

--- a/Quicksilver/Code-QuickStepCore/QSAlertManager.m
+++ b/Quicksilver/Code-QuickStepCore/QSAlertManager.m
@@ -1,67 +1,148 @@
 #import "QSAlertManager.h"
 
-@implementation QSAlertManager
-- (void)sheetDidEnd:(NSWindow *)sheet returnCode:(NSInteger)theReturnCode contextInfo:(void *)contextInfo {
-	returnCode = theReturnCode;
-	[NSApp stopModal];
-}
-- (NSInteger) returnCode { return returnCode; }
+@interface QSAlertManager ()
+
+@property (assign) NSInteger returnCode;
+
 @end
 
-NSInteger QSRunSheet(id panel, NSWindow *attachToWin, NSString *title, NSString *msg, NSString *defaultButton, NSString *alternateButton, NSString *otherButton) {
-	QSAlertManager *obj = [[QSAlertManager alloc] init];
-	[NSApp beginSheet:panel modalForWindow:attachToWin modalDelegate:obj didEndSelector:@selector(sheetDidEnd:returnCode:contextInfo:) contextInfo:nil];
-	[NSApp runModalForWindow:panel];
-	[NSApp endSheet:panel];
-	[panel orderOut:nil];
-	NSReleaseAlertPanel(panel);
-	NSInteger result = [obj returnCode];
-	return result;
+@implementation QSAlertManager
+
++ (instancetype)defaultManager {
+    static QSAlertManager *defaultManager;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        defaultManager = [[self alloc] init];
+    });
+    return defaultManager;
 }
 
-NSLock *onlyOneAlertSheetAtATimeLock = nil;
+#pragma mark -
+#pragma mark NSAlert
+
+- (void)beginAlert:(NSAlert *)alert onWindow:(NSWindow *)window completionHandler:(void (^)(NSModalResponse response))handler {
+    NSParameterAssert(alert != nil);
+
+    QSGCDMainAsync(^{
+        NSModalResponse response = NSAlertErrorReturn;
+        if (window && [alert respondsToSelector:@selector(beginSheetModalForWindow:completionHandler:)]) {
+            [alert beginSheetModalForWindow:window completionHandler:^(NSModalResponse response) {
+                [NSApp stopModalWithCode:response];
+            }];
+
+            response = [NSApp runModalForWindow:window];
+        } else if (window) {
+            [alert beginSheetModalForWindow:window modalDelegate:self didEndSelector:@selector(alertDidEnd:returnCode:contextInfo:) contextInfo:NULL];
+
+            response = [NSApp runModalForWindow:window];
+        } else {
+            response = [alert runModal];
+        }
+
+        if (handler) handler(response);
+    });
+}
+
+- (void)alertDidEnd:(NSAlert *)sheet returnCode:(NSInteger)theReturnCode contextInfo:(void *)contextInfo {
+    [NSApp stopModalWithCode:theReturnCode];
+}
+
+- (NSModalResponse)runAlert:(NSAlert *)alert onWindow:(NSWindow *)window {
+    __block NSModalResponse alertResponse = NSAlertErrorReturn;
+    __block dispatch_semaphore_t alertSemaphore = dispatch_semaphore_create(0);
+
+    [self beginAlert:alert onWindow:window completionHandler:^(NSModalResponse response) {
+        alertResponse = response;
+        dispatch_semaphore_signal(alertSemaphore);
+    }];
+
+    // Now let's mostly-busy loop while we wait for the semaphore above to get signaled
+    long result = 0;
+    do {
+        [[NSRunLoop mainRunLoop] runMode:NSModalPanelRunLoopMode beforeDate:[NSDate dateWithTimeIntervalSinceNow:5]];
+        result = dispatch_semaphore_wait(alertSemaphore, DISPATCH_TIME_NOW);
+    } while (result != 0);
+
+    return alertResponse;
+}
+
+- (NSModalResponse)runAlertWithTitle:(NSString *)title message:(NSString *)message buttons:(NSArray *)buttons style:(NSAlertStyle)style attachToWindow:(NSWindow *)window {
+    NSParameterAssert(title != nil);
+    NSParameterAssert(buttons != nil);
+    NSAssert(buttons.count > 1, @"Must have at least one button");
+
+    // Configure the alert
+    NSAlert *alert = [[NSAlert alloc] init];
+    alert.messageText = title;
+    alert.informativeText = message;
+    for (NSString *buttonTitle in buttons) {
+        [alert addButtonWithTitle:buttonTitle];
+    }
+
+    alert.alertStyle = style;
+
+    return [self runAlert:alert onWindow:window];
+}
+
+// FIXME: This (and the property) can die when we're sure the QSRun.*Sheet functions are gone
+- (void)sheetDidEnd:(NSWindow *)sheet returnCode:(NSInteger)returnCode contextInfo:(void *)contextInfo {
+    self.returnCode = returnCode;
+    [NSApp stopModal];
+}
+
+@end
+
+// Eeek. This doesn't eve uses its parameters...
+NSInteger QSRunSheet(id panel, NSWindow *attachToWin, NSString *title, NSString *msg, NSString *defaultButton, NSString *alternateButton, NSString *otherButton) {
+    NSInteger result;
+    @synchronized ([QSAlertManager defaultManager]) {
+        [NSApp beginSheet:panel modalForWindow:attachToWin modalDelegate:[QSAlertManager defaultManager] didEndSelector:@selector(sheetDidEnd:returnCode:contextInfo:) contextInfo:nil];
+        [NSApp runModalForWindow:panel];
+        [NSApp endSheet:panel];
+        [panel orderOut:nil];
+        NSReleaseAlertPanel(panel);
+        result = [[QSAlertManager defaultManager] returnCode];
+    }
+    return result;
+}
+
+NSInteger _QSRunSheet(NSWindow *attachToWin, NSString *title, NSString *msg, NSString *defaultButton, NSString *alternateButton, NSString *otherButton, NSAlertStyle style) {
+    NSMutableArray *buttons = [[NSMutableArray alloc] initWithCapacity:3];
+    if (defaultButton)   [buttons addObject:defaultButton];
+    if (alternateButton) [buttons addObject:alternateButton];
+    if (otherButton)     [buttons addObject:otherButton];
+
+    NSModalResponse response = [[QSAlertManager defaultManager] runAlertWithTitle:title message:msg buttons:buttons style:style attachToWindow:attachToWin];
+
+    // Convert our response to the old NSPanel values
+    // New-style
+    //    NSAlertDefaultReturn means the user pressed the default button.
+    //    NSAlertAlternateReturn means the user pressed the alternate button.
+    //    NSAlertOtherReturn means the user pressed the other button.
+    //    NSAlertErrorReturn means an error occurred while running the alert panel.
+    // Old-style
+    //    NSAlertFirstButtonReturn	= 1000,
+    //    NSAlertSecondButtonReturn	= 1001,
+    //    NSAlertThirdButtonReturn	= 1002
+
+    if (response == NSAlertFirstButtonReturn) {
+        return NSAlertDefaultReturn;
+    } else if (response == NSAlertSecondButtonReturn) {
+        return NSAlertOtherReturn;
+    } else if (response == NSAlertThirdButtonReturn) {
+        return NSAlertAlternateReturn;
+    }
+    return NSAlertErrorReturn;
+}
 
 NSInteger QSRunAlertSheet(NSWindow *attachToWin, NSString *title, NSString *msg, NSString *defaultButton, NSString *alternateButton, NSString *otherButton) {
-	if (onlyOneAlertSheetAtATimeLock == nil)
-		onlyOneAlertSheetAtATimeLock = [[NSLock alloc] init];
-	[onlyOneAlertSheetAtATimeLock lock];
-
-	NSInteger returnVal = -1;
-	if (attachToWin == nil)
-		returnVal = NSRunAlertPanel(title, @"%@", defaultButton, alternateButton, otherButton, msg);
-	else {
-		returnVal = QSRunSheet(NSGetAlertPanel(title, @"%@", defaultButton, alternateButton, otherButton, msg), attachToWin, title, msg, defaultButton, alternateButton, otherButton);
-	}
-
-	[onlyOneAlertSheetAtATimeLock unlock];
-	return returnVal;
+    return _QSRunSheet(attachToWin, title, msg, defaultButton, alternateButton, otherButton, NSWarningAlertStyle);
 }
 
 NSInteger QSRunInformationalAlertSheet(NSWindow *attachToWin, NSString *title, NSString *msg, NSString *defaultButton, NSString *alternateButton, NSString *otherButton) {
-	if (onlyOneAlertSheetAtATimeLock == nil)
-		onlyOneAlertSheetAtATimeLock = [[NSLock alloc] init];
-	[onlyOneAlertSheetAtATimeLock lock];
-
-	NSInteger returnVal = -1;
-	if (attachToWin == nil)
-		returnVal = NSRunInformationalAlertPanel(title, @"%@", defaultButton, alternateButton, otherButton, msg);
-	else
-		returnVal = QSRunSheet(NSGetInformationalAlertPanel(title, @"%@", defaultButton, alternateButton, otherButton, msg), attachToWin, title, msg, defaultButton, alternateButton, otherButton);
-
-	[onlyOneAlertSheetAtATimeLock unlock];
-	return returnVal;
+    return _QSRunSheet(attachToWin, title, msg, defaultButton, alternateButton, otherButton, NSInformationalAlertStyle);
 }
 
 NSInteger QSRunCriticalAlertSheet(NSWindow *attachToWin, NSString *title, NSString *msg, NSString *defaultButton, NSString *alternateButton, NSString *otherButton) {
-	if (onlyOneAlertSheetAtATimeLock == nil)
-		onlyOneAlertSheetAtATimeLock = [[NSLock alloc] init];
-	[onlyOneAlertSheetAtATimeLock lock];
-	NSInteger returnVal = -1;
-	if (attachToWin == nil)
-		returnVal = NSRunCriticalAlertPanel(title, @"%@", defaultButton, alternateButton, otherButton, msg);
-	else
-		returnVal = QSRunSheet(NSGetCriticalAlertPanel(title, @"%@", defaultButton, alternateButton, otherButton, msg), attachToWin, title, msg, defaultButton, alternateButton, otherButton);
-
-	[onlyOneAlertSheetAtATimeLock unlock];
-	return returnVal;
+    return _QSRunSheet(attachToWin, title, msg, defaultButton, alternateButton, otherButton, NSCriticalAlertStyle);
 }

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Code/QSActionProvider_EmbeddedProviders.m
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Code/QSActionProvider_EmbeddedProviders.m
@@ -717,7 +717,12 @@
                     [[NSWorkspace sharedWorkspace] noteFileSystemChanged:[thisFile stringByDeletingLastPathComponent]];
                     [newPaths addObject:destinationFile];
                 } else {
-                    [[NSAlert alertWithMessageText:@"Move Error" defaultButton:nil alternateButton:nil otherButton:nil informativeTextWithFormat:@"Error Moving File: %@ to %@\n\n%@", thisFile, destination, [err localizedDescription]] runModal];
+                    NSString *message = [NSString stringWithFormat:NSLocalizedString(@"The following error occured while trying to move \"%1$@\" to \"%2$@\"\n\n%3$@", nil), thisFile, destination, [err localizedDescription]];
+                    [[QSAlertManager defaultManager] runAlertWithTitle:NSLocalizedString(@"Move error", nil)
+                                                               message:message
+                                                               buttons:@[NSLocalizedString(@"OK", nil)]
+                                                                 style:NSWarningAlertStyle
+                                                        attachToWindow:nil];
                 }
             }
             [[NSWorkspace sharedWorkspace] noteFileSystemChanged:destination];


### PR DESCRIPTION
So, this is an alternate version of #2104. Sorry @skurfer, I didn't like the "one delegate to rule them all approach", though as I said earlier, it's because of the API.

This one uses a block to notify what choice the user made. Right now it uses the same kind of block than the alerts do, but depending on some discussion, that can change. I prefer that to moving gobs of important code to [unrelated places](https://github.com/quicksilver/Quicksilver/pull/2104/files?diff=unified#diff-29f2dfd46753000b6ca6b67b790754d9R481). I do agree the update code is not the most streamlined code to pick on, but, well...

Something I planned for but didn't yet handle is automatically escalating notifications to alerts via the delegate callback (that's why I started on cleaning up `QSAlertManager` first, then proceeded to notification handling). The issue is that I can't think of a good way of _not_ doing so without changing the block's signature. Maybe provide a third method that has the automatic escalation behavior in ?
