### PR TITLE
Fix CGSPrivate (again)

### DIFF
--- a/Quicksilver/Code-External/CGSPrivate.h
+++ b/Quicksilver/Code-External/CGSPrivate.h
@@ -53,9 +53,9 @@
 */
 
 // Internal CoreGraphics typedefs
-typedef NSInteger	CGSConnection;
-typedef NSInteger   CGSWindow;
-typedef NSInteger   CGSValue;
+typedef int		CGSConnection;
+typedef int		CGSWindow;
+typedef int		CGSValue;
 
 //// CONSTANTS ////
 

--- a/Quicksilver/Code-QuickStepEffects/QSWindowAnimation.m
+++ b/Quicksilver/Code-QuickStepEffects/QSWindowAnimation.m
@@ -115,7 +115,7 @@
 		CGSSetWindowAlpha(cgs, wid, alpha);
 
 		if ([childWindows count]) {
-			CGSSetWindowAlpha(cgs, [[childWindows lastObject] windowNumber] , alpha);
+			CGSSetWindowAlpha(cgs, (int)[[childWindows lastObject] windowNumber] , alpha);
 		}
 		if (progress == 1.0f)
 			[_window setAlphaValue:alpha];
@@ -123,7 +123,7 @@
 	}
 	if (brightFt) {
 		CGFloat brightness = (*brightFt) (self, _percent);
-		CGSSetWindowListBrightness(cgs, &wid, &brightness, 1);
+		CGSSetWindowListBrightness(cgs, &wid, (float *)&brightness, 1);
 	}
 	if (progress == 1.0f)
 	[self finishAnimation];
@@ -140,7 +140,7 @@
 - (void)setWindow:(NSWindow *)aWindow {
 	if(_window != aWindow){
 		_window = aWindow;
-		wid = [aWindow windowNumber];
+		wid = (int)[aWindow windowNumber];
 	}
 }
 
@@ -174,7 +174,7 @@
 		//	[_window setAlphaValue:1.0f];
 
 	}
-	CGSSetWindowListBrightness(cgs, &wid, &_brightA, 1);
+	CGSSetWindowListBrightness(cgs, &wid, (float *)&_brightA, 1);
 
 }
 


### PR DESCRIPTION
I've did it again. In my eagerness to silence warnings, I broke CGSPrivate.

I was trying to fix the Cube issues (since @skurfer was kinda expecting that from #2144) and noticed a hard crash (the same as #1811). So this one stops the crash, but the animation is still horrible (here I can see it jump down (topscreen/topwindow distance seem to become bottomscreen/bottomwindow) and turn to some invisible window side before getting a hold of itself...

I'll try to pinpoint what's going wrong with it, but I have no clue whatsoever about what. is. going. on.

I'll merge that ASAP because it's a quick fix. Just wanted a heads up to you guys.