### PR TITLE
Fix for #2111

### DIFF
--- a/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
@@ -746,7 +746,8 @@ NSMutableDictionary *bindingsDict = nil;
 		NSRect titleFrame = [self frame];
 		NSRect editorFrame = NSInsetRect(titleFrame, NSHeight(titleFrame) /16, NSHeight(titleFrame)/16);
 		editorFrame.origin = NSMakePoint(NSHeight(titleFrame) /16, NSHeight(titleFrame)/16);
-    
+        editorFrame = NSIntegralRect(editorFrame);
+
         [[self textModeEditor] setMaxSize:NSMakeSize(FLT_MAX, FLT_MAX)];
         [[self textModeEditor] setFocusRingType:NSFocusRingTypeNone];        
         [[self textModeEditor] setDelegate: self];


### PR DESCRIPTION
After much twiddling with debuggers and Flashlights, I think I got it.

The problem is that sometimes, the calculation of the containing scrollview doesn't end on an integral rect. [This](https://github.com/quicksilver/Quicksilver/blob/master/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m#L746), returns this rect `
(origin = (x = 1.25, y = 1.25), size = (width = 57.5, height = 17.5))` which is then set as the scroll view frame, and this triggers a bug within the layout code where the text fields tries to adapt to that weird size but just ends up blowing up the stack because it's not pixel-aligned.

We might want check the various affected interfaces so this does not look too jarring visually.