### PR TITLE
Text preferences

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSPreferenceKeys.h
+++ b/Quicksilver/Code-QuickStepCore/QSPreferenceKeys.h
@@ -61,6 +61,7 @@ Following lines are no longer used in this project.
 #define kQSTextMatchedUnderline @"Text Matched Underline"
 #define kQSTextMatchedAlwaysShowName @"Text Matched Always Show Name"
 #define kQSTextAllowTightening @"Text Allow Tightening"
+#define kQSTextGlowDivisor @"Text Glow Divisor"
 
 #define kResultTableSplit @"Result Table Split Width"
 

--- a/Quicksilver/Code-QuickStepCore/QSPreferenceKeys.h
+++ b/Quicksilver/Code-QuickStepCore/QSPreferenceKeys.h
@@ -56,6 +56,12 @@ Following lines are no longer used in this project.
 #define kQSAppearance3A @"QSAppearance3A"
 #define kQSAppearance3T @"QSAppearance3T"
 
+// Text Appearance Properties
+#define kQSTextMatchedGlow @"Text Matched Glow"
+#define kQSTextMatchedUnderline @"Text Matched Underline"
+#define kQSTextMatchedAlwaysShowName @"Text Matched Always Show Name"
+#define kQSTextAllowTightening @"Text Allow Tightening"
+
 #define kResultTableSplit @"Result Table Split Width"
 
 // Date of last known Quicksilver Crash

--- a/Quicksilver/Code-QuickStepInterface/QSObjectCell.m
+++ b/Quicksilver/Code-QuickStepInterface/QSObjectCell.m
@@ -486,7 +486,8 @@
 			}
 			if ([defaults boolForKey:kQSTextMatchedGlow]) {
 				NSShadow *glow = [[NSShadow alloc] init];
-				CGFloat radius = self.nameFont.pointSize/16.0;
+				CGFloat divisor = [[defaults objectForKey:kQSTextGlowDivisor] floatValue];
+				CGFloat radius = self.nameFont.pointSize/divisor;
 				[glow setShadowBlurRadius:radius];
 				[glow setShadowColor:fadedColor];
 				[attributes setObject:glow forKey:NSShadowAttributeName];

--- a/Quicksilver/Code-QuickStepInterface/QSObjectCell.m
+++ b/Quicksilver/Code-QuickStepInterface/QSObjectCell.m
@@ -447,8 +447,9 @@
         }
         
 		if (!nameString) nameString = [drawObject displayName];
+		NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
 		BOOL showRankedStringOnly = nameString == nil
-			|| ![[NSUserDefaults standardUserDefaults] boolForKey:kQSTextMatchedAlwaysShowName]
+			|| ![defaults boolForKey:kQSTextMatchedAlwaysShowName]
 			|| [nameString isEqualToString:[drawObject displayName]];
         if (!nameString) {
             // fall back to the identifier if no reasonable name can be found
@@ -478,7 +479,6 @@
 			NSMutableDictionary *attributes = [NSMutableDictionary dictionaryWithObjectsAndKeys:
 				showRankedStringOnly ? mainColor : fadedColor, NSForegroundColorAttributeName,
 				nil];
-			NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
 			if ([defaults boolForKey:kQSTextMatchedUnderline]) {
 				[attributes setObject:showRankedStringOnly ? mainColor : fadedColor forKey:NSUnderlineColorAttributeName];
 				[attributes setObject:[NSNumber numberWithFloat:2.0] forKey:NSUnderlineStyleAttributeName];

--- a/Quicksilver/Code-QuickStepInterface/QSObjectCell.m
+++ b/Quicksilver/Code-QuickStepInterface/QSObjectCell.m
@@ -392,6 +392,9 @@
 	[style setFirstLineHeadIndent:1.0];
 	[style setHeadIndent:1.0];
 	[style setAlignment:[self alignment]];
+	if ([NSApplication isYosemite] && ![[NSUserDefaults standardUserDefaults] boolForKey:kQSTextAllowTightening]) {
+		[style setTighteningFactorForTruncation:0.0];
+	}
 	//
 	/// NSLog(@"%d %d", [self isHighlighted] , [self state]);
 
@@ -444,7 +447,9 @@
         }
         
 		if (!nameString) nameString = [drawObject displayName];
-        BOOL rankedStringIsName = [nameString isEqualToString:[drawObject displayName]] || nameString == nil;
+		BOOL showRankedStringOnly = nameString == nil
+			|| ![[NSUserDefaults standardUserDefaults] boolForKey:kQSTextMatchedAlwaysShowName]
+			|| [nameString isEqualToString:[drawObject displayName]];
         if (!nameString) {
             // fall back to the identifier if no reasonable name can be found
             nameString = [drawObject identifier];
@@ -459,24 +464,34 @@
 		NSRect textDrawRect = [self titleRectForBounds:cellFrame];
         
 		NSMutableAttributedString *titleString = [[NSMutableAttributedString alloc] initWithString:nameString];
-        [titleString setAttributes:rankedStringIsName ? nameAttributes : detailsAttributes range:NSMakeRange(0, [titleString length])];
+        [titleString setAttributes:showRankedStringOnly ? nameAttributes : detailsAttributes range:NSMakeRange(0, [titleString length])];
         
         
 		if (abbreviationString && ![abbreviationString hasPrefix:@"QSActionMnemonic"]) {
-			[titleString addAttribute:NSForegroundColorAttributeName value:rankedStringIsName ? fadedColor : [fadedColor colorWithAlphaComponent:0.8] range:NSMakeRange(0, [titleString length])];
+			[titleString addAttribute:NSForegroundColorAttributeName value:showRankedStringOnly ? fadedColor : [fadedColor colorWithAlphaComponent:0.8] range:NSMakeRange(0, [titleString length])];
             
 			// Organise displaying the text, underlining the letters typed (in the name)
 			NSUInteger i = 0;
 			NSUInteger j = 0;
 			NSUInteger hits[[titleString length]];
 			NSUInteger count = [hitMask getIndexes:(NSUInteger *)&hits maxCount:[titleString length] inIndexRange:nil];
-			NSDictionary *attributes = [NSDictionary dictionaryWithObjectsAndKeys:
-                                        rankedStringIsName ? mainColor : fadedColor, NSForegroundColorAttributeName,
-                                        rankedStringIsName ? mainColor : fadedColor, NSUnderlineColorAttributeName,
-                                        [NSNumber numberWithInteger:2.0] , NSUnderlineStyleAttributeName,
-                                        [NSNumber numberWithDouble:1.0] , NSBaselineOffsetAttributeName,
-                                        nil];
-            
+			NSMutableDictionary *attributes = [NSMutableDictionary dictionaryWithObjectsAndKeys:
+				showRankedStringOnly ? mainColor : fadedColor, NSForegroundColorAttributeName,
+				nil];
+			NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+			if ([defaults boolForKey:kQSTextMatchedUnderline]) {
+				[attributes setObject:showRankedStringOnly ? mainColor : fadedColor forKey:NSUnderlineColorAttributeName];
+				[attributes setObject:[NSNumber numberWithFloat:2.0] forKey:NSUnderlineStyleAttributeName];
+				[attributes setObject:[NSNumber numberWithFloat:1.0] forKey:NSBaselineOffsetAttributeName];
+			}
+			if ([defaults boolForKey:kQSTextMatchedGlow]) {
+				NSShadow *glow = [[NSShadow alloc] init];
+				CGFloat radius = self.nameFont.pointSize/16.0;
+				[glow setShadowBlurRadius:radius];
+				[glow setShadowColor:fadedColor];
+				[attributes setObject:glow forKey:NSShadowAttributeName];
+			}
+
 			for(i = 0; i<count; i += j) {
 				for (j = 1; i+j<count && hits[i+j-1] +1 == hits[i+j]; j++);
 				[titleString addAttributes:attributes range:NSMakeRange(hits[i], j)];
@@ -486,7 +501,7 @@
 		}
         
         // Ranked string and nameString aren't the same. Show 'nameString  ⟷ rankedString' in the UI
-        if (!rankedStringIsName && [drawObject displayName].length) {
+        if (!showRankedStringOnly && [drawObject displayName].length) {
             [titleString addAttribute:NSFontAttributeName value:detailsFont range:NSMakeRange(0,[titleString length])];
             NSMutableAttributedString *attributedNameString = [[NSMutableAttributedString alloc] initWithString:[drawObject displayName]];
             [attributedNameString setAttributes:nameAttributes range:NSMakeRange(0, [[drawObject displayName] length])];

--- a/Quicksilver/Nibs/QSAppearancePrefPane.xib
+++ b/Quicksilver/Nibs/QSAppearancePrefPane.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="5056" systemVersion="13D65" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="9060" systemVersion="15B42" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
     <dependencies>
-        <deployment version="1070" defaultVersion="1070" identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="5056"/>
+        <deployment identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="9060"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="QSAppearancePrefPane">
@@ -13,21 +13,22 @@
             </connections>
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
-        <customObject id="-3" userLabel="Application"/>
-        <window title="&lt;&lt; do not localize >>" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" deferred="NO" oneShot="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="12" userLabel="PrefPane">
+        <customObject id="-3" userLabel="Application" customClass="NSObject"/>
+        <window title="&lt;&lt; do not localize &gt;&gt;" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" deferred="NO" oneShot="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="12" userLabel="PrefPane">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
-            <rect key="contentRect" x="163" y="379" width="384" height="300"/>
+            <rect key="contentRect" x="163" y="379" width="384" height="484"/>
             <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1028"/>
             <value key="minSize" type="size" width="384" height="5"/>
             <value key="maxSize" type="size" width="384" height="384"/>
             <view key="contentView" id="6">
-                <rect key="frame" x="0.0" y="0.0" width="384" height="300"/>
+                <rect key="frame" x="0.0" y="0.0" width="384" height="484"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <button toolTip="Enable eye-candy" id="98">
-                        <rect key="frame" x="17" y="233" width="245" height="18"/>
+                        <rect key="frame" x="17" y="417" width="245" height="18"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                        <animations/>
                         <buttonCell key="cell" type="check" title="Superfluous visual effects" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="194">
                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                             <font key="font" metaFont="smallSystem"/>
@@ -37,8 +38,9 @@
                         </connections>
                     </button>
                     <textField verticalHuggingPriority="750" id="100">
-                        <rect key="frame" x="17" y="257" width="132" height="14"/>
+                        <rect key="frame" x="17" y="441" width="132" height="14"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                        <animations/>
                         <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="left" title="Select Interface:" id="195">
                             <font key="font" metaFont="smallSystem"/>
                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -46,8 +48,9 @@
                         </textFieldCell>
                     </textField>
                     <button id="101">
-                        <rect key="frame" x="193" y="101" width="164" height="18"/>
+                        <rect key="frame" x="193" y="285" width="164" height="18"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                        <animations/>
                         <buttonCell key="cell" type="check" title="Bezels are glass" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="196">
                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                             <font key="font" metaFont="smallSystem"/>
@@ -57,8 +60,9 @@
                         </connections>
                     </button>
                     <button id="103">
-                        <rect key="frame" x="193" y="81" width="164" height="18"/>
+                        <rect key="frame" x="193" y="265" width="164" height="18"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                        <animations/>
                         <buttonCell key="cell" type="check" title="Bezels have shadows" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="197">
                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                             <font key="font" metaFont="smallSystem"/>
@@ -68,8 +72,9 @@
                         </connections>
                     </button>
                     <popUpButton toolTip="Interface type" verticalHuggingPriority="750" id="105">
-                        <rect key="frame" x="148" y="252" width="110" height="22"/>
+                        <rect key="frame" x="148" y="436" width="110" height="22"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                        <animations/>
                         <popUpButtonCell key="cell" type="push" title="Window" bezelStyle="rounded" alignment="left" controlSize="small" lineBreakMode="clipping" state="on" borderStyle="borderAndBezel" inset="2" arrowPosition="arrowAtCenter" preferredEdge="maxY" selectedItem="115" id="198">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="smallSystem"/>
@@ -85,8 +90,9 @@
                         </connections>
                     </popUpButton>
                     <colorWell toolTip="Background color for the selected pane in the main window" id="106">
-                        <rect key="frame" x="134" y="98" width="24" height="24"/>
+                        <rect key="frame" x="134" y="282" width="24" height="24"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                        <animations/>
                         <color key="color" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                         <connections>
                             <binding destination="132" name="value" keyPath="values.QSAppearance1A" id="154">
@@ -97,13 +103,15 @@
                         </connections>
                     </colorWell>
                     <imageView toolTip="Background" id="107">
-                        <rect key="frame" x="111" y="125" width="24" height="27"/>
+                        <rect key="frame" x="111" y="309" width="24" height="27"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                        <animations/>
                         <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="AppearanceBack" id="199"/>
                     </imageView>
                     <colorWell toolTip="Text color of the result window header/footer text" id="108">
-                        <rect key="frame" x="157" y="75" width="24" height="24"/>
+                        <rect key="frame" x="157" y="259" width="24" height="24"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                        <animations/>
                         <color key="color" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                         <connections>
                             <binding destination="132" name="value" keyPath="values.QSAppearance2T" id="IBR-rL-rZK">
@@ -114,8 +122,9 @@
                         </connections>
                     </colorWell>
                     <colorWell toolTip="Text color in the main window" id="109">
-                        <rect key="frame" x="157" y="98" width="24" height="24"/>
+                        <rect key="frame" x="157" y="282" width="24" height="24"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                        <animations/>
                         <color key="color" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                         <connections>
                             <binding destination="132" name="value" keyPath="values.QSAppearance1T" id="157">
@@ -125,21 +134,24 @@
                             </binding>
                         </connections>
                     </colorWell>
-                    <box verticalHuggingPriority="750" title="Box" boxType="separator" titlePosition="noTitle" id="112">
-                        <rect key="frame" x="19" y="204" width="324" height="4"/>
+                    <box verticalHuggingPriority="750" title="Box" boxType="separator" titlePosition="noTitle" id="112" userLabel="Horizontal Line above Colors">
+                        <rect key="frame" x="19" y="388" width="324" height="4"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                        <animations/>
                         <color key="borderColor" white="0.0" alpha="0.41999999999999998" colorSpace="calibratedWhite"/>
                         <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                         <font key="titleFont" metaFont="system"/>
                     </box>
                     <imageView toolTip="Text" id="113">
-                        <rect key="frame" x="157" y="125" width="24" height="27"/>
+                        <rect key="frame" x="157" y="309" width="24" height="27"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                        <animations/>
                         <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="AppearanceText" id="200"/>
                     </imageView>
                     <textField verticalHuggingPriority="750" id="114">
-                        <rect key="frame" x="17" y="75" width="88" height="18"/>
+                        <rect key="frame" x="17" y="259" width="88" height="18"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                        <animations/>
                         <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="left" title="Result Headers:" id="201">
                             <font key="font" metaFont="smallSystem"/>
                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -147,8 +159,9 @@
                         </textFieldCell>
                     </textField>
                     <textField verticalHuggingPriority="750" id="116">
-                        <rect key="frame" x="17" y="52" width="88" height="18"/>
+                        <rect key="frame" x="17" y="236" width="88" height="18"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                        <animations/>
                         <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="left" title="Result Lists:" id="202">
                             <font key="font" metaFont="smallSystem"/>
                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -156,8 +169,9 @@
                         </textFieldCell>
                     </textField>
                     <colorWell toolTip="Color of the results list selected row" id="117">
-                        <rect key="frame" x="134" y="52" width="24" height="24"/>
+                        <rect key="frame" x="134" y="236" width="24" height="24"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                        <animations/>
                         <color key="color" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                         <connections>
                             <binding destination="132" name="value" keyPath="values.QSAppearance3A" id="161">
@@ -168,8 +182,9 @@
                         </connections>
                     </colorWell>
                     <colorWell toolTip="Text color in the results list rows" id="118">
-                        <rect key="frame" x="157" y="52" width="24" height="24"/>
+                        <rect key="frame" x="157" y="236" width="24" height="24"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                        <animations/>
                         <color key="color" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                         <connections>
                             <binding destination="132" name="value" keyPath="values.QSAppearance3T" id="163">
@@ -180,13 +195,15 @@
                         </connections>
                     </colorWell>
                     <imageView toolTip="Selection &amp; Accents" id="119">
-                        <rect key="frame" x="134" y="125" width="24" height="27"/>
+                        <rect key="frame" x="134" y="309" width="24" height="27"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                        <animations/>
                         <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="AppearanceSelection" id="203"/>
                     </imageView>
                     <colorWell toolTip="Background color of the main window" id="121">
-                        <rect key="frame" x="111" y="98" width="24" height="24"/>
+                        <rect key="frame" x="111" y="282" width="24" height="24"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                        <animations/>
                         <color key="color" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                         <connections>
                             <binding destination="132" name="value" keyPath="values.QSAppearance1B" id="137">
@@ -197,8 +214,9 @@
                         </connections>
                     </colorWell>
                     <colorWell toolTip="Background color of the results list" id="122">
-                        <rect key="frame" x="111" y="52" width="24" height="24"/>
+                        <rect key="frame" x="111" y="236" width="24" height="24"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                        <animations/>
                         <color key="color" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                         <connections>
                             <binding destination="132" name="value" keyPath="values.QSAppearance3B" id="144">
@@ -209,8 +227,9 @@
                         </connections>
                     </colorWell>
                     <colorWell toolTip="Header and footer background color in the result list" id="123">
-                        <rect key="frame" x="111" y="75" width="24" height="24"/>
+                        <rect key="frame" x="111" y="259" width="24" height="24"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                        <animations/>
                         <color key="color" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                         <connections>
                             <binding destination="132" name="value" keyPath="values.QSAppearance2B" id="140">
@@ -221,8 +240,9 @@
                         </connections>
                     </colorWell>
                     <textField verticalHuggingPriority="750" id="124">
-                        <rect key="frame" x="17" y="98" width="88" height="18"/>
+                        <rect key="frame" x="17" y="282" width="88" height="18"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                        <animations/>
                         <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="left" title="Main Window:" id="204">
                             <font key="font" metaFont="smallSystem"/>
                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -230,8 +250,9 @@
                         </textFieldCell>
                     </textField>
                     <button verticalHuggingPriority="750" id="125">
-                        <rect key="frame" x="110" y="28" width="72" height="16"/>
+                        <rect key="frame" x="110" y="212" width="72" height="16"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                        <animations/>
                         <buttonCell key="cell" type="push" title="Defaults" bezelStyle="rounded" alignment="center" controlSize="mini" borderStyle="border" inset="2" id="205">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="miniSystem"/>
@@ -241,8 +262,9 @@
                         </connections>
                     </button>
                     <textField toolTip="Unused" verticalHuggingPriority="750" id="127">
-                        <rect key="frame" x="138" y="79" width="16" height="16"/>
+                        <rect key="frame" x="138" y="263" width="16" height="16"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                        <animations/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="left" drawsBackground="YES" id="206">
                             <font key="font" metaFont="system"/>
                             <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
@@ -250,8 +272,9 @@
                         </textFieldCell>
                     </textField>
                     <button toolTip="Click to customise the interface" verticalHuggingPriority="750" id="188">
-                        <rect key="frame" x="253" y="249" width="95" height="28"/>
+                        <rect key="frame" x="253" y="433" width="95" height="28"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
+                        <animations/>
                         <buttonCell key="cell" type="push" title="Customize" bezelStyle="rounded" alignment="center" controlSize="small" borderStyle="border" inset="2" id="209">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="smallSystem"/>
@@ -261,8 +284,9 @@
                         </connections>
                     </button>
                     <button toolTip="Preview the colour changes in the interface" verticalHuggingPriority="750" id="190">
-                        <rect key="frame" x="253" y="128" width="95" height="28"/>
+                        <rect key="frame" x="253" y="312" width="95" height="28"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <animations/>
                         <buttonCell key="cell" type="push" title="Preview" bezelStyle="rounded" alignment="center" controlSize="small" borderStyle="border" inset="2" id="210">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="smallSystem"/>
@@ -272,8 +296,9 @@
                         </connections>
                     </button>
                     <textField verticalHuggingPriority="750" id="211">
-                        <rect key="frame" x="17" y="279" width="136" height="17"/>
+                        <rect key="frame" x="17" y="463" width="136" height="17"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <animations/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Interface" id="212">
                             <font key="font" metaFont="system"/>
                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -281,8 +306,9 @@
                         </textFieldCell>
                     </textField>
                     <textField verticalHuggingPriority="750" id="213">
-                        <rect key="frame" x="35" y="214" width="272" height="17"/>
+                        <rect key="frame" x="35" y="398" width="272" height="17"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <animations/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Make the interface pop in and out" id="214">
                             <font key="font" metaFont="smallSystem"/>
                             <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
@@ -290,8 +316,9 @@
                         </textFieldCell>
                     </textField>
                     <textField verticalHuggingPriority="750" id="215">
-                        <rect key="frame" x="17" y="181" width="113" height="17"/>
+                        <rect key="frame" x="17" y="365" width="113" height="17"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <animations/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Colors" id="216">
                             <font key="font" metaFont="system"/>
                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -299,25 +326,96 @@
                         </textFieldCell>
                     </textField>
                     <textField verticalHuggingPriority="750" id="217">
-                        <rect key="frame" x="17" y="164" width="329" height="14"/>
+                        <rect key="frame" x="17" y="348" width="329" height="14"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <animations/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Use the palette below to alter the colors of the interface" id="218">
                             <font key="font" metaFont="smallSystem"/>
                             <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
+                    <box verticalHuggingPriority="750" title="Box" boxType="separator" titlePosition="noTitle" id="4sn-lu-cqm" userLabel="Horizontal Line above Text">
+                        <rect key="frame" x="20" y="195" width="324" height="4"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                        <animations/>
+                        <color key="borderColor" white="0.0" alpha="0.41999999999999998" colorSpace="calibratedWhite"/>
+                        <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                        <font key="titleFont" metaFont="system"/>
+                    </box>
+                    <textField verticalHuggingPriority="750" id="0CU-2w-qmg" userLabel="Text">
+                        <rect key="frame" x="18" y="172" width="113" height="17"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <animations/>
+                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Text" id="bxO-4R-uyu">
+                            <font key="font" metaFont="system"/>
+                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
+                    <button toolTip="Underline the searched for characters in an item’s name" id="dSq-e1-t7W">
+                        <rect key="frame" x="17" y="147" width="340" height="20"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                        <animations/>
+                        <buttonCell key="cell" type="check" title="Underline Matched Text" bezelStyle="regularSquare" imagePosition="left" controlSize="small" inset="2" id="RuL-qQ-Adf">
+                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                            <font key="font" metaFont="smallSystem"/>
+                        </buttonCell>
+                        <connections>
+                            <binding destination="132" name="value" keyPath="values.Text Matched Underline" id="G3G-tr-xOF"/>
+                        </connections>
+                    </button>
+                    <button toolTip="Add a glow to the searched for characters in an item’s name" id="3x8-3C-Qos">
+                        <rect key="frame" x="17" y="127" width="340" height="20"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                        <animations/>
+                        <buttonCell key="cell" type="check" title="Add Glow to Matched Text" bezelStyle="regularSquare" imagePosition="left" controlSize="small" inset="2" id="Z2c-mk-eka">
+                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                            <font key="font" metaFont="smallSystem"/>
+                        </buttonCell>
+                        <connections>
+                            <binding destination="132" name="value" keyPath="values.Text Matched Glow" id="FnN-ge-6B9"/>
+                        </connections>
+                    </button>
+                    <button id="Xq1-Sv-bTE">
+                        <rect key="frame" x="17" y="107" width="340" height="20"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                        <animations/>
+                        <buttonCell key="cell" type="check" title="Always Show Name" bezelStyle="regularSquare" imagePosition="left" controlSize="small" inset="2" id="tWF-dQ-7J6">
+                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                            <font key="font" metaFont="smallSystem"/>
+                        </buttonCell>
+                        <connections>
+                            <binding destination="132" name="value" keyPath="values.Text Matched Always Show Name" id="GiC-f2-LxN"/>
+                        </connections>
+                    </button>
+                    <button toolTip="When the item’s name can’t fit, try squeezing letters together before truncating" id="QE0-Cl-LSL">
+                        <rect key="frame" x="17" y="87" width="340" height="20"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                        <animations/>
+                        <buttonCell key="cell" type="check" title="Compress Long Names" bezelStyle="regularSquare" imagePosition="left" controlSize="small" inset="2" id="4UN-QX-5xq">
+                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                            <font key="font" metaFont="smallSystem"/>
+                        </buttonCell>
+                        <connections>
+                            <binding destination="132" name="value" keyPath="values.Text Allow Tightening" id="PuA-29-Czv"/>
+                        </connections>
+                    </button>
                 </subviews>
+                <animations/>
             </view>
+            <point key="canvasLocation" x="273" y="239"/>
         </window>
         <userDefaultsController representsSharedInstance="YES" id="132" userLabel="Shared Defaults"/>
         <view id="111">
             <rect key="frame" x="0.0" y="0.0" width="125" height="1"/>
             <autoresizingMask key="autoresizingMask"/>
+            <animations/>
         </view>
         <view id="110">
             <rect key="frame" x="0.0" y="0.0" width="125" height="1"/>
             <autoresizingMask key="autoresizingMask"/>
+            <animations/>
         </view>
     </objects>
     <resources>

--- a/Quicksilver/Nibs/QSAppearancePrefPane.xib
+++ b/Quicksilver/Nibs/QSAppearancePrefPane.xib
@@ -377,7 +377,7 @@
                             <binding destination="132" name="value" keyPath="values.Text Matched Glow" id="FnN-ge-6B9"/>
                         </connections>
                     </button>
-                    <button id="Xq1-Sv-bTE">
+                    <button toolTip="When the search matches an item’s label, keep the name visible" id="Xq1-Sv-bTE">
                         <rect key="frame" x="17" y="107" width="340" height="20"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                         <animations/>

--- a/Quicksilver/Resources/QSDefaults.plist
+++ b/Quicksilver/Resources/QSDefaults.plist
@@ -89,5 +89,7 @@
 	<false/>
 	<key>Text Matched Underline</key>
 	<true/>
+	<key>Text Glow Divisor</key>
+	<real>16</real>
 </dict>
 </plist>

--- a/Quicksilver/Resources/QSDefaults.plist
+++ b/Quicksilver/Resources/QSDefaults.plist
@@ -81,5 +81,13 @@
 	<string>QSDefaultStringRanker</string>
 	<key>Browse Mode</key>
 	<integer>2</integer>
+	<key>Text Allow Tightening</key>
+	<true/>
+	<key>Text Matched Always Show Name</key>
+	<true/>
+	<key>Text Matched Glow</key>
+	<false/>
+	<key>Text Matched Underline</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
Adds 4 new preferences for controlling the appearance of text in a `QSObjectCell`:

  * Underline matched text
  * Make matched text “glow” (a shadow that matches the details color, which is the text color faded by 20%)
  * Allow users to turn off “name ⟷ label” and just show the matched string (the original behavior). A gift for @hmelman and I’m sure others.
  * Allow users to disable text tightening. It causes letters to overlap with some fonts.

This is mostly motivated by some problems that were plaguing users, and my long-time hatred of the underlined letters. (I’ve been using “glow” for like a year locally.) I thought it made sense to do them all together. We could also add a color picker for matched text and some other options, but this is a good starting point.

Note that I updated the NIB’s deployment target.

The defaults for these prefs will mimic the existing behavior.