### PR TITLE
allow Quicksilver Selection to refer to other proxy objects

### DIFF
--- a/Quicksilver/Code-App/QSController.m
+++ b/Quicksilver/Code-App/QSController.m
@@ -539,7 +539,6 @@ static QSController *defaultController = nil;
 	} else {
 		QSObject *object = [[[self interfaceController] dSelector] objectValue];
 		if ([object isEqual:proxy]) return [[[self interfaceController] dSelector] previousObjectValue];
-        if ([object isProxyObject]) return nil;
 		return object;
 	}
 	return nil;


### PR DESCRIPTION
Not sure why this would have been prevented. The line above already protects against a circular reference.

I see that I’m the one that wrote it, but I was just rewriting a test that was already there.