### PR TITLE
Fix check_indent false positives on comment blocks

### DIFF
--- a/Quicksilver/Tools/travis/check_indent.rb
+++ b/Quicksilver/Tools/travis/check_indent.rb
@@ -5,10 +5,16 @@ require 'set'
 
 changed_lines = `git diff $TRAVIS_COMMIT_RANGE -- *.[mh]`.split("\n").select { |l| l.start_with? "+" }
 
+comment_block = false
+
 changed_lines.each do |line|
-	if /^\+ /.match(line) then
+	if /^\+ /.match(line) and not comment_block then
 		puts "Invalid line #{line}"
 		exit 1
+	elsif /^\+\s*?\/\*\*/.match(line) then
+		comment_block = true
+	elsif /^\+\s*?\*\*\//.match(line) then
+		comment_block = false
 	end
 end
 


### PR DESCRIPTION
Don't worry about indents inside comment blocks

I saw that the test on @skurfer's  `objectchosen` branch were failing because of bad spaces/tabs in comment blocks. This change allows spaces/tabs/anything in comment blocks, although I'm still not sure if we should do this. If we're enforcing one format over the other, then shouldn't we also do that inside comment blocks?

Discuss ;-)