### PR TITLE
Don't mount volumes when resolving aliases

### DIFF
--- a/Quicksilver/Code-QuickStepFoundation/NSFileManager_BLTRExtensions.m
+++ b/Quicksilver/Code-QuickStepFoundation/NSFileManager_BLTRExtensions.m
@@ -126,28 +126,27 @@
 
 - (NSString *)resolveAliasAtPath:(NSString *)aliasFullPath usingUI:(BOOL)usingUI {
 	NSURL *url = [NSURL fileURLWithPath:aliasFullPath];
-    
-    // First resolve any symlinks
-    NSURL *resolvedURL = [url URLByReallyResolvingSymlinksInPath];
-    
-    // File is a Finder alias file, resolve bookmark data first
-    NSError *err;
-    NSData *bookmarkData = [NSURL bookmarkDataWithContentsOfURL:resolvedURL error:&err];
-    if (!bookmarkData) {
-        return [resolvedURL path];
-    }
-    
-    NSUInteger options = 0;
-    if (!usingUI) {
-        options |= (NSURLBookmarkResolutionWithoutUI | NSURLBookmarkResolutionWithoutMounting);
-    }
-    NSURL *aliasURL = [NSURL URLByResolvingBookmarkData:bookmarkData options:options relativeToURL:nil bookmarkDataIsStale:nil error:&err];
-    
-    if (!aliasURL) {
-        return nil;
-    }
-    return [aliasURL path];
-    
+	
+	// First resolve any symlinks
+	NSURL *resolvedURL = [url URLByReallyResolvingSymlinksInPath];
+
+	// File is a Finder alias file, resolve bookmark data first
+	NSError *err;
+	NSData *bookmarkData = [NSURL bookmarkDataWithContentsOfURL:resolvedURL error:&err];
+	if (!bookmarkData) {
+		return [resolvedURL path];
+	}
+
+	NSUInteger options = 0;
+	if (!usingUI) {
+		options |= (NSURLBookmarkResolutionWithoutUI | NSURLBookmarkResolutionWithoutMounting);
+	}
+	NSURL *aliasURL = [NSURL URLByResolvingBookmarkData:bookmarkData options:options relativeToURL:nil bookmarkDataIsStale:nil error:&err];
+
+	if (!aliasURL) {
+		return nil;
+	}
+	return [aliasURL path];
 }
 
 - (NSArray *)itemsForPath:(NSString *)path depth:(NSInteger)depth types:(NSArray *)types {

--- a/Quicksilver/Code-QuickStepFoundation/NSFileManager_BLTRExtensions.m
+++ b/Quicksilver/Code-QuickStepFoundation/NSFileManager_BLTRExtensions.m
@@ -139,12 +139,12 @@
     
     NSUInteger options = 0;
     if (!usingUI) {
-        options |= NSURLBookmarkResolutionWithoutUI;
-    };
+        options |= (NSURLBookmarkResolutionWithoutUI | NSURLBookmarkResolutionWithoutMounting);
+    }
     NSURL *aliasURL = [NSURL URLByResolvingBookmarkData:bookmarkData options:options relativeToURL:nil bookmarkDataIsStale:nil error:&err];
     
     if (!aliasURL) {
-        return [resolvedURL path];
+        return nil;
     }
     return [aliasURL path];
     


### PR DESCRIPTION
I think this is going to be controversial. This makes QS never try to mount network volumes when resolving aliases, as right now we have no way to discern whether this is a "user-initiated" resolution, or some background scan.

Thinking about it, I should have split that... The second part makes the resolution fail completely instead of returning itself. Say you're browsing some folder containing one of those remote aliases, if you right-arrowed (and had the patience to wait for it to fail), you'd end up with a new result set with only that alias, instead of the expected bump.