### PR TITLE
show proxy object icons more reliably

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSCommand.m
+++ b/Quicksilver/Code-QuickStepCore/QSCommand.m
@@ -466,6 +466,7 @@ NSTimeInterval QSTimeIntervalForString(NSString *intervalString) {
 	} else {
 		// indirect object is either present, or unnecessary - run the action
 		QSObject *returnValue = [actionObject performOnDirectObject:directObject indirectObject:indirectObject];
+		[[NSNotificationCenter defaultCenter] postNotificationName:QSCommandExecutedNotification object:self];
 		if (returnValue) {
 			// if the action returns something, wipe out the first pane
 			/* (The main object would get replaced anyway. This is only done to

--- a/Quicksilver/Code-QuickStepCore/QSNotifications.h
+++ b/Quicksilver/Code-QuickStepCore/QSNotifications.h
@@ -9,6 +9,8 @@
 #define QSCatalogIndexingCompleted @"QSCatalogIndexingCompleted"
 #define QSCatalogSourceInvalidated @"QSCatalogSourceInvalidated"
 
+#define QSCommandExecutedNotification @"QSCommandExecutedNotification"
+
 #define QSDebugLogRequest @"QSDebugLogRequest"
 
 #define QSActiveApplicationChanged QSProcessMonitorFrontApplicationSwitched

--- a/Quicksilver/Code-QuickStepCore/QSProxyObject.m
+++ b/Quicksilver/Code-QuickStepCore/QSProxyObject.m
@@ -90,8 +90,12 @@
 
 - (void)releaseProxy {
 	//NSLog(@"release proxy");
-    [[NSNotificationCenter defaultCenter] removeObserver:self name:QSObjectIconModified object:[cache objectForKey:QSProxyTargetCache]];
 	[cache removeObjectForKey:QSProxyTargetCache];
+}
+
+- (void)dealloc
+{
+	[[NSNotificationCenter defaultCenter] removeObserver:self name:QSObjectIconModified object:nil];
 }
 
 - (NSArray *)proxyTypes {

--- a/Quicksilver/Code-QuickStepCore/QSProxyObject.m
+++ b/Quicksilver/Code-QuickStepCore/QSProxyObject.m
@@ -73,6 +73,7 @@
     if (proxy) {
         [self setObject:proxy forCache:QSProxyTargetCache];
 		[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(releaseProxy) name:QSReleaseOldCachesNotification object:nil];
+		[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(releaseProxy) name:QSCommandExecutedNotification object:nil];
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(objectIconModified:) name:QSObjectIconModified object:proxy];
     }
 	return proxy;
@@ -82,6 +83,7 @@
 - (void)releaseProxy {
 	//NSLog(@"release proxy");
 	[[NSNotificationCenter defaultCenter] removeObserver:self name:QSReleaseOldCachesNotification object:nil];
+	[[NSNotificationCenter defaultCenter] removeObserver:self name:QSCommandExecutedNotification object:nil];
 	[[NSNotificationCenter defaultCenter] removeObserver:self name:QSObjectIconModified object:[cache objectForKey:QSProxyTargetCache]];
 	// hold onto the object long enough for the command to execute, then release
 	NSTimeInterval interval = kQSDefaultProxyCacheTime;

--- a/Quicksilver/Code-QuickStepInterface/QSObjectCell.m
+++ b/Quicksilver/Code-QuickStepInterface/QSObjectCell.m
@@ -278,30 +278,6 @@
 	[self drawInteriorWithFrame:[self drawingRectForBounds:cellFrame] inView:controlView];
 }
 
-- (NSArray*)imagesForTypes:(NSArray *)types {
-	NSMutableArray *typeImageArray = [NSMutableArray arrayWithCapacity:1];
-	NSString *thisType;
-	NSDictionary *imageDictionary = [self typeImageDictionary];
-	for(thisType in types) {
-		NSImage *typeImage = [imageDictionary objectForKey:thisType];
-		if (typeImage) [typeImageArray addObject:typeImage];
-	}
-	return typeImageArray;
-}
-- (NSDictionary *)typeImageDictionary {
-    static __strong NSDictionary *d;
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        d = [NSDictionary dictionaryWithObjectsAndKeys:
-             QSFilePathType, [QSResourceManager imageNamed:@"fileType"] ,
-             QSTextType, [QSResourceManager imageNamed:@"textType"] ,
-             NSURLPboardType, [QSResourceManager imageNamed:@"webType"] ,
-             NSRTFDPboardType, [QSResourceManager imageNamed:@"stylizedTextType"] ,
-             nil];
-    });
-    return d;
-}
-
 - (NSImage *)image {
     if ([[self representedObject] respondsToSelector:@selector(icon)]) {
         return [[self representedObject] icon];

--- a/Quicksilver/Code-QuickStepInterface/QSResultController.m
+++ b/Quicksilver/Code-QuickStepInterface/QSResultController.m
@@ -296,22 +296,10 @@ NSMutableDictionary *kindDescriptions = nil;
 - (void)objectIconModified:(NSNotification *)notif
 {
     QSGCDMainAsync(^{
-        // if results are showing, check for icons that need updating
-        if ([[self window] isVisible]) {
-            QSObject *object = [notif object];
-            // if updated object is is in the results, update it in the list
-            NSUInteger ind = [currentResults indexOfObject:object];
-            if (ind != NSNotFound) {
-                [resultTable setNeedsDisplayInRect:[resultTable rectOfRow:ind]];
-            }
-            // if updated object is is in the child results, update it in the list
-            if ([[NSUserDefaults standardUserDefaults] boolForKey:@"QSResultsShowChildren"]) {
-                ind = [[[self selectedItem] children] indexOfObject:object];
-                if (ind != NSNotFound) {
-                    [resultChildTable setNeedsDisplayInRect:[resultChildTable rectOfRow:ind]];
-                }
-            }
-        }
+		[resultTable setNeedsDisplay];
+		if ([[NSUserDefaults standardUserDefaults] boolForKey:@"QSResultsShowChildren"]) {
+			[resultChildTable setNeedsDisplay];
+		}
     });
 }
 

--- a/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
@@ -83,6 +83,7 @@ NSMutableDictionary *bindingsDict = nil;
 	searchMode = SearchFilter;
 	[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(hideResultView:) name:@"NSWindowDidResignKeyNotification" object:[self window]];
 	[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(clearAll) name:QSReleaseAllNotification object:nil];
+	[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(objectIconModified:) name:QSObjectIconModified object:nil];
 
 	resultsPadding = 0;
 	historyArray = [[NSMutableArray alloc] initWithCapacity:10];
@@ -541,8 +542,6 @@ NSMutableDictionary *bindingsDict = nil;
     }
     // if the two objects are not the same, send an 'object chagned' notif
 	if (newObject != currentObject) {
-        [[NSNotificationCenter defaultCenter] removeObserver:self name:QSObjectIconModified object:currentObject];
-        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(objectIconModified:) name:QSObjectIconModified object:newObject];
 		[super setObjectValue:newObject];
         [[NSNotificationCenter defaultCenter] postNotificationName:@"SearchObjectChanged" object:self];
 	}


### PR DESCRIPTION
Fixes #2069, which was the original motivation, but I also put this out there to get your opinion on the changes to the observers. I’ve long wondered what would happen if we did this.

(My motivation for trying was to get the mini-icons in a comma trick collection to update. It was either this, or another complicated mess of adding and removing observers for individual objects.)

I think it’s OK because we can tell the OS a billion times that a view needs to be redrawn, but it won’t actually redraw unless it decides it’s a good time to do so. Is that correct? In any case, icon changes don’t come in too rapidly. The only “problem” I see is that all three panes get the notice and ask to be redrawn.

Before this is merged, I’d also like to see if we can get other places to observe icon changes. (Like every view in the Preferences window, and the optional zooming trigger window.)
