### PR TITLE
Explode Combined Objects

### DIFF
--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Code/QSObjectActions.m
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Code/QSObjectActions.m
@@ -25,6 +25,7 @@
 # define kQSObjectShowSourceAction @"QSObjectShowSourceAction"
 # define kQSObjectOmitAction @"QSObjectOmitAction"
 # define kQSObjectAssignLabelAction @"QSObjectAssignLabelAction"
+# define kQSObjectExplodeCombinedAction @"QSObjectExplodeCombinedAction"
 
 #import "QSTextProxy.h"
 #import "QSWindowAnimation.h"
@@ -44,6 +45,9 @@
     {
             [newActions addObject:kQSObjectShowSourceAction];
     }
+	if ([dObject count] > 1) {
+		[newActions addObject:kQSObjectExplodeCombinedAction];
+	}
 	return newActions;
 }
 
@@ -186,6 +190,14 @@
 	[data writeToFile:savePath atomically:NO];
 	return [QSObject fileObjectWithPath:savePath];
 
+}
+
+- (QSObject *)explodeCombinedObject:(QSObject *)dObject
+{
+	NSMutableArray *components = [[dObject splitObjects] mutableCopy];
+	QSInterfaceController *controller = [(QSController *)[NSApp delegate] interfaceController];
+	[controller showArray:components];
+	return nil;
 }
 
 - (NSArray *)validIndirectObjectsForAction:(NSString *)action directObject:(QSObject *)dObject {

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/QSCorePlugIn-Info.plist
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/QSCorePlugIn-Info.plist
@@ -128,6 +128,19 @@
 			<key>icon</key>
 			<string>Find</string>
 		</dict>
+		<key>QSObjectExplodeCombinedAction</key>
+		<dict>
+			<key>validatesObjects</key>
+			<true/>
+			<key>actionClass</key>
+			<string>QSObjectActions</string>
+			<key>directTypes</key>
+			<array>
+				<string>*</string>
+			</array>
+			<key>actionSelector</key>
+			<string>explodeCombinedObject:</string>
+		</dict>
 		<key>QSCreateFileAction</key>
 		<dict>
 			<key>displaysResult</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/en.lproj/QSAction.description.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/en.lproj/QSAction.description.strings
@@ -44,6 +44,8 @@
 	<string>Display Text in a Pop-up Dialog</string>
 	<key>QSObjectShowChildrenAction</key>
 	<string>Open Contents of Item in Quicksilver</string>
+	<key>QSObjectExplodeCombinedAction</key>
+	<string>Show selected items in the results list</string>
 	<key>QSShellScriptRunAction</key>
 	<string>Run a Shell Script</string>
 	<key>QSObjectSelectAction</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/en.lproj/QSAction.name.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/en.lproj/QSAction.name.strings
@@ -202,6 +202,8 @@
 	<string>Show Action Menu</string>
 	<key>QSObjectShowChildrenAction</key>
 	<string>Show Contents</string>
+	<key>QSObjectExplodeCombinedAction</key>
+	<string>Explode Selection</string>
 	<key>QSObjectShowSourceAction</key>
 	<string>Show Source in Catalog</string>
 	<key>QSPutOnShelfAction</key>


### PR DESCRIPTION
A new action that does the same thing as `⌃⌘]`, as suggested in comments on #2092.

Maybe “explode” is the wrong word for the user-facing name. I’m open to suggestions.