### PR TITLE
call the local setObjectValue when clearing

### DIFF
--- a/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
@@ -568,7 +568,7 @@ NSMutableDictionary *bindingsDict = nil;
 }
 
 - (void)clearObjectValue {
-	[super setObjectValue:nil];
+	[self setObjectValue:nil];
 	selection--;
 	[[NSNotificationCenter defaultCenter] postNotificationName:@"SearchObjectChanged" object:self];
 }


### PR DESCRIPTION
I’m not sure of all the consequences, since the two implementations of `setObjectValue:` are pretty different. But since all we’re doing is wiping things out, the version in `self` seems to make more sense.