### PR TITLE
Fixes for Recents and Favorites

### DIFF
--- a/Quicksilver/PlugIns-Main/Finder/Info.plist
+++ b/Quicksilver/PlugIns-Main/Finder/Info.plist
@@ -51,20 +51,11 @@
 					<string>Finder Sidebar Items</string>
 					<key>settings</key>
 					<dict>
-						<key>bundle</key>
-						<string>com.apple.sidebarlists</string>
-						<key>keypath</key>
-						<array>
-							<string>favoriteitems</string>
-							<string>CustomListItems</string>
-							<string>*</string>
-							<string>Alias</string>
-						</array>
-						<key>type</key>
-						<integer>3</integer>
+						<key>path</key>
+						<string>~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.FavoriteItems.sfl</string>
 					</dict>
 					<key>source</key>
-					<string>QSDefaultsObjectSource</string>
+					<string>QSSharedFileListSource</string>
 				</dict>
 			</array>
 			<key>icon</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Code/QSSharedFileListSource.h
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Code/QSSharedFileListSource.h
@@ -1,0 +1,13 @@
+//
+//  QSSharedFileListSource.h
+//  Quicksilver
+//
+//  Created by Rob McBroom on 2016/03/16.
+//
+//
+
+#import <QSCore/QSCore.h>
+
+@interface QSSharedFileListSource : QSObjectSource
+
+@end

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Code/QSSharedFileListSource.m
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Code/QSSharedFileListSource.m
@@ -13,7 +13,21 @@
 
 - (BOOL)indexIsValidFromDate:(NSDate *)indexDate forEntry:(NSDictionary *)theEntry
 {
-	return NO;
+	NSDictionary *settings = [theEntry objectForKey:kItemSettings];
+	NSString *sflPath = [settings objectForKey:kItemPath];
+	if (!sflPath) {
+		return YES;
+	}
+	NSString *path = [sflPath stringByStandardizingPath];
+	NSFileManager *manager = [NSFileManager defaultManager];
+	if (![manager fileExistsAtPath:path isDirectory:NULL]) {
+		return YES;
+	}
+	NSDate *modDate = [[manager attributesOfItemAtPath:path error:NULL] fileModificationDate];
+	if ([modDate compare:indexDate] == NSOrderedDescending) {
+		return NO;
+	}
+	return YES;
 }
 
 - (NSArray *)objectsForEntry:(NSDictionary *)theEntry

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Code/QSSharedFileListSource.m
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Code/QSSharedFileListSource.m
@@ -1,0 +1,47 @@
+//
+//  QSSharedFileListSource.m
+//  Quicksilver
+//
+//  Created by Rob McBroom on 2016/03/16.
+//
+//
+
+#import "QSSharedFileListSource.h"
+#import "QSFoundation.h"
+
+@implementation QSSharedFileListSource
+
+- (BOOL)indexIsValidFromDate:(NSDate *)indexDate forEntry:(NSDictionary *)theEntry
+{
+	return NO;
+}
+
+- (NSArray *)objectsForEntry:(NSDictionary *)theEntry
+{
+	NSDictionary *settings = [theEntry objectForKey:kItemSettings];
+	NSMutableArray *sflItemArray = [NSMutableArray arrayWithCapacity:0];
+	NSString *sflPath = [settings objectForKey:kItemPath];
+	NSString *path = [sflPath stringByStandardizingPath];
+	if ([[NSFileManager defaultManager] fileExistsAtPath:path isDirectory:nil]) {
+		NSDictionary *sflData = [NSKeyedUnarchiver unarchiveObjectWithFile:path];
+		for (SFLListItem *item in sflData[@"items"]) {
+			// item's class is SFLListItem
+			if ([item URL]) {
+				[sflItemArray addObject:item];
+			}
+		}
+		[sflItemArray sortUsingComparator:^NSComparisonResult(SFLListItem *item1, SFLListItem *item2) {
+			return item1.order > item2.order;
+		}];
+		
+	}
+	return [sflItemArray arrayByEnumeratingArrayUsingBlock:^id(SFLListItem *item) {
+		NSURL *url = [item URL];
+		if ([url isFileURL]) {
+			return [QSObject fileObjectWithFileURL:url];
+		}
+		return [QSObject URLObjectWithURL:[[item URL] absoluteString] title:[item name]];
+	}];
+}
+
+@end

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/QSCorePlugIn-Info.plist
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/QSCorePlugIn-Info.plist
@@ -1245,6 +1245,8 @@
 			<string>QSUserDefinedProxySource</string>
 			<key>QSGroupObjectSource</key>
 			<string>QSGroupObjectSource</string>
+			<key>QSSharedFileListSource</key>
+			<string>QSSharedFileListSource</string>
 		</dict>
 		<key>QSFileActionCreators</key>
 		<dict>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/QSCorePlugIn-Info.plist
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/QSCorePlugIn-Info.plist
@@ -1961,22 +1961,11 @@
 					<array>
 						<dict>
 							<key>source</key>
-							<string>QSDefaultsObjectSource</string>
+							<string>QSSharedFileListSource</string>
 							<key>settings</key>
 							<dict>
-								<key>bundle</key>
-								<string>com.apple.recentitems</string>
-								<key>watchTarget</key>
-								<true/>
-								<key>type</key>
-								<integer>3</integer>
-								<key>keypath</key>
-								<array>
-									<string>RecentApplications</string>
-									<string>CustomListItems</string>
-									<string>*</string>
-									<string>Bookmark</string>
-								</array>
+								<key>path</key>
+								<string>~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.RecentApplications.sfl</string>
 							</dict>
 							<key>icon</key>
 							<string>GenericApplicationIcon</string>
@@ -1985,22 +1974,11 @@
 						</dict>
 						<dict>
 							<key>source</key>
-							<string>QSDefaultsObjectSource</string>
-							<key>watchTarget</key>
-							<true/>
+							<string>QSSharedFileListSource</string>
 							<key>settings</key>
 							<dict>
-								<key>bundle</key>
-								<string>com.apple.recentitems</string>
-								<key>type</key>
-								<integer>3</integer>
-								<key>keypath</key>
-								<array>
-									<string>RecentDocuments</string>
-									<string>CustomListItems</string>
-									<string>*</string>
-									<string>Bookmark</string>
-								</array>
+								<key>path</key>
+								<string>~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.RecentDocuments.sfl</string>
 							</dict>
 							<key>icon</key>
 							<string>GenericDocumentIcon</string>
@@ -2009,22 +1987,11 @@
 						</dict>
 						<dict>
 							<key>source</key>
-							<string>QSDefaultsObjectSource</string>
-							<key>watchTarget</key>
-							<true/>
+							<string>QSSharedFileListSource</string>
 							<key>settings</key>
 							<dict>
-								<key>bundle</key>
-								<string>com.apple.recentitems</string>
-								<key>type</key>
-								<integer>2</integer>
-								<key>keypath</key>
-								<array>
-									<string>Hosts</string>
-									<string>CustomListItems</string>
-									<string>*</string>
-									<string>URL</string>
-								</array>
+								<key>path</key>
+								<string>~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.RecentServers.sfl</string>
 							</dict>
 							<key>icon</key>
 							<string>GenericFileServerIcon</string>
@@ -2059,22 +2026,13 @@
 				</dict>
 				<dict>
 					<key>source</key>
-					<string>QSDefaultsObjectSource</string>
+					<string>QSSharedFileListSource</string>
 					<key>enabled</key>
 					<true/>
 					<key>settings</key>
 					<dict>
-						<key>bundle</key>
-						<string>com.apple.sidebarlists</string>
-						<key>type</key>
-						<integer>2</integer>
-						<key>keypath</key>
-						<array>
-							<string>favoriteservers</string>
-							<string>CustomListItems</string>
-							<string>*</string>
-							<string>URL</string>
-						</array>
+						<key>path</key>
+						<string>~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.FavoriteServers.sfl</string>
 					</dict>
 					<key>ID</key>
 					<string>QSPresetFavoriteServers</string>

--- a/Quicksilver/Quicksilver.xcodeproj/project.pbxproj
+++ b/Quicksilver/Quicksilver.xcodeproj/project.pbxproj
@@ -420,6 +420,7 @@
 		D46D3C7C16B33D0B00387EA9 /* countBadge3@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = D46D3C7816B33D0B00387EA9 /* countBadge3@2x.png */; };
 		D46D3C7D16B33D0B00387EA9 /* countBadge4@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = D46D3C7916B33D0B00387EA9 /* countBadge4@2x.png */; };
 		D46D3C7E16B33D0B00387EA9 /* countBadge5@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = D46D3C7A16B33D0B00387EA9 /* countBadge5@2x.png */; };
+		D48F231D1C99CCC4006504A8 /* QSSharedFileListSource.m in Sources */ = {isa = PBXBuildFile; fileRef = D48F231C1C99CCC4006504A8 /* QSSharedFileListSource.m */; };
 		D493990D1350078E00B908C6 /* QSDownloads.h in Headers */ = {isa = PBXBuildFile; fileRef = D49399091350078E00B908C6 /* QSDownloads.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D493990E1350078E00B908C6 /* QSDownloads.m in Sources */ = {isa = PBXBuildFile; fileRef = D493990A1350078E00B908C6 /* QSDownloads.m */; };
 		D49A8B02166EA8FC0086B5A9 /* QSUserDefinedProxySource.m in Sources */ = {isa = PBXBuildFile; fileRef = D49A8B01166EA8FC0086B5A9 /* QSUserDefinedProxySource.m */; };
@@ -1948,6 +1949,8 @@
 		D46D3C7816B33D0B00387EA9 /* countBadge3@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "countBadge3@2x.png"; sourceTree = "<group>"; };
 		D46D3C7916B33D0B00387EA9 /* countBadge4@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "countBadge4@2x.png"; sourceTree = "<group>"; };
 		D46D3C7A16B33D0B00387EA9 /* countBadge5@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "countBadge5@2x.png"; sourceTree = "<group>"; };
+		D48F231B1C99CCC4006504A8 /* QSSharedFileListSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = QSSharedFileListSource.h; sourceTree = "<group>"; };
+		D48F231C1C99CCC4006504A8 /* QSSharedFileListSource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = QSSharedFileListSource.m; sourceTree = "<group>"; };
 		D49399091350078E00B908C6 /* QSDownloads.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = QSDownloads.h; sourceTree = "<group>"; usesTabs = 1; };
 		D493990A1350078E00B908C6 /* QSDownloads.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = QSDownloads.m; sourceTree = "<group>"; usesTabs = 1; };
 		D49A8B00166EA8FC0086B5A9 /* QSUserDefinedProxySource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = QSUserDefinedProxySource.h; sourceTree = "<group>"; };
@@ -3041,6 +3044,8 @@
 				E180011007B2B48900010DB0 /* QSObject+ColorHandling.m */,
 				7FDF328707F7B11800594789 /* QSObjectActions.h */,
 				7FDF328807F7B11800594789 /* QSObjectActions.m */,
+				D48F231B1C99CCC4006504A8 /* QSSharedFileListSource.h */,
+				D48F231C1C99CCC4006504A8 /* QSSharedFileListSource.m */,
 				E180011107B2B48900010DB0 /* QSShellScriptRunAction.h */,
 				E180011207B2B48900010DB0 /* QSShellScriptRunAction.m */,
 				7FF59032080439B00031368C /* QSTextParser.h */,
@@ -4908,6 +4913,7 @@
 				E180012807B2B48900010DB0 /* QSDefaultsObjectSource.m in Sources */,
 				7FF590210804398F0031368C /* QSDirectoryParser.m in Sources */,
 				E180012E07B2B48900010DB0 /* QSFileSystemObjectSource.m in Sources */,
+				D48F231D1C99CCC4006504A8 /* QSSharedFileListSource.m in Sources */,
 				7FBE3D1209586FE60049CC78 /* QSFileTemplateManager.m in Sources */,
 				E180013007B2B48900010DB0 /* QSFSBrowserMediator.m in Sources */,
 				7F9441C60803AB2D007EDC31 /* QSGroupObjectSource.m in Sources */,


### PR DESCRIPTION
Updates the following catalog presets to work in …whatever version of OS X broke them.

* Finder Sidebar Items
* Recent Applications
* Recent Documents
* Recent Servers
* Favorite Servers

This surely breaks those things for older OS X versions, but this crap changes so often, I wonder if they were even working in the first place. :smiley:

fixes #2187