### PR TITLE
Reduce Mutables

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSObject.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject.m
@@ -153,7 +153,10 @@ NSSize QSMaxIconSize;
 	NSMutableArray *array;
 	// Set used to keep track of the objects already added
 	NSMutableSet *setOfObjects = [[NSMutableSet alloc] init];
-	
+
+	// Make sure objects is immutable
+	objects = [objects copy];
+
 	// add each object from the list of objects to the combinedData dict
 	for (id thisObject in objects) {
 		if (!typesSet) {
@@ -173,11 +176,9 @@ NSSize QSMaxIconSize;
 			[setOfObjects addObject:thisObject];
 		}
 	}
-	// get the number of objects added to combinedData, then release setOfObjects
-	NSInteger objectCount = [setOfObjects count];
 	
 	// If there's still only 1 object (case: if the comma trick is used on the same object multiple times)
-	if (objectCount == 1) {
+	if ([setOfObjects count] == 1) {
 		return [objects objectAtIndex:0];
 	}
 	

--- a/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.h
+++ b/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.h
@@ -68,10 +68,6 @@ typedef NS_ENUM(NSUInteger, QSSearchMode) {
 	QSResultController *resultController;
 	QSSearchMode searchMode;
 
-	NSMutableArray *sourceArray; // The original source array for searches
-	NSMutableArray *searchArray; // Interim array for searching smaller and smaller pieces
-	NSMutableArray *resultArray; // Final filtered array for current search string
-
 	NSUInteger selection;
 	BOOL browsing;
 	BOOL validMnemonic;
@@ -82,6 +78,10 @@ typedef NS_ENUM(NSUInteger, QSSearchMode) {
     QSObject *quicklookObject;
 
 }
+
+@property (copy) NSArray *sourceArray; // The original source array for searches
+@property (copy) NSArray *searchArray; // Interim array for searching smaller and smaller pieces
+@property (strong) NSMutableArray *resultArray; // Final filtered array for current search string
 
 @property (assign) BOOL updatesSilently;
 @property (assign) BOOL recordsHistory;
@@ -115,10 +115,6 @@ typedef NS_ENUM(NSUInteger, QSSearchMode) {
 - (void)redisplayObjectValue:(QSObject *)newObject;
 - (void)pageScroll:(NSInteger)direction;
 
-- (NSMutableArray *)sourceArray;
-- (void)setSourceArray:(NSMutableArray *)newSourceArray;
-- (NSMutableArray *)searchArray;
-- (void)setSearchArray:(NSMutableArray *)newSearchArray;
 - (NSMutableArray *)resultArray;
 - (void)setResultArray:(NSMutableArray *)newResultArray;
 


### PR DESCRIPTION
As promised, a pull to reduce the use of mutable objects. First for `splitObjects`, then for various arrays stored for the search object view. Only the `resultArray` really needs to be mutable as that's what is changed as you search