### PR TITLE
Prevent an exception from being thrown

### DIFF
--- a/Quicksilver/Code-QuickStepInterface/QSResultController.m
+++ b/Quicksilver/Code-QuickStepInterface/QSResultController.m
@@ -381,8 +381,11 @@ NSMutableDictionary *kindDescriptions = nil;
 		[self setSelectedItem:newSelectedItem];
 		[resultChildTable noteNumberOfRowsChanged];
         [self updateStatusString];
-        
-		if ([[NSApp currentEvent] modifierFlags] & NSFunctionKeyMask && [[NSApp currentEvent] isARepeat]) {
+		
+		NSEvent *event = [NSApp currentEvent];
+		// Check the event can have isARepeat called on it safely. From the docs for -[NSEvent isARepeat]: "Raises an NSInternalInconsistencyException if sent to an NSFlagsChanged event or other non-key event."
+		BOOL validKeyEvent = ([event type] == NSKeyDown) || ([event type] == NSKeyUp);
+		if ([event modifierFlags] & NSFunctionKeyMask && validKeyEvent && [event isARepeat]) {
 			if ([childrenLoadTimer isValid]) {
 				[childrenLoadTimer setFireDate:[NSDate dateWithTimeIntervalSinceNow:0.5]];
 			} else {


### PR DESCRIPTION
I recently noticed some exceptions in my system log originating from QS. I've put a few examples in a gist: https://gist.github.com/mattbeshara/b07bef9bca8662d4e8e2d3c6ce306bb7

The cause seems to be that sometimes when I have the search window open, QS isn't getting the type of NSEvent it expects from [NSApp currentEvent]. A couple of "SysDefined" events sometimes occur where the code only expects either NSKeyDown or NSKeyUp events. I don't know what those unexpected events are, what triggers them, or when they occur, so I don't know how to reproduce this for those specific events. The code checks that the function key is held down before calling [NSEvent isARepeat], but I don't know what relationship that may have with the non-key events it's getting.

Getting the exception thrown is reproducible though, by causing another kind of unhandled event to occur. Open the search window, type a letter to cause an object to appear in the first pane if there isn't one there already, position the mouse cursor over the icon in the first pane, hold the function key, and scroll with a mouse or trackpad.

To prevent that exception from being thrown, this patch checks that an event is a valid key event before calling isARepeat on it.