### PR TITLE
Don't mention 'relaunch required' when updating plugins as part of an app upgrade

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSPlugInManager.m
+++ b/Quicksilver/Code-QuickStepCore/QSPlugInManager.m
@@ -861,7 +861,8 @@
 				relaunchForObsoletes = YES;
 			}
 		}
-		BOOL suggestRelaunch = (!liveLoaded || relaunchForObsoletes);
+		// only suggest relaunch if not live loaded, we're removing an obsolete and we're not in the middle of an update
+		BOOL suggestRelaunch = (!liveLoaded || relaunchForObsoletes) && ![QSTask taskWithIdentifier:@"QSAppUpdateInstalling"];
 		QSShowNotifierWithAttributes([NSDictionary dictionaryWithObjectsAndKeys:@"QSPlugInInstalledNotification", QSNotifierType, image, QSNotifierIcon, title, QSNotifierTitle, suggestRelaunch?@"Relaunch required (⌘⌃Q)":nil, QSNotifierText, nil]);
 	}
 	return YES;


### PR DESCRIPTION
When you do an app upgrade, Quicksilver first downloads the app, then checks for plugin updates and installs them. When installing these plugins a notification pops up saying the plugin is installed as per [this line](https://github.com/quicksilver/Quicksilver/blob/master/Quicksilver/Code-QuickStepCore/QSPlugInManager.m#L865)

The message 'Relaunch Required' really shouldn't display if Quicksilver is in the middle of an upgrade process (for which a relaunch would be required anyway)