### PR TITLE
assign parents

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSObject.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject.m
@@ -717,11 +717,11 @@ NSSize QSMaxIconSize;
 	if (newAltChildren) {
         if ([[self cache] objectForKey:kQSObjectChildren] != newAltChildren) {
             [[self cache] setObject:newAltChildren forKey:kQSObjectAltChildren];
+			NSString *parentID = [self identifier];
+			for (QSObject *child in newAltChildren) {
+				[child setParentID:parentID];
+			}
         }
-		NSString *parentID = [self identifier];
-		for (QSObject *child in newAltChildren) {
-			[child setParentID:parentID];
-		}
     } else {
         [[self cache] removeObjectForKey:kQSObjectAltChildren];
     }

--- a/Quicksilver/Code-QuickStepCore/QSObject.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject.m
@@ -697,9 +697,10 @@ NSSize QSMaxIconSize;
 	if (newChildren) {
         if ([[self cache] objectForKey:kQSObjectChildren] != newChildren) {
             [[self cache] setObject:newChildren forKey:kQSObjectChildren];
-			[newChildren enumerateObjectsWithOptions:NSEnumerationConcurrent usingBlock:^(QSObject *obj, NSUInteger idx, BOOL *stop) {
-				[obj setParentID:[self identifier]];
-			}];
+			NSString *parentID = [self identifier];
+			for (QSObject *child in newChildren) {
+				[child setParentID:parentID];
+			}
         }
     } else {
         [[self cache] removeObjectForKey:kQSObjectChildren];

--- a/Quicksilver/Code-QuickStepCore/QSObject.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject.m
@@ -718,6 +718,10 @@ NSSize QSMaxIconSize;
         if ([[self cache] objectForKey:kQSObjectChildren] != newAltChildren) {
             [[self cache] setObject:newAltChildren forKey:kQSObjectAltChildren];
         }
+		NSString *parentID = [self identifier];
+		for (QSObject *child in newAltChildren) {
+			[child setParentID:parentID];
+		}
     } else {
         [[self cache] removeObjectForKey:kQSObjectAltChildren];
     }

--- a/Quicksilver/Code-QuickStepCore/QSObject.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject.m
@@ -697,6 +697,9 @@ NSSize QSMaxIconSize;
 	if (newChildren) {
         if ([[self cache] objectForKey:kQSObjectChildren] != newChildren) {
             [[self cache] setObject:newChildren forKey:kQSObjectChildren];
+			[newChildren enumerateObjectsWithOptions:NSEnumerationConcurrent usingBlock:^(QSObject *obj, NSUInteger idx, BOOL *stop) {
+				[obj setParentID:[self identifier]];
+			}];
         }
     } else {
         [[self cache] removeObjectForKey:kQSObjectChildren];

--- a/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
@@ -1810,15 +1810,6 @@ NSMutableDictionary *bindingsDict = nil;
         // should show parent's level
         newSelectedObject = parent;
         if (newSelectedObject) {
-            if ((NSInteger)[historyArray count] > historyIndex + 1) {
-                if ([[[historyArray objectAtIndex:historyIndex+1] valueForKey:@"selection"] isEqual:parent]) {
-                    [historyArray removeObjectAtIndex:historyIndex+1];
-                }
-#ifdef DEBUG
-                if (VERBOSE) NSLog(@"Parent Missing, No History, %@", [[historyArray objectAtIndex:0] valueForKey:@"selection"]);
-#endif
-            }
-            
 			newObjects = (alt ? [newSelectedObject altSiblings] : [newSelectedObject siblings]);
             if (![newObjects containsObject:newSelectedObject])
                 newObjects = [newSelectedObject altSiblings];

--- a/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
@@ -1819,8 +1819,7 @@ NSMutableDictionary *bindingsDict = nil;
 #endif
             }
             
-            if (!newObjects)
-                newObjects = (alt ? [newSelectedObject altSiblings] : [newSelectedObject siblings]);
+			newObjects = (alt ? [newSelectedObject altSiblings] : [newSelectedObject siblings]);
             if (![newObjects containsObject:newSelectedObject])
                 newObjects = [newSelectedObject altSiblings];
             


### PR DESCRIPTION
This should have always been there, right? Why wasn’t it?

I know retain cycles are something to worry about, but I’m sure the affected objects have a dozen references to them in various places anyway.

The first commit is the main thing, but I fixed some other minor things while investigating. My gut tells me all that left-arrow code needs to be refactored, but I’m not going any deeper for the moment.