### PR TITLE
prevent duplicate QSObjects

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSObject.h
+++ b/Quicksilver/Code-QuickStepCore/QSObject.h
@@ -147,7 +147,6 @@ typedef struct _QSObjectFlags {
 @interface QSObject (Accessors)
 - (NSString *)identifier;
 - (void)setIdentifier:(NSString *)newIdentifier;
-- (void)setIdentifier:(NSString *)newIdentifier addToObjectDictionary:(BOOL)add;
 - (NSString *)name;
 - (void)setName:(NSString *)newName;
 - (NSArray *)children;

--- a/Quicksilver/Code-QuickStepCore/QSObject.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject.m
@@ -78,6 +78,11 @@ NSSize QSMaxIconSize;
 	return self;
 }
 
+- (NSUInteger)hash
+{
+	return [[self identifier] hash];
+}
+
 - (BOOL)isEqual:(id)anObject {
   if (self != anObject && [anObject isKindOfClass:[QSRankedObject class]]) {
     anObject = [anObject object];

--- a/Quicksilver/Code-QuickStepCore/QSObject.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject.m
@@ -80,7 +80,11 @@ NSSize QSMaxIconSize;
 
 - (NSUInteger)hash
 {
-	return [[self identifier] hash];
+	NSString *ident = [self identifier];
+	if (!ident) {
+		ident = [self stringValue];
+	}
+	return [ident hash];
 }
 
 - (BOOL)isEqual:(id)anObject {

--- a/Quicksilver/Code-QuickStepCore/QSObject.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject.m
@@ -641,11 +641,6 @@ NSSize QSMaxIconSize;
 
 - (void)setIdentifier:(NSString *)newIdentifier
 {
-    [self setIdentifier:newIdentifier addToObjectDictionary:YES];
-}
-
-- (void)setIdentifier:(NSString *)newIdentifier addToObjectDictionary:(BOOL)add
-{
     @synchronized(self) {
         if (identifier != nil && newIdentifier != nil) {
             if(![identifier isEqualToString:newIdentifier]) {
@@ -663,9 +658,7 @@ NSSize QSMaxIconSize;
             identifier = nil;
         } else if (identifier == nil) {
             flags.noIdentifier = NO;
-            if (add) {
-                [QSLib setIdentifier:newIdentifier forObject:self];
-            }
+			[QSLib setIdentifier:newIdentifier forObject:self];
             [meta setObject:newIdentifier forKey:kQSObjectObjectID];
             identifier = newIdentifier;
         }
@@ -865,7 +858,7 @@ NSSize QSMaxIconSize;
     if ([meta objectForKey:kQSObjectPrimaryName])
         [self setName:[meta objectForKey:kQSObjectPrimaryName]];
 	if ([meta objectForKey:kQSObjectObjectID]) {
-        [self setIdentifier:[meta objectForKey:kQSObjectObjectID] addToObjectDictionary:NO];
+        [self setIdentifier:[meta objectForKey:kQSObjectObjectID]];
     }
 	if ([meta objectForKey:kQSObjectPrimaryType])
 		[self setPrimaryType:[meta objectForKey:kQSObjectPrimaryType]];


### PR DESCRIPTION
R[TFM][1] FTW!

This should fix the problems we’ve seen with duplicates in the third pane (#2097) and God knows how many other places.

This is also, I’m sure, the _true_ fix for #1459. I remember you were trying to clean up the way identifiers were managed at the time @pjrobertson and we had to revert the changes, but could never figure out why. We can probably re-implement those changes now (once I figure out what they were).

[1]: https://developer.apple.com/library/mac/documentation/Cocoa/Reference/Foundation/Classes/NSSet_Class/index.html#//apple_ref/occ/instm/NSSet/member: