### PR TITLE
Applescript third pane

### DIFF
--- a/Quicksilver/Code-QuickStepInterface/QSResizingInterfaceController.m
+++ b/Quicksilver/Code-QuickStepInterface/QSResizingInterfaceController.m
@@ -35,7 +35,7 @@
 
 //	NSLog(@"adjust x%d", argumentCount);
 	if (argumentCount == 2) {
-		BOOL indirectOptional = [[aSelector objectValue] indirectOptional];
+		BOOL indirectOptional = [action indirectOptional];
 
 //		  NSLog(@"adjust %d", indirectOptional);
 		// When the 3rd pane is not optional, show it (most likely case, so first)

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Code/QSAppleScriptActions.m
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Code/QSAppleScriptActions.m
@@ -293,7 +293,15 @@
     return [self typeArrayForScript:path forHandler:@"DAEDgiob"];
 }
 
+-(NSArray *)defaultIndirectObjectForScript:(NSString *)path {
+	/* TODO: This code currently does nothing. 
+	   Future: Allow the user to define an identifier for the default iObject. Could be a proxy object
+	*/
+	return [self typeArrayForScript:path forHandler:@"DAEDgiov"];
+}
+
 - (NSArray *)validIndirectObjectsForAction:(NSString *)action directObject:(QSObject *)dObject {
+	
 	if ([action isEqualToString:kAppleScriptOpenTextAction]) {
         return [NSArray arrayWithObject:[QSObject textProxyObjectWithDefaultValue:@""]];
     } else if ([action isEqualToString:kAppleScriptOpenFilesAction]) {
@@ -309,11 +317,14 @@
 -(NSArray *)validIndirectObjectsForAppleScript:(NSString *)script directObject:(QSObject *)dObject {
     NSString *scriptPath = [self scriptPathForID:script];
     
-    id indirectTypes = [self validIndrectTypesForScript:scriptPath];
+    NSArray * indirectTypes = [self validIndrectTypesForScript:scriptPath];
     if (indirectTypes) {
-        NSMutableArray *indirectObjects = [NSMutableArray array];
+		if ([indirectTypes count] == 1 && [indirectTypes[0] isEqualToString:QSTextType]) {
+			return [NSArray arrayWithObject:[QSObject textProxyObjectWithDefaultValue:@""]];
+		}
+        NSMutableArray *indirectObjects = [NSMutableArray arrayWithObject:[NSNull null]];
         for (NSString *type in indirectTypes) {
-            [indirectObjects addObjectsFromArray:[QSLib arrayForType:type]];
+            [indirectObjects addObjectsFromArray:[QSLib scoredArrayForType:type]];
         }
         return [indirectObjects copy];
     }


### PR DESCRIPTION
Fixes the stuff in #2071 

Thanks @Sesquipedalian for reporting this and and also Mike Petonic for alerting me to this on the dev forums. Quite a big usability problem.

There is now an addition of a '3rd pane not-optional' choice for 3-pane actions.
That is, if you set the 'get argument count' part to return `-3` then the 3rd pane is optional. If it returns `3` then the 3rd pane is *not* optional (and will display by default).

I used -3 and 3 as I thought it was kind of intuitive `-3` meaning optional, `3` meaning not optional.
Open to other suggestions though