### PR TITLE
Be more specific about when the 3rd pane should open/close

### DIFF
--- a/Quicksilver/Code-QuickStepInterface/QSResizingInterfaceController.m
+++ b/Quicksilver/Code-QuickStepInterface/QSResizingInterfaceController.m
@@ -42,7 +42,9 @@
 		if (!indirectOptional) {
 			[self expandWindow:sender];
 			return;
-		} else {
+		} else if ([iSelector objectValue]) {
+			return;
+		}else {
 			NSResponder *firstResponder = [[self window] firstResponder];
 			if (firstResponder == iSelector
 				 || firstResponder == [iSelector currentEditor]) {
@@ -51,7 +53,9 @@
 			}
 		}
 	}
+	if (expanded) {
 		[self contractWindow:sender];
+	}
 
 }
 

--- a/Quicksilver/Code-QuickStepInterface/QSResizingInterfaceController.m
+++ b/Quicksilver/Code-QuickStepInterface/QSResizingInterfaceController.m
@@ -56,7 +56,10 @@
 }
 
 - (void)firstResponderChanged:(NSResponder *)aResponder {
-    [self adjustWindow:nil];
+	if (!aResponder || [aResponder isKindOfClass:[QSObjectView class]]) {
+		// only adjust the window if the search object view has changed (not if another item has taken first responder
+		[self adjustWindow:nil];
+	}
 }
 
 - (void)expandWindow:(id)sender {


### PR DESCRIPTION
Fixes #2234  - see that for a full discussion.

The 2nd commit also fixes a usability bug I came across testing this:

* 1st pane: type text
* 2nd pane: choose 'Create File [...]'
* Tab to 3rd pane to open it up
* Select an object in the 3rd pane
* Tab back to the 1st pane

Notice how the 3rd pane closes, hiding your selected object. The truth is, even though the 3rd pane is hidden its value will still be used when executing the action, so it should really stay open to make it more explicit to the user "this object will be used". If they don't want a 3rd pane action anymore they can just wipe it out with ⌃U as per usual