### PR TITLE
Sorting by date

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSBasicObject.h
+++ b/Quicksilver/Code-QuickStepCore/QSBasicObject.h
@@ -16,6 +16,7 @@
 - (NSString *)identifier;
 - (NSString *)label;
 - (NSString *)name;
+- (NSDate *)date;
 - (BOOL)enabled;
 - (void)setEnabled:(BOOL)flag;
 - (id)primaryObject;

--- a/Quicksilver/Code-QuickStepCore/QSBasicObject.m
+++ b/Quicksilver/Code-QuickStepCore/QSBasicObject.m
@@ -22,6 +22,7 @@
 - (NSString *)identifier {return nil;}
 - (NSString *)label {return nil;}
 - (NSString *)name {return @"Object";}
+- (NSDate *)date {return [NSDate distantPast];}
 - (BOOL)enabled {return ![[QSLibrarian sharedInstance] itemIsOmitted:self];}
 - (void)setEnabled:(BOOL)flag {[[QSLibrarian sharedInstance] setItem:self isOmitted:!flag];}
 - (id)primaryObject {return nil;}

--- a/Quicksilver/Code-QuickStepCore/QSObject.h
+++ b/Quicksilver/Code-QuickStepCore/QSObject.h
@@ -17,6 +17,7 @@ extern NSSize QSMaxIconSize;
 - (NSString *)detailsOfObject:(QSObject *)object;
 - (NSString *)identifierForObject:(QSObject *)object;
 - (NSString *)kindOfObject:(QSObject *)object;
+- (NSDate *)dateForObject:(QSObject *)object;
 - (void)setQuickIconForObject:(QSObject *)object;
 - (BOOL)loadIconForObject:(QSObject *)object;
 - (BOOL)drawIconForObject:(QSObject *)object inRect:(NSRect)rect flipped:(BOOL)flipped;
@@ -38,6 +39,7 @@ extern NSSize QSMaxIconSize;
 // meta dictionary keys
 #define kQSObjectPrimaryName      @"QSObjectName"
 #define kQSObjectAlternateName    @"QSObjectLabel"
+#define kQSObjectDate             @"QSObjectDate"
 #define kQSObjectPrimaryType      @"QSObjectType"
 #define kQSObjectSource           @"QSObjectSource"
 #define kQSObjectIconName         @"QSObjectIconName"
@@ -83,6 +85,7 @@ typedef struct _QSObjectFlags {
 	NSString *name;
 	NSString *label;
 	NSString *identifier;
+	NSDate *datetime;
 	NSImage *icon;
 	NSString *primaryType;
 	id primaryObject;
@@ -139,6 +142,8 @@ typedef struct _QSObjectFlags {
 // This private method is required for QSProxyObject.m
 - (id)_safeObjectForType:(id)aKey;
 
+- (NSDate *)date;
+- (void)setDate:(NSDate *)newDatetime;
 @end
 
 @interface QSObject (Icon)

--- a/Quicksilver/Code-QuickStepCore/QSObject.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject.m
@@ -69,6 +69,7 @@ NSSize QSMaxIconSize;
 		meta = [NSMutableDictionary dictionaryWithCapacity:0];
 		name = nil;
 		label = nil;
+		datetime = nil;
 		icon = nil;
 		identifier = nil;
 		primaryType = nil;
@@ -246,6 +247,7 @@ NSSize QSMaxIconSize;
     copy.name = [name copy];
     copy.label = [label copy];
     copy.identifier = [identifier copy];
+	copy->datetime = [datetime copy];
     copy.icon = [icon copy];
     copy.primaryType = [primaryType copy];
     copy.primaryObject = [primaryObject copy];
@@ -812,6 +814,28 @@ NSSize QSMaxIconSize;
 	lastAccess = newlastAccess;
 }
 
+- (NSDate *)date
+{
+	if (!datetime) {
+		datetime = [self objectForMeta:kQSObjectDate];
+	}
+	id handler = nil;
+	if (!datetime && (handler = [self handlerForSelector:@selector(dateForObject:)])) {
+		datetime = [handler dateForObject:self];
+	}
+	if (datetime) {
+		return datetime;
+	}
+	return [NSDate distantPast];
+}
+
+- (void)setDate:(NSDate *)newDatetime
+{
+	if (datetime != newDatetime) {
+		datetime = newDatetime;
+		[self setObject:datetime forMeta:kQSObjectDate];
+	}
+}
 @end
 
 @implementation QSObject (Archiving)

--- a/Quicksilver/Code-QuickStepCore/QSObject.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject.m
@@ -247,7 +247,7 @@ NSSize QSMaxIconSize;
     copy.name = [name copy];
     copy.label = [label copy];
     copy.identifier = [identifier copy];
-	copy->datetime = [datetime copy];
+	copy.date = [datetime copy];
     copy.icon = [icon copy];
     copy.primaryType = [primaryType copy];
     copy.primaryObject = [primaryObject copy];

--- a/Quicksilver/Code-QuickStepCore/QSObject_FileHandling.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject_FileHandling.m
@@ -668,6 +668,7 @@ NSArray *recentDocumentsForBundle(NSString *bundleIdentifier) {
 		if ([paths count] == 1) {
 			NSString *path = [paths lastObject];
 			[[self dataDictionary] setObject:path forKey:QSFilePathType];
+			[self setDate:[self fileModificationDate]];
 			NSString *uti = [self fileUTI];
 			id handler = [QSReg instanceForKey:uti inTable:@"QSFileObjectCreationHandlers"];
 			if (handler) {
@@ -702,7 +703,7 @@ NSArray *recentDocumentsForBundle(NSString *bundleIdentifier) {
     NSError *err = nil;
     
     // Note: NSURLLocalizedLabelKey gives a localized string of the Finder label (tag in 10.9+). E.g. Red / Rouge
-    dict = [fileURL resourceValuesForKeys:@[NSURLTypeIdentifierKey, NSURLIsDirectoryKey, NSURLIsAliasFileKey, NSURLIsPackageKey, NSURLLocalizedLabelKey, NSURLLocalizedNameKey, NSURLVolumeURLKey, NSURLIsExecutableKey, NSURLIsWritableKey, NSURLLabelColorKey] error:&err];
+    dict = [fileURL resourceValuesForKeys:@[NSURLTypeIdentifierKey, NSURLIsDirectoryKey, NSURLIsAliasFileKey, NSURLIsPackageKey, NSURLLocalizedLabelKey, NSURLLocalizedNameKey, NSURLVolumeURLKey, NSURLIsExecutableKey, NSURLIsWritableKey, NSURLLabelColorKey, NSURLContentModificationDateKey] error:&err];
     NSMutableDictionary *mutableDict = [dict mutableCopy];
 
     if (!dict) {
@@ -830,6 +831,10 @@ NSArray *recentDocumentsForBundle(NSString *bundleIdentifier) {
 
 - (NSString *)fileUTI {
     return [[self infoRecord] objectForKey:NSURLTypeIdentifierKey];
+}
+
+- (NSDate *)fileModificationDate {
+	return [[self infoRecord] objectForKey:NSURLContentModificationDateKey];
 }
 
 - (NSString *)bundleNameFromInfoDict:(NSDictionary *)infoDict {

--- a/Quicksilver/Code-QuickStepInterface/QSInterfaceController.h
+++ b/Quicksilver/Code-QuickStepInterface/QSInterfaceController.h
@@ -40,8 +40,6 @@ typedef NS_ENUM(NSUInteger, QSSearchOrder) {
     TISInputSourceRef savedKeyboard;
 }
 
-@property (assign) QSSearchMode searchMode;
-
 + (NSResponder *)firstResponder;
 - (QSCommand *)currentCommand;
 - (void)setCommand:(QSCommand *)command;

--- a/Quicksilver/Code-QuickStepInterface/QSInterfaceController.h
+++ b/Quicksilver/Code-QuickStepInterface/QSInterfaceController.h
@@ -3,13 +3,12 @@
 #import <Cocoa/Cocoa.h>
 
 @class QSSearchObjectView;
-@class QSActionMatrix;
-
 @class QSWindow;
 @class QSMenuButton;
-//@class QSPrefsController;
-@class QSObject, QSBasicObject;
+@class QSObject;
+@class QSBasicObject;
 @class QSCommand;
+
 @interface QSInterfaceController : NSWindowController {
 	IBOutlet QSSearchObjectView *dSelector;
 	IBOutlet QSSearchObjectView *aSelector;

--- a/Quicksilver/Code-QuickStepInterface/QSInterfaceController.h
+++ b/Quicksilver/Code-QuickStepInterface/QSInterfaceController.h
@@ -9,6 +9,18 @@
 @class QSBasicObject;
 @class QSCommand;
 
+typedef NS_ENUM(NSUInteger, QSSearchMode) {
+    QSSearchModeAll = 1,     // Filter Catalog
+    QSSearchModeFilter = 2,  // Filter Results
+    QSSearchModeSnap = 3,    // Snap to Best
+//    QSSearchModeShuffle = 4, // Not Sure (not used?)
+};
+
+typedef NS_ENUM(NSUInteger, QSSearchOrder) {
+    QSSearchOrderByName = 1,
+    QSSearchOrderByScore = 2,
+};
+
 @interface QSInterfaceController : NSWindowController {
 	IBOutlet QSSearchObjectView *dSelector;
 	IBOutlet QSSearchObjectView *aSelector;
@@ -27,6 +39,8 @@
     
     TISInputSourceRef savedKeyboard;
 }
+
+@property (assign) QSSearchMode searchMode;
 
 + (NSResponder *)firstResponder;
 - (QSCommand *)currentCommand;

--- a/Quicksilver/Code-QuickStepInterface/QSInterfaceController.h
+++ b/Quicksilver/Code-QuickStepInterface/QSInterfaceController.h
@@ -19,6 +19,8 @@ typedef NS_ENUM(NSUInteger, QSSearchMode) {
 typedef NS_ENUM(NSUInteger, QSSearchOrder) {
     QSSearchOrderByName = 1,
     QSSearchOrderByScore = 2,
+	QSSearchOrderByDateAscending = 3,
+	QSSearchOrderByDateDescending = 4,
 };
 
 @interface QSInterfaceController : NSWindowController {

--- a/Quicksilver/Code-QuickStepInterface/QSInterfaceController.m
+++ b/Quicksilver/Code-QuickStepInterface/QSInterfaceController.m
@@ -105,7 +105,7 @@
 	// [aSelector setInitiatesDrags:NO];
 	[aSelector setDropMode:QSRejectDropMode];
 
-	[aSelector setSearchMode:SearchFilter];
+	[aSelector setSearchMode:QSSearchModeFilter];
 	[aSelector setAllowNonActions:NO];
 	// only store history for the first pane
 	dSelector.recordsHistory = YES;
@@ -371,7 +371,7 @@
         }
     }
 	[self updateControl:iSelector withArray:indirects];
-	[iSelector setSearchMode:(indirects?SearchFilter:SearchFilterAll)];
+	[iSelector setSearchMode:(indirects ? QSSearchModeFilter : QSSearchModeAll)];
 }
 
 - (void)updateViewLocations {
@@ -413,7 +413,7 @@
     [self clearObjectView:dSelector];
     [dSelector setSourceArray:array];
     [dSelector setResultArray:array];
-    [dSelector setSearchMode:SearchFilter];
+    [dSelector setSearchMode:QSSearchModeFilter];
     if (dObject) {
         // show an item from this array if set
         [dSelector selectObjectValue:dObject];
@@ -699,7 +699,7 @@
     
 	[[self window] makeFirstResponder:dSelector];
     
-	[dSelector setSearchMode:SearchFilterAll];
+	[dSelector setSearchMode:QSSearchModeAll];
 }
 
 - (IBAction)activateInTextMode:(id)sender {

--- a/Quicksilver/Code-QuickStepInterface/QSResultController.h
+++ b/Quicksilver/Code-QuickStepInterface/QSResultController.h
@@ -4,7 +4,7 @@
 
 @class QSObjectView, QSSearchObjectView, QSTableView;
 
-@interface QSResultController : NSWindowController <NSTableViewDataSource, NSWindowDelegate>
+@interface QSResultController : NSWindowController
 {
  @public
 	IBOutlet NSTextField *	searchStringField;	// What the user types when searching (seen in the results view)
@@ -49,11 +49,15 @@
 
 
 @property (strong) IBOutlet QSTableView *resultTable;
+@property (strong) IBOutlet QSSearchObjectView *objectView;
+
 @property (strong) NSArray *currentResults;
 @property (strong) QSObject *selectedItem;
 @property (strong) NSTextField *searchStringField;
 
 + (id)sharedInstance;
+
+- (id)initWithObjectView:(QSObjectView *)objectView;
 
 - (IBAction)defineMnemonic:(id)sender;
 - (IBAction)setScore:(id)sender;
@@ -61,7 +65,6 @@
 - (IBAction)omitItem:(id)sender;
 - (IBAction)assignAbbreviation:(id)sender;
 
-- (id)initWithFocus:(id)myFocus;
 
 //- (void)setSplitLocation;
 

--- a/Quicksilver/Code-QuickStepInterface/QSResultController.h
+++ b/Quicksilver/Code-QuickStepInterface/QSResultController.h
@@ -5,55 +5,30 @@
 @class QSObjectView, QSSearchObjectView, QSTableView;
 
 @interface QSResultController : NSWindowController
-{
- @public
-	IBOutlet NSTextField *	searchStringField;	// What the user types when searching (seen in the results view)
-	IBOutlet NSTextField * searchModeField;	// Seen in the result view. Either: @"Filter Catalog", @"Filter Results" or @"Snap to Best"
-	IBOutlet NSTextField *	selectionView;
-	IBOutlet NSSplitView *	splitView;
-	IBOutlet QSTableView *	resultTable;
-	IBOutlet QSTableView *	resultChildTable;
-	QSIconLoader *resultIconLoader;
-	QSIconLoader *resultChildIconLoader;
-	IBOutlet NSTextField *	resultCountField;
 
-	IBOutlet NSMenuItem *filterCatalog; // NSMenuItem (see ResultController.xib)
-	IBOutlet NSMenuItem *filterResults; // NSMenuItem (see ResultController.xib)
-	IBOutlet NSMenuItem *snapToBest; //  NSMenuItem (see ResultController.xib)
- 	IBOutlet NSMenu *searchModeMenu; // NSMenu opened when clicking the gear (see ResultController.xib)
-	IBOutlet NSMenuItem *sortByScore; // NSMenuItem (see ResultController.xib)
-	IBOutlet NSMenuItem *sortByName; // NSMenuItem (see ResultController.xib)
-	
-	NSInteger selectedResult;
-	QSObject *selectedItem;
-	BOOL browsing;
-	BOOL needsReload;
-    BOOL shouldSaveWindowSize;
-	NSRange loadingRange;
-	NSArray *currentResults;
-	QSSearchObjectView *focus;
-	NSInteger scrollViewTrackingRect;
-    NSUInteger windowHeight;
-
-//	NSArray **sourceArrayPointer;
-	NSTimer *iconTimer;
-	NSTimer *childrenLoadTimer;
-	BOOL loadingIcons;
-	BOOL loadingChildIcons;
-	BOOL iconLoadValid;
-	BOOL childIconLoadValid;
-
-  //  NSRange visibleRange;
-   // NSRange visibleChildRange;
-}
-
-
-@property (strong) IBOutlet QSTableView *resultTable;
 @property (strong) IBOutlet QSSearchObjectView *objectView;
 
 @property (strong) NSArray *currentResults;
 @property (strong) QSObject *selectedItem;
-@property (strong) NSTextField *searchStringField;
+
+// TODO: Most of you are meant to become private
+@property (strong) IBOutlet QSTableView *resultTable;
+
+@property (strong) IBOutlet NSTextField *searchStringField;	// What the user types when searching (seen in the results view)
+@property (strong) IBOutlet NSTextField *searchModeField;	// Seen in the result view. Either: @"Filter Catalog", @"Filter Results" or @"Snap to Best"
+@property (strong) IBOutlet NSTextField *selectionView;
+@property (strong) IBOutlet NSSplitView *splitView;
+@property (strong) IBOutlet QSTableView *resultChildTable;
+
+@property (strong) IBOutlet NSTextField *resultCountField;
+
+// FIXME: Isn't that a little too much outlets ?
+@property (strong) IBOutlet NSMenuItem *filterCatalog;  // NSMenuItem (see ResultController.xib)
+@property (strong) IBOutlet NSMenuItem *filterResults;  // NSMenuItem (see ResultController.xib)
+@property (strong) IBOutlet NSMenuItem *snapToBest;     // NSMenuItem (see ResultController.xib)
+@property (strong) IBOutlet NSMenu     *searchModeMenu; // NSMenu opened when clicking the gear (see ResultController.xib)
+@property (strong) IBOutlet NSMenuItem *sortByScore;    // NSMenuItem (see ResultController.xib)
+@property (strong) IBOutlet NSMenuItem *sortByName;     // NSMenuItem (see ResultController.xib)
 
 + (id)sharedInstance;
 

--- a/Quicksilver/Code-QuickStepInterface/QSResultController.h
+++ b/Quicksilver/Code-QuickStepInterface/QSResultController.h
@@ -1,12 +1,15 @@
 
 
-#import <AppKit/AppKit.h>
+#import <QSInterface/QSInterface.h>
+#import <QSInterface/QSInterfaceController.h>
 
 @class QSObjectView, QSSearchObjectView, QSTableView;
 
 @interface QSResultController : NSWindowController
 
 @property (strong) IBOutlet QSSearchObjectView *objectView;
+@property (assign) QSSearchMode searchMode;
+@property (assign) QSSearchOrder searchOrder;
 
 @property (strong) NSArray *currentResults;
 @property (strong) QSObject *selectedItem;
@@ -41,38 +44,8 @@
 - (IBAction)assignAbbreviation:(id)sender;
 
 
-//- (void)setSplitLocation;
-
-- (void)loadChildren;
-/*!
- setSearchFilterAllActivated
- @abstract   Sets the results view to show the 'Filter Catalog' search mode is activated
- @discussion  Sets the results view to show the 'Filter Catalog' search mode is selected 
- by setting the NSMenuItem's state and the 'searchModeField' string value to @"(Filter Catalog")
- */
-- (IBAction)setSearchFilterAllActivated;
-/*!
- setSearchFilterActivated
- @abstract   Sets the results view to show the 'Filter Results' search mode is activated
- @discussion  Sets the results view to show the 'Filter Catalog' search mode is selected 
- by setting the NSMenuItem's state and the 'searchModeField' string value to @"(Filter Results")
- */
-- (IBAction)setSearchFilterActivated;
-/*!
- setSearchSnapActivated
- @abstract   Sets the results view to show the 'Snap to Best' search mode is activated
- @discussion  Sets the results view to show the 'Filter Catalog' search mode is selected 
- by setting the NSMenuItem's state and the 'searchModeField' string value to @"(Snap to Best")
- */
-- (IBAction)setSearchSnapActivated;
-/*!
- setSearchMode
- @abstract   Sets the search mode for Quicksilver
- @discussion Sets the search mode which can be one of: 'Filter Results, 'Filter Catalog' or 'Snap to Best'
- @param      sender IB NSMenuItem within the 'Search Mode' menu
- */
-- (IBAction)setSearchMode:(id)sender;
 - (void)arrayChanged:(NSNotification*)notif;
+
 - (void)bump:(NSInteger)i;
 
 - (void)updateSelectionInfo;
@@ -83,22 +56,7 @@
 - (QSIconLoader *)resultChildIconLoader;
 - (void)setResultChildIconLoader:(QSIconLoader *)aResultChildIconLoader;
 - (void)objectIconModified:(NSNotification *)notif;
-/*!
- sortByName
- @abstract   Sets the results view to show the 'Sort by Name' search mode is activated
- @discussion  Sets the results view to show the 'Sort by Name' search mode is selected 
-by altering its state to enabled (Adds a checkmark in the menu)
- @param sender The NSMenuItem clicked in the interface
- */
-- (IBAction)sortByName:(id)sender;
-/*!
- sortByScore
- @abstract   Sets the results view to show the 'Sort by Score' search mode is activated
- @discussion  Sets the results view to show the 'Sort by Score' search mode is selected 
- by altering its state to enabled (Adds a checkmark in the menu)
- @param sender The NSMenuItem clicked in the interface
- */
-- (IBAction)sortByScore:(id)sender;
+
 @end
 
 

--- a/Quicksilver/Code-QuickStepInterface/QSResultController.h
+++ b/Quicksilver/Code-QuickStepInterface/QSResultController.h
@@ -32,6 +32,8 @@
 @property (strong) IBOutlet NSMenu     *searchModeMenu; // NSMenu opened when clicking the gear (see ResultController.xib)
 @property (strong) IBOutlet NSMenuItem *sortByScore;    // NSMenuItem (see ResultController.xib)
 @property (strong) IBOutlet NSMenuItem *sortByName;     // NSMenuItem (see ResultController.xib)
+@property (strong) IBOutlet NSMenuItem *sortByDateA;    // NSMenuItem (see ResultController.xib)
+@property (strong) IBOutlet NSMenuItem *sortByDateD;    // NSMenuItem (see ResultController.xib)
 
 + (id)sharedInstance;
 

--- a/Quicksilver/Code-QuickStepInterface/QSResultController.m
+++ b/Quicksilver/Code-QuickStepInterface/QSResultController.m
@@ -230,11 +230,13 @@ NSMutableDictionary *kindDescriptions = nil;
         case QSSearchOrderByName:
             [_sortByName setState:NSOnState];
             [_sortByScore setState:NSOffState];
+			[_resultTable setSortDescriptors:[NSSortDescriptor descriptorArrayWithKey:@"name" ascending:YES selector:@selector(localizedCompare:)]];
             break;
 
         case QSSearchOrderByScore:
             [_sortByName setState:NSOffState];
             [_sortByScore setState:NSOnState];
+			[_resultTable setSortDescriptors:[NSSortDescriptor descriptorArrayWithKey:@"score" ascending:NO]];
             break;
 
         default:
@@ -246,10 +248,6 @@ NSMutableDictionary *kindDescriptions = nil;
 
 - (IBAction)changeSearchOrder:(id)sender {
     self.searchOrder = [sender tag];
-
-	if ([[self nextResponder] respondsToSelector:@selector(changeSearchOrder:)]) {
-		[[self nextResponder] performSelector:@selector(changeSearchOrder:) withObject:sender];
-	}
 }
 
 - (void)bump:(NSInteger)i {
@@ -747,4 +745,13 @@ NSMutableDictionary *kindDescriptions = nil;
     [[self.objectView controller] executeCommand:self];
 }
 
+- (void)tableView:(NSTableView *)tv sortDescriptorsDidChange:(NSArray<NSSortDescriptor *> *)oldDescriptors
+{
+	[[self.objectView resultArray] sortUsingDescriptors:[tv sortDescriptors]];
+	[self arrayChanged:nil];
+	if ([[self.objectView resultArray] count]) {
+		id firstObject = [[self.objectView resultArray] objectAtIndex:0];
+		[self.objectView selectObjectValue:firstObject];
+	}
+}
 @end

--- a/Quicksilver/Code-QuickStepInterface/QSResultController.m
+++ b/Quicksilver/Code-QuickStepInterface/QSResultController.m
@@ -36,13 +36,26 @@
 
 NSMutableDictionary *kindDescriptions = nil;
 
-@interface QSResultController () <NSTableViewDataSource, NSWindowDelegate>
+@interface QSResultController () <NSTableViewDataSource, NSWindowDelegate> {
+@private
+
+    NSInteger _selectedResult;
+    QSObject *_selectedItem;
+
+    BOOL _shouldSaveWindowSize;
+    NSArray *_currentResults;
+    NSInteger _scrollViewTrackingRect;
+    NSUInteger _windowHeight;
+
+    QSIconLoader *_resultIconLoader;
+    QSIconLoader *_resultChildIconLoader;
+
+    NSTimer *_childrenLoadTimer;
+}
 
 @end
 
 @implementation QSResultController
-
-@synthesize resultTable=resultTable,currentResults,selectedItem,searchStringField;
 
 + (void)initialize {
     if (!kindDescriptions)
@@ -60,54 +73,54 @@ NSMutableDictionary *kindDescriptions = nil;
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context {
     if ([keyPath isEqualToString:@"rowHeight"]) {
         if ([change objectForKey:NSKeyValueChangeNewKey]) {
-            [(QSObjectCell *)[[resultTable tableColumnWithIdentifier: COLUMNID_NAME] dataCell] setShowDetails:([[change objectForKey:NSKeyValueChangeNewKey] doubleValue] >= 34.0)];
+            QSObjectCell *nameCell = (QSObjectCell *)[[_resultTable tableColumnWithIdentifier: COLUMNID_NAME] dataCell];
+            BOOL shouldShowDetails = ([[change objectForKey:NSKeyValueChangeNewKey] doubleValue] >= 34.0);
+            [nameCell setShowDetails:shouldShowDetails];
+            return;
         }
     }
+    [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
 }
 
 #pragma mark -
 #pragma mark Lifetime
 - (id)init {
 	self = [self initWithWindowNibName:@"ResultWindow"];
-	if (self) {
-        _objectView = nil;
-		loadingIcons = NO;
-		loadingChildIcons = NO;
-		iconTimer = nil;
-		childrenLoadTimer = nil;
-		selectedItem = nil;
-		loadingRange = NSMakeRange(0, 0);
-		scrollViewTrackingRect = 0;
-        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(objectIconModified:) name:QSObjectIconModified object:nil];
-	}
+    if (!self) return nil;
+
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(objectIconModified:) name:QSObjectIconModified object:nil];
+
 	return self;
 }
 
 - (id)initWithObjectView:(QSSearchObjectView *)objectView {
+    NSParameterAssert(objectView != nil);
+
     self = [self init];
-    if (self) {
-        _objectView = objectView;
-	}
+    if (!self) return nil;
+
+    _objectView = objectView;
+
     return self;
 }
 
 - (void)windowDidLoad {
 	[(QSWindow *)[self window] setHideOffset:NSMakePoint(32, 0)];
 	[(QSWindow *)[self window] setShowOffset:NSMakePoint(16, 0)];
-    windowHeight = [[self window] frame].size.height;
+    _windowHeight = [[self window] frame].size.height;
 	[self setupResultTable];
 
-	[splitView setAutosaveName:@"QSResultWindowSplitView"];
+	[_splitView setAutosaveName:@"QSResultWindowSplitView"];
     
 	if (![[NSUserDefaults standardUserDefaults] boolForKey:@"QSResultsShowChildren"]) {
-		NSView *tableView = [resultTable enclosingScrollView];
+		NSView *tableView = [_resultTable enclosingScrollView];
 		[tableView removeFromSuperview];
-		[tableView setFrame:[splitView frame]];
-		[tableView setAutoresizingMask:[splitView autoresizingMask]];
+		[tableView setFrame:[_splitView frame]];
+		[tableView setAutoresizingMask:[_splitView autoresizingMask]];
 
-		[[splitView superview] addSubview:tableView];
-		resultChildTable = nil;
-		[splitView removeFromSuperview];
+		[[_splitView superview] addSubview:tableView];
+		_resultChildTable = nil;
+		[_splitView removeFromSuperview];
 	}
     NSUserDefaultsController *sucd = [NSUserDefaultsController sharedUserDefaultsController];
     [sucd addObserver:self
@@ -116,7 +129,7 @@ NSMutableDictionary *kindDescriptions = nil;
               context:nil];
     [[self window] bind:@"backgroundColor" toObject:sucd withKeyPath:@"values.QSAppearance2B" options:@{NSValueTransformerNameBindingOption : NSUnarchiveFromDataTransformerName}];
     
-    for (NSView *view in @[searchModeField, searchStringField, selectionView]) {
+    for (NSView *view in @[_searchModeField, _searchStringField, _selectionView]) {
         [view bind:@"textColor" toObject:sucd withKeyPath:@"values.QSAppearance2T" options:@{NSValueTransformerNameBindingOption : NSUnarchiveFromDataTransformerName}];
     }
     
@@ -139,16 +152,15 @@ NSMutableDictionary *kindDescriptions = nil;
         
         [t setOpaque:NO];
     };
-    b(resultTable);
-    b(resultChildTable);
-
+    b(_resultTable);
+    b(_resultChildTable);
 }
 
 - (void)dealloc {
 	NSUserDefaultsController *sucd = [NSUserDefaultsController sharedUserDefaultsController];
 	[sucd removeObserver:self forKeyPath:@"values.QSAppearance3B"];
     
-    for (QSTableView *t in @[resultTable, resultChildTable]) {
+    for (QSTableView *t in @[_resultTable, _resultChildTable]) {
         [[[t tableColumnWithIdentifier:@"NameColumn"] dataCell] unbind:@"textColor"];
         [t unbind:@"backgroundColor"];
         [t unbind:@"highlightColor"];
@@ -161,37 +173,36 @@ NSMutableDictionary *kindDescriptions = nil;
 #pragma mark -
 #pragma mark Accessors, Utilities
 
-
 - (void)updateScrollViewTrackingRect {
 	NSView *view = [[self window] contentView];
-	if (scrollViewTrackingRect) [view removeTrackingRect:scrollViewTrackingRect];
-	scrollViewTrackingRect = [view addTrackingRect:[view frame] owner:self userData:nil assumeInside:NO];
+	if (_scrollViewTrackingRect) [view removeTrackingRect:_scrollViewTrackingRect];
+	_scrollViewTrackingRect = [view addTrackingRect:[view frame] owner:self userData:nil assumeInside:NO];
 }
 
 - (IBAction)setSearchFilterAllActivated {
-	if ([filterCatalog state] == NSOffState) {
-		[filterCatalog setState:NSOnState];
-		[filterResults setState:NSOffState];
-		[snapToBest setState:NSOffState];
-		[searchModeField setStringValue:filterCatalogString];
+	if ([_filterCatalog state] == NSOffState) {
+		[_filterCatalog setState:NSOnState];
+		[_filterResults setState:NSOffState];
+		[_snapToBest setState:NSOffState];
+		[_searchModeField setStringValue:filterCatalogString];
 	}
 }
 
 - (IBAction)setSearchFilterActivated {
-	if ([filterResults state] == NSOffState) {
-		[filterResults setState:NSOnState];
-		[filterCatalog setState:NSOffState];
-		[snapToBest setState:NSOffState];
-		[searchModeField setStringValue:filterResultsString];
+	if ([_filterResults state] == NSOffState) {
+		[_filterResults setState:NSOnState];
+		[_filterCatalog setState:NSOffState];
+		[_snapToBest setState:NSOffState];
+		[_searchModeField setStringValue:filterResultsString];
 	}
 }
 
 - (IBAction)setSearchSnapActivated {
-	if ([snapToBest state] == NSOffState) {
-		[snapToBest setState:NSOnState];
-		[filterResults setState:NSOffState];
-		[filterCatalog setState:NSOffState];
-		[searchModeField setStringValue:snapToBestString];
+	if ([_snapToBest state] == NSOffState) {
+		[_snapToBest setState:NSOnState];
+		[_filterResults setState:NSOffState];
+		[_filterCatalog setState:NSOffState];
+		[_searchModeField setStringValue:snapToBestString];
 	}
 }
 
@@ -200,14 +211,14 @@ NSMutableDictionary *kindDescriptions = nil;
 }
 
 - (IBAction)sortByName:(id)sender{
-	[sortByName setState:NSOnState];
-	[sortByScore setState:NSOffState];
+	[_sortByName setState:NSOnState];
+	[_sortByScore setState:NSOffState];
     [self.objectView sortByName:sender];
 }
 
 - (IBAction)sortByScore:(id)sender {
-	[sortByName setState:NSOffState];
-	[sortByScore setState:NSOnState];
+	[_sortByName setState:NSOffState];
+	[_sortByScore setState:NSOnState];
     [self.objectView sortByScore:sender];
 }
 
@@ -221,9 +232,9 @@ NSMutableDictionary *kindDescriptions = nil;
 }
 
 - (void)loadChildren {
-	if (NSEqualRects(NSZeroRect, [resultChildTable visibleRect]) )
+	if (NSEqualRects(NSZeroRect, [_resultChildTable visibleRect]) )
         return;
-	[resultChildTable reloadData];
+	[_resultChildTable reloadData];
 }
 
 /*- (void)setSplitLocation {
@@ -253,47 +264,46 @@ NSMutableDictionary *kindDescriptions = nil;
 
 - (void)iconLoader:(QSIconLoader *)loader loadedIndex:(NSInteger)m inArray:(NSArray *)array {
     QSGCDMainAsync(^{
-        if (loader == resultIconLoader) {
-            [resultTable setNeedsDisplayInRect:[resultTable rectOfRow:m]];
-        } else if (loader == resultChildIconLoader) {
-            [resultChildTable setNeedsDisplayInRect:[resultChildTable rectOfRow:m]];
+        if (loader == _resultIconLoader) {
+            [_resultTable setNeedsDisplayInRect:[_resultTable rectOfRow:m]];
+        } else if (loader == _resultChildIconLoader) {
+            [_resultChildTable setNeedsDisplayInRect:[_resultChildTable rectOfRow:m]];
         }
     });
 }
 
 - (BOOL)iconsAreLoading {
-    BOOL resultsIconLoading = [resultIconLoader isLoading];
-    return (resultsIconLoading ? YES : [resultChildIconLoader isLoading]);
+    return [_resultIconLoader isLoading] || [_resultChildIconLoader isLoading];
 }
 
 - (QSIconLoader *)resultIconLoader {
-	if (!resultIconLoader) {
+	if (!_resultIconLoader) {
 		[self setResultIconLoader:[QSIconLoader loaderWithArray:[self currentResults]]];
-		[resultIconLoader setDelegate:self];
+		[_resultIconLoader setDelegate:self];
 	}
-	return resultIconLoader;
+	return _resultIconLoader;
 }
 
 - (void)setResultIconLoader:(QSIconLoader *)aResultIconLoader {
 	//NSLog(@"setloader %@", aResultIconLoader);
-	if (resultIconLoader != aResultIconLoader) {
-		[resultIconLoader invalidate];
-		resultIconLoader = aResultIconLoader;
+	if (_resultIconLoader != aResultIconLoader) {
+		[_resultIconLoader invalidate];
+		_resultIconLoader = aResultIconLoader;
 	}
 }
 
 - (QSIconLoader *)resultChildIconLoader {
-    if (!resultChildIconLoader) {
-        [self setResultChildIconLoader:[QSIconLoader loaderWithArray:[selectedItem children]]];
-        [resultChildIconLoader setDelegate:self];
+    if (!_resultChildIconLoader) {
+        [self setResultChildIconLoader:[QSIconLoader loaderWithArray:[_selectedItem children]]];
+        [_resultChildIconLoader setDelegate:self];
     }
-    return resultChildIconLoader;
+    return _resultChildIconLoader;
 }
 
 - (void)setResultChildIconLoader:(QSIconLoader *)aResultChildIconLoader {
-	if (resultChildIconLoader != aResultChildIconLoader) {
-		[resultChildIconLoader invalidate];
-		resultChildIconLoader = aResultChildIconLoader;
+	if (_resultChildIconLoader != aResultChildIconLoader) {
+		[_resultChildIconLoader invalidate];
+		_resultChildIconLoader = aResultChildIconLoader;
 	}
 }
 
@@ -304,15 +314,15 @@ NSMutableDictionary *kindDescriptions = nil;
         if ([[self window] isVisible]) {
             QSObject *object = [notif object];
             // if updated object is is in the results, update it in the list
-            NSUInteger ind = [currentResults indexOfObject:object];
+            NSUInteger ind = [_currentResults indexOfObject:object];
             if (ind != NSNotFound) {
-                [resultTable setNeedsDisplayInRect:[resultTable rectOfRow:ind]];
+                [_resultTable setNeedsDisplayInRect:[_resultTable rectOfRow:ind]];
             }
             // if updated object is is in the child results, update it in the list
             if ([[NSUserDefaults standardUserDefaults] boolForKey:@"QSResultsShowChildren"]) {
                 ind = [[[self selectedItem] children] indexOfObject:object];
                 if (ind != NSNotFound) {
-                    [resultChildTable setNeedsDisplayInRect:[resultChildTable rectOfRow:ind]];
+                    [_resultChildTable setNeedsDisplayInRect:[_resultChildTable rectOfRow:ind]];
                 }
             }
         }
@@ -349,26 +359,26 @@ NSMutableDictionary *kindDescriptions = nil;
         [self setCurrentResults:[self.objectView resultArray]];
         [self updateStatusString];
         
-        [resultTable reloadData];
+        [_resultTable reloadData];
         
         //visibleRange = [resultTable rowsInRect:[resultTable visibleRect]];
         //	NSLog(@"arraychanged %d", [[self currentResults] count]);
         //[self threadedIconLoad];
-        [[self resultIconLoader] loadIconsInRange:[resultTable rowsInRect:[resultTable visibleRect]]];
+        [[self resultIconLoader] loadIconsInRange:[_resultTable rowsInRect:[_resultTable visibleRect]]];
     });
 }
 
 - (NSRect)windowFrame {
     NSRect windowFrame = [[self window] frame];
-    NSUInteger resultCount = [currentResults count];
-    NSUInteger verticalSpacing = [resultTable intercellSpacing].height;
-    NSUInteger newWindowHeight =  (([resultTable rowHeight] + verticalSpacing) * resultCount) + 31;
+    NSUInteger resultCount = [_currentResults count];
+    NSUInteger verticalSpacing = [_resultTable intercellSpacing].height;
+    NSUInteger newWindowHeight =  (([_resultTable rowHeight] + verticalSpacing) * resultCount) + 31;
     if ([[NSUserDefaults standardUserDefaults] boolForKey:@"QSResultsShowChildren"]) {
         // Be sure to chose the taller of the two: results list or results child list
-        NSUInteger childResultHeight = (([resultChildTable rowHeight] + [resultChildTable intercellSpacing].height) * [resultChildTable numberOfRows]) + 31;
+        NSUInteger childResultHeight = (([_resultChildTable rowHeight] + [_resultChildTable intercellSpacing].height) * [_resultChildTable numberOfRows]) + 31;
         newWindowHeight = MAX(newWindowHeight, childResultHeight);
     }
-    windowFrame.size.height =  newWindowHeight > windowHeight || [currentResults count] == 0 ? windowHeight : newWindowHeight;
+    windowFrame.size.height =  newWindowHeight > _windowHeight || [_currentResults count] == 0 ? _windowHeight : newWindowHeight;
     if (windowFrame.size.height != [[self window] frame].size.height) {
         windowFrame.origin.y = windowFrame.origin.y - (windowFrame.size.height - [[self window] frame].size.height);
     }
@@ -376,26 +386,26 @@ NSMutableDictionary *kindDescriptions = nil;
 }
 
 - (void)updateSelectionInfo {
-	selectedResult = [resultTable selectedRow];
+	_selectedResult = [_resultTable selectedRow];
     
-	if (selectedResult < 0 || ![[self currentResults] count]) return;
-	QSObject *newSelectedItem = [[self currentResults] objectAtIndex:selectedResult];
+	if (_selectedResult < 0 || ![[self currentResults] count]) return;
+	QSObject *newSelectedItem = [[self currentResults] objectAtIndex:_selectedResult];
     
-	if (selectedItem != newSelectedItem) {
+	if (_selectedItem != newSelectedItem) {
 		[self setSelectedItem:newSelectedItem];
-		[resultChildTable noteNumberOfRowsChanged];
+		[_resultChildTable noteNumberOfRowsChanged];
         [self updateStatusString];
-		
+
 		NSEvent *event = [NSApp currentEvent];
 		// Check the event can have isARepeat called on it safely. From the docs for -[NSEvent isARepeat]: "Raises an NSInternalInconsistencyException if sent to an NSFlagsChanged event or other non-key event."
 		BOOL validKeyEvent = ([event type] == NSKeyDown) || ([event type] == NSKeyUp);
 		if ([event modifierFlags] & NSFunctionKeyMask && validKeyEvent && [event isARepeat]) {
-			if ([childrenLoadTimer isValid]) {
-				[childrenLoadTimer setFireDate:[NSDate dateWithTimeIntervalSinceNow:0.5]];
+			if ([_childrenLoadTimer isValid]) {
+				[_childrenLoadTimer setFireDate:[NSDate dateWithTimeIntervalSinceNow:0.5]];
 			} else {
 				// ***warning  * this should be triggered by the keyUp
                 if (![NSApp nextEventMatchingMask:NSKeyUpMask untilDate:[NSDate dateWithTimeIntervalSinceNow:0.333] inMode:NSDefaultRunLoopMode dequeue:NO]) {
-                    childrenLoadTimer = [NSTimer scheduledTimerWithTimeInterval:0.5 target:self selector:@selector(loadChildren) userInfo:nil repeats:NO];
+                    _childrenLoadTimer = [NSTimer scheduledTimerWithTimeInterval:0.5 target:self selector:@selector(loadChildren) userInfo:nil repeats:NO];
                 }
 			}
 		} else {
@@ -406,15 +416,15 @@ NSMutableDictionary *kindDescriptions = nil;
     
     if ([[[NSUserDefaults standardUserDefaults] objectForKey:kUseEffects] boolValue] && [QSInterfaceController firstResponder] == self.objectView) {
         NSRect windowFrame = [self windowFrame];
-        shouldSaveWindowSize = NO;
+        _shouldSaveWindowSize = NO;
         [[self window] setFrame:windowFrame display:YES animate:YES];
-        shouldSaveWindowSize = YES;
+        _shouldSaveWindowSize = YES;
     }
     
     /* Restart the icon loading for the children view */
     if ([[NSUserDefaults standardUserDefaults] boolForKey:@"QSResultsShowChildren"]) {
         [self setResultChildIconLoader:nil];
-        [[self resultChildIconLoader] loadIconsInRange:[resultChildTable rowsInRect:[resultChildTable visibleRect]]];
+        [[self resultChildIconLoader] loadIconsInRange:[_resultChildTable rowsInRect:[_resultChildTable visibleRect]]];
     }
 }
 
@@ -422,11 +432,11 @@ NSMutableDictionary *kindDescriptions = nil;
 {
     // HenningJ 20110419 there is no localized version of "%d of %d". Additionally, something goes wrong while trying to localize it.
     // NSString *fmt = NSLocalizedStringFromTableInBundle(@"%d of %d", nil, [NSBundle bundleForClass:[self class]], @"");
-    NSString *status = [NSString stringWithFormat:@"%ld of %ld", (long)selectedResult + 1, (long)[[self currentResults] count]];
-    if ([resultTable rowHeight] < 34 && [selectedItem details]) {
-        status = [status stringByAppendingFormat:@" %C %@", (unsigned short)0x25B8, [selectedItem details]];
+    NSString *status = [NSString stringWithFormat:@"%ld of %ld", (long)_selectedResult + 1, (long)[[self currentResults] count]];
+    if ([_resultTable rowHeight] < 34 && [_selectedItem details]) {
+        status = [status stringByAppendingFormat:@" %C %@", (unsigned short)0x25B8, [_selectedItem details]];
     }
-    [(NSTextField *)selectionView setStringValue:status];
+    [(NSTextField *)_selectionView setStringValue:status];
 }
 
 #pragma mark -
@@ -469,18 +479,18 @@ NSMutableDictionary *kindDescriptions = nil;
 
 // called twice when a user resized the results window
 - (void)windowDidResize:(NSNotification *)aNotification {
-    if (!shouldSaveWindowSize) {
+    if (!_shouldSaveWindowSize) {
         return;
     }
-    [[self resultIconLoader] loadIconsInRange:[resultTable rowsInRect:[resultTable visibleRect]]];
-	if (!NSEqualRects(NSZeroRect, [resultChildTable visibleRect]) && [self numberOfRowsInTableView:resultChildTable])
-		[[self resultChildIconLoader] loadIconsInRange:[resultChildTable rowsInRect:[resultChildTable visibleRect]]];
+    [[self resultIconLoader] loadIconsInRange:[_resultTable rowsInRect:[_resultTable visibleRect]]];
+	if (!NSEqualRects(NSZeroRect, [_resultChildTable visibleRect]) && [self numberOfRowsInTableView:_resultChildTable])
+		[[self resultChildIconLoader] loadIconsInRange:[_resultChildTable rowsInRect:[_resultChildTable visibleRect]]];
 
 	[self updateScrollViewTrackingRect];
     
     // saves size for result window when it is resized
     [[self window] saveFrameUsingName:@"QSResultWindow"];
-    windowHeight = [self window].frame.size.height;
+    _windowHeight = [self window].frame.size.height;
 }
 
 #pragma mark -
@@ -498,7 +508,7 @@ NSMutableDictionary *kindDescriptions = nil;
 
 - (BOOL)splitView:(NSSplitView *)sender canCollapseSubview:(NSView *)subview {
 	//NSLog(@"collapse");
-	return subview != [resultTable enclosingScrollView];
+	return subview != [_resultTable enclosingScrollView];
 	// if (subview == infoBox) return YES;
 	// else return NO;
 }
@@ -530,7 +540,7 @@ NSMutableDictionary *kindDescriptions = nil;
 
 - (void)splitViewDidResizeSubviews:(NSNotification *)notification {
 	if ([[NSApp currentEvent] type] == NSLeftMouseDragged) {
-        CGFloat split = NSWidth([[resultChildTable enclosingScrollView] frame]) / NSWidth([splitView frame]);
+        CGFloat split = NSWidth([[_resultChildTable enclosingScrollView] frame]) / NSWidth([_splitView frame]);
         [[NSUserDefaults standardUserDefaults] setFloat:split
                                                  forKey:kResultTableSplit];
     }
@@ -542,75 +552,50 @@ NSMutableDictionary *kindDescriptions = nil;
 //Table Methods
 
 - (void)setupResultTable {
-	//NSLog(@"setup result");
-	NSTableColumn *tableColumn = nil;
-	//  QSImageAndTextCell *imageAndTextCell = nil;
-	//NSImageCell *imageCell = nil;
+	[_resultTable setTarget:self];
 
-	[resultTable setTarget:self];
-
-	[resultTable setAction:@selector(tableViewAction:)];
-	[resultTable setDoubleAction:@selector(tableViewDoubleAction:)];
-	[resultTable setVerticalMotionCanBeginDrag:NO];
-
-	//	[resultTable setRowHeight:36];
-	// imageAndTextCell = [[[QSImageAndTextCell alloc] init] autorelease];
-	// [imageAndTextCell setEditable: YES];
-	//  [imageAndTextCell setFont:[NSFont systemFontOfSize:11]];
-	//  [imageAndTextCell setWraps:NO];
-	//[imageAndTextCell setScrollable:YES];
+	[_resultTable setAction:@selector(tableViewAction:)];
+	[_resultTable setDoubleAction:@selector(tableViewDoubleAction:)];
+	[_resultTable setVerticalMotionCanBeginDrag:NO];
 
 	QSObjectCell *objectCell = [[QSObjectCell alloc] init];
-	tableColumn = [resultTable tableColumnWithIdentifier: COLUMNID_NAME];
-    if ([resultTable rowHeight] < 34.0) {
+	NSTableColumn *tableColumn = [_resultTable tableColumnWithIdentifier:COLUMNID_NAME];
+    if ([_resultTable rowHeight] < 34.0) {
         [objectCell setShowDetails:NO];
     }
 	[tableColumn setDataCell:objectCell];
 
-	tableColumn = [resultChildTable tableColumnWithIdentifier: COLUMNID_NAME];
+	tableColumn = [_resultChildTable tableColumnWithIdentifier:COLUMNID_NAME];
 	[tableColumn setDataCell:objectCell];
 
-	tableColumn = [resultTable tableColumnWithIdentifier: COLUMNID_RANK];
+	tableColumn = [_resultTable tableColumnWithIdentifier:COLUMNID_RANK];
 
 	NSCell *rankCell = [[QSRankCell alloc] init];
 	[tableColumn setDataCell:rankCell];
 
 	//[searchModePopUp setEnabled:fALPHA];
 
-	tableColumn = [resultTable tableColumnWithIdentifier: COLUMNID_EQUIV];
+	tableColumn = [_resultTable tableColumnWithIdentifier:COLUMNID_EQUIV];
 	[[tableColumn dataCell] setFont:[NSFont systemFontOfSize:9]];
 	[[tableColumn dataCell] setTextColor:[NSColor darkGrayColor]];
 
-	[resultTable removeTableColumn:tableColumn];
+	[_resultTable removeTableColumn:tableColumn];
 
-	[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(viewChanged:) name:NSViewBoundsDidChangeNotification object:[[resultTable enclosingScrollView] contentView]];
-	[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(childViewChanged:) name:NSViewBoundsDidChangeNotification object:[[resultChildTable enclosingScrollView] contentView]];
+	[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(viewChanged:) name:NSViewBoundsDidChangeNotification object:[[_resultTable enclosingScrollView] contentView]];
+	[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(childViewChanged:) name:NSViewBoundsDidChangeNotification object:[[_resultChildTable enclosingScrollView] contentView]];
 }
 
 - (void)viewChanged:(NSNotification*)notif {
-	NSRange newRange = [resultTable rowsInRect:[resultTable visibleRect]];
-    
-	//  NSLog(@"%d-%d are visible %d", visibleRange.location, visibleRange.location+visibleRange.length, [self iconsAreLoading]);
-    
-	//[self iconsAreLoading];
-	//	NSBeep();
-    [[self resultIconLoader] loadIconsInRange:newRange];
-	//	[self threadedIconLoad];
-    
-	// loadingRange = newRange;
+    [[self resultIconLoader] loadIconsInRange:[_resultTable rowsInRect:[_resultTable visibleRect]]];
 }
 
 - (void)childViewChanged:(NSNotification*)notif {
-	NSRange newRange = [resultChildTable rowsInRect:[resultChildTable visibleRect]];
-	//visibleRange = [resultTable rowsInRect:[resultTable visibleRect]];
-	//s NSLog(@"%d-%d are visible", visibleRange.location, visibleRange.location+visibleRange.length); /
-	// [self threadedChildIconLoad];
-    [[self resultChildIconLoader] loadIconsInRange:newRange];
+    [[self resultChildIconLoader] loadIconsInRange:[_resultChildTable rowsInRect:[_resultChildTable visibleRect]]];
 }
 
 - (NSInteger)numberOfRowsInTableView:(NSTableView *)tableView {
-	if (tableView == resultChildTable) {
-		return [[selectedItem children] count];
+	if (tableView == _resultChildTable) {
+		return [[_selectedItem children] count];
 	} else {
 		return [[self currentResults] count];
 	}
@@ -628,14 +613,14 @@ NSMutableDictionary *kindDescriptions = nil;
 
 	NSRectFill(clipRect);
 
-	id object = [[self currentResults] objectAtIndex:rowIndex];
-	[[(QSObject *)object name] drawInRect:clipRect withAttributes:nil];
+	QSObject *object = [[self currentResults] objectAtIndex:rowIndex];
+	[[object name] drawInRect:clipRect withAttributes:nil];
 
 	return NO;
 }
 
 - (id)tableView:(NSTableView *)tableView objectValueForTableColumn:(NSTableColumn *)tableColumn row:(NSInteger)row {
-	if (tableView == resultTable && [[self currentResults] count] > (NSUInteger)row) {
+	if (tableView == _resultTable && [[self currentResults] count] > (NSUInteger)row) {
 		QSObject *thisObject = [[self currentResults] objectAtIndex:row];
 
 		if ([[tableColumn identifier] isEqualToString:COLUMNID_TYPE]) {
@@ -659,7 +644,7 @@ NSMutableDictionary *kindDescriptions = nil;
 - (void)tableView:(NSTableView *)aTableView willDisplayCell:(id)aCell forTableColumn:(NSTableColumn *)aTableColumn row:(NSInteger)rowIndex {
 	if ([[aTableColumn identifier] isEqualToString:COLUMNID_NAME]) {
 		NSArray *array = [self currentResults];
-		if (aTableView == resultChildTable) array = [selectedItem children];
+		if (aTableView == _resultChildTable) array = [_selectedItem children];
         
         // avoid attempting to access objects in a nonexistent array or an index out of bounds
         if (!array || rowIndex >= (NSInteger)[array count]) {
@@ -701,11 +686,11 @@ NSMutableDictionary *kindDescriptions = nil;
 }
 
 - (void)tableViewSelectionDidChange:(NSNotification *)aNotification {
-	if (aNotification && [aNotification object] != resultTable) return;
+	if (aNotification && [aNotification object] != _resultTable) return;
 
-	if (selectedResult != -1 && selectedResult != [resultTable selectedRow]) {
-		selectedResult = [resultTable selectedRow];
-        [self.objectView selectIndex:[resultTable selectedRow]];
+	if (_selectedResult != -1 && _selectedResult != [_resultTable selectedRow]) {
+		_selectedResult = [_resultTable selectedRow];
+        [self.objectView selectIndex:[_resultTable selectedRow]];
 		[self updateSelectionInfo];
 	}
 }
@@ -732,4 +717,5 @@ NSMutableDictionary *kindDescriptions = nil;
 - (IBAction)tableViewDoubleAction:(id)sender {
     [[self.objectView controller] executeCommand:self];
 }
+
 @end

--- a/Quicksilver/Code-QuickStepInterface/QSResultController.m
+++ b/Quicksilver/Code-QuickStepInterface/QSResultController.m
@@ -36,6 +36,10 @@
 
 NSMutableDictionary *kindDescriptions = nil;
 
+@interface QSResultController () <NSTableViewDataSource, NSWindowDelegate>
+
+@end
+
 @implementation QSResultController
 
 @synthesize resultTable=resultTable,currentResults,selectedItem,searchStringField;
@@ -66,7 +70,7 @@ NSMutableDictionary *kindDescriptions = nil;
 - (id)init {
 	self = [self initWithWindowNibName:@"ResultWindow"];
 	if (self) {
-        focus = nil;
+        _objectView = nil;
 		loadingIcons = NO;
 		loadingChildIcons = NO;
 		iconTimer = nil;
@@ -79,10 +83,10 @@ NSMutableDictionary *kindDescriptions = nil;
 	return self;
 }
 
-- (id)initWithFocus:(id)myFocus {
+- (id)initWithObjectView:(QSSearchObjectView *)objectView {
     self = [self init];
     if (self) {
-        focus = myFocus;
+        _objectView = objectView;
 	}
     return self;
 }
@@ -192,19 +196,19 @@ NSMutableDictionary *kindDescriptions = nil;
 }
 
 - (IBAction)setSearchMode:(id)sender {
-    [focus setSearchMode:[sender tag]];
+    [self.objectView setSearchMode:[sender tag]];
 }
 
 - (IBAction)sortByName:(id)sender{
 	[sortByName setState:NSOnState];
 	[sortByScore setState:NSOffState];
-    [focus sortByName:sender];
+    [self.objectView sortByName:sender];
 }
 
 - (IBAction)sortByScore:(id)sender {
 	[sortByName setState:NSOffState];
 	[sortByScore setState:NSOnState];
-    [focus sortByScore:sender];
+    [self.objectView sortByScore:sender];
 }
 
 - (void)bump:(NSInteger)i {
@@ -319,30 +323,30 @@ NSMutableDictionary *kindDescriptions = nil;
 #pragma mark Actions
 - (IBAction)defineMnemonic:(id)sender {
 	//	NSLog(@"%d", [resultTable clickedRow]);
-	if (![focus mnemonicDefined])
-		[focus defineMnemonic:sender];
+	if (![self.objectView mnemonicDefined])
+		[self.objectView defineMnemonic:sender];
 	else
-		[focus removeMnemonic:sender];
+		[self.objectView removeMnemonic:sender];
 }
 
 - (IBAction)setScore:(id)sender {return;}
 
 - (IBAction)clearMnemonics:(id)sender {
-	[focus removeImpliedMnemonic:sender];
+	[self.objectView removeImpliedMnemonic:sender];
 }
 
 - (IBAction)omitItem:(id)sender {
-	[[QSLibrarian sharedInstance] setItem:[focus objectValue] isOmitted:YES];
+	[[QSLibrarian sharedInstance] setItem:[self.objectView objectValue] isOmitted:YES];
 }
 
 - (IBAction)assignAbbreviation:(id)sender {
-	[[QSLibrarian sharedInstance] assignCustomAbbreviationForItem:[focus objectValue]];
+	[[QSLibrarian sharedInstance] assignCustomAbbreviationForItem:[self.objectView objectValue]];
 }
 
 - (void)arrayChanged:(NSNotification*)notif {
     QSGCDMainSync(^{
         [self setResultIconLoader:nil];
-        [self setCurrentResults:[focus resultArray]];
+        [self setCurrentResults:[self.objectView resultArray]];
         [self updateStatusString];
         
         [resultTable reloadData];
@@ -400,7 +404,7 @@ NSMutableDictionary *kindDescriptions = nil;
 	}
 
     
-    if ([[[NSUserDefaults standardUserDefaults] objectForKey:kUseEffects] boolValue] && [QSInterfaceController firstResponder] == focus) {
+    if ([[[NSUserDefaults standardUserDefaults] objectForKey:kUseEffects] boolValue] && [QSInterfaceController firstResponder] == self.objectView) {
         NSRect windowFrame = [self windowFrame];
         shouldSaveWindowSize = NO;
         [[self window] setFrame:windowFrame display:YES animate:YES];
@@ -447,13 +451,13 @@ NSMutableDictionary *kindDescriptions = nil;
 
 			case '\r': //Return
 					  //[self sendAction:[self action] to:[self target]];
-				[[focus controller] executeCommand:self];
+				[[self.objectView controller] executeCommand:self];
 				break;
 			case '\t': //Tab
 			case 25: //Back Tab
 			case 27: //Escape
 				[[self window] orderOut:self];
-				[focus keyDown:theEvent];
+				[self.objectView keyDown:theEvent];
 				return;
 		}
 	}
@@ -664,7 +668,7 @@ NSMutableDictionary *kindDescriptions = nil;
 		QSObject *thisObject = [array objectAtIndex:rowIndex];
 
 		[aCell setRepresentedObject:thisObject];
-        [aCell setState:[focus objectIsInCollection:thisObject]];
+        [aCell setState:[self.objectView objectIsInCollection:thisObject]];
 	}
 	if ([[aTableColumn identifier] isEqualToString:COLUMNID_RANK]) {
 		NSArray *array = [self currentResults];
@@ -688,7 +692,7 @@ NSMutableDictionary *kindDescriptions = nil;
 	NSArray *array = [self currentResults];
 	QSObject *thisObject = [array objectAtIndex:row];
 
-    return [thisObject rankMenuWithTarget:focus];
+    return [thisObject rankMenuWithTarget:self.objectView];
 }
 
 - (BOOL)tableView:(NSTableView *)tv writeRows:(NSArray*)rows toPasteboard:(NSPasteboard*)pboard {
@@ -701,7 +705,7 @@ NSMutableDictionary *kindDescriptions = nil;
 
 	if (selectedResult != -1 && selectedResult != [resultTable selectedRow]) {
 		selectedResult = [resultTable selectedRow];
-        [focus selectIndex:[resultTable selectedRow]];
+        [self.objectView selectIndex:[resultTable selectedRow]];
 		[self updateSelectionInfo];
 	}
 }
@@ -720,12 +724,12 @@ NSMutableDictionary *kindDescriptions = nil;
 
 		NSArray *array = [self currentResults];
 		QSObject *thisObject = [array objectAtIndex:[sender clickedRow]];
-        [NSMenu popUpContextMenu:[thisObject rankMenuWithTarget:focus] withEvent:theEvent forView:sender];
+        [NSMenu popUpContextMenu:[thisObject rankMenuWithTarget:self.objectView] withEvent:theEvent forView:sender];
 
 	}
 }
 
 - (IBAction)tableViewDoubleAction:(id)sender {
-    [[focus controller] executeCommand:self];
+    [[self.objectView controller] executeCommand:self];
 }
 @end

--- a/Quicksilver/Code-QuickStepInterface/QSResultController.m
+++ b/Quicksilver/Code-QuickStepInterface/QSResultController.m
@@ -51,6 +51,9 @@ NSMutableDictionary *kindDescriptions = nil;
     QSIconLoader *_resultChildIconLoader;
 
     NSTimer *_childrenLoadTimer;
+
+    QSSearchOrder _searchOrder;
+    QSSearchMode _searchMode;
 }
 
 @end
@@ -179,47 +182,79 @@ NSMutableDictionary *kindDescriptions = nil;
 	_scrollViewTrackingRect = [view addTrackingRect:[view frame] owner:self userData:nil assumeInside:NO];
 }
 
-- (IBAction)setSearchFilterAllActivated {
-	if ([_filterCatalog state] == NSOffState) {
-		[_filterCatalog setState:NSOnState];
-		[_filterResults setState:NSOffState];
-		[_snapToBest setState:NSOffState];
-		[_searchModeField setStringValue:filterCatalogString];
+- (QSSearchMode)searchMode {
+    return _searchMode;
+}
+
+- (void)setSearchMode:(QSSearchMode)searchMode {
+    [self willChangeValueForKey:@"searchMode"];
+    _searchMode = searchMode;
+	switch (searchMode) {
+		default:
+			_searchMode = QSSearchModeAll;
+        case QSSearchModeAll:
+            [_filterCatalog setState:NSOnState];
+            [_filterResults setState:NSOffState];
+            [_snapToBest setState:NSOffState];
+            [_searchModeField setStringValue:filterCatalogString];
+            break;
+
+        case QSSearchModeFilter:
+            [_filterResults setState:NSOnState];
+            [_filterCatalog setState:NSOffState];
+            [_snapToBest setState:NSOffState];
+            [_searchModeField setStringValue:filterResultsString];
+            break;
+
+        case QSSearchModeSnap:
+            [_snapToBest setState:NSOnState];
+            [_filterResults setState:NSOffState];
+            [_filterCatalog setState:NSOffState];
+            [_searchModeField setStringValue:snapToBestString];
+            break;
+    }
+    [self didChangeValueForKey:@"searchMode"];
+}
+
+- (IBAction)changeSearchMode:(id)sender {
+	self.searchMode = [sender tag];
+
+	if ([[self nextResponder] respondsToSelector:@selector(changeSearchMode:)]) {
+		[[self nextResponder] performSelector:@selector(changeSearchMode:) withObject:sender];
 	}
 }
 
-- (IBAction)setSearchFilterActivated {
-	if ([_filterResults state] == NSOffState) {
-		[_filterResults setState:NSOnState];
-		[_filterCatalog setState:NSOffState];
-		[_snapToBest setState:NSOffState];
-		[_searchModeField setStringValue:filterResultsString];
+- (QSSearchOrder)searchOrder {
+    return _searchOrder;
+}
+
+- (void)setSearchOrder:(QSSearchOrder)searchOrder {
+    [self willChangeValueForKey:@"searchOrder"];
+    _searchOrder = searchOrder;
+    switch (searchOrder) {
+        case QSSearchOrderByName:
+            [_sortByName setState:NSOnState];
+            [_sortByScore setState:NSOffState];
+            break;
+
+        case QSSearchOrderByScore:
+            [_sortByName setState:NSOffState];
+            [_sortByScore setState:NSOnState];
+            break;
+
+        default:
+            _searchOrder = QSSearchOrderByScore;
+            break;
+    }
+    [self willChangeValueForKey:@"searchOrder"];
+}
+
+- (IBAction)changeSearchOrder:(id)sender {
+    self.searchOrder = [sender tag];
+
+	if ([[self nextResponder] respondsToSelector:@selector(changeSearchOrder:)]) {
+		[[self nextResponder] performSelector:@selector(changeSearchOrder:) withObject:sender];
 	}
-}
-
-- (IBAction)setSearchSnapActivated {
-	if ([_snapToBest state] == NSOffState) {
-		[_snapToBest setState:NSOnState];
-		[_filterResults setState:NSOffState];
-		[_filterCatalog setState:NSOffState];
-		[_searchModeField setStringValue:snapToBestString];
-	}
-}
-
-- (IBAction)setSearchMode:(id)sender {
-    [self.objectView setSearchMode:[sender tag]];
-}
-
-- (IBAction)sortByName:(id)sender{
-	[_sortByName setState:NSOnState];
-	[_sortByScore setState:NSOffState];
-    [self.objectView sortByName:sender];
-}
-
-- (IBAction)sortByScore:(id)sender {
-	[_sortByName setState:NSOffState];
-	[_sortByScore setState:NSOnState];
-    [self.objectView sortByScore:sender];
 }
 
 - (void)bump:(NSInteger)i {
@@ -332,7 +367,6 @@ NSMutableDictionary *kindDescriptions = nil;
 #pragma mark -
 #pragma mark Actions
 - (IBAction)defineMnemonic:(id)sender {
-	//	NSLog(@"%d", [resultTable clickedRow]);
 	if (![self.objectView mnemonicDefined])
 		[self.objectView defineMnemonic:sender];
 	else

--- a/Quicksilver/Code-QuickStepInterface/QSResultController.m
+++ b/Quicksilver/Code-QuickStepInterface/QSResultController.m
@@ -27,7 +27,7 @@
 
 #define IconLoadNotification @"IconsLoaded"
 
-// These should be localizable, but I'm not sure how to do that
+// FIXME: These should be localizable, but I'm not sure how to do that
 #define filterResultsString @"Filter Results"
 #define filterCatalogString @"Filter Catalog"
 #define snapToBestString @"Snap to Best"

--- a/Quicksilver/Code-QuickStepInterface/QSResultController.m
+++ b/Quicksilver/Code-QuickStepInterface/QSResultController.m
@@ -27,11 +27,6 @@
 
 #define IconLoadNotification @"IconsLoaded"
 
-// FIXME: These should be localizable, but I'm not sure how to do that
-#define filterResultsString @"Filter Results"
-#define filterCatalogString @"Filter Catalog"
-#define snapToBestString @"Snap to Best"
-
 #import "QSTextProxy.h"
 
 NSMutableDictionary *kindDescriptions = nil;
@@ -196,21 +191,21 @@ NSMutableDictionary *kindDescriptions = nil;
             [_filterCatalog setState:NSOnState];
             [_filterResults setState:NSOffState];
             [_snapToBest setState:NSOffState];
-            [_searchModeField setStringValue:filterCatalogString];
+            [_searchModeField setStringValue:NSLocalizedString(@"Filter Catalog", @"")];
             break;
 
         case QSSearchModeFilter:
             [_filterResults setState:NSOnState];
             [_filterCatalog setState:NSOffState];
             [_snapToBest setState:NSOffState];
-            [_searchModeField setStringValue:filterResultsString];
+            [_searchModeField setStringValue:NSLocalizedString(@"Filter Results", @"")];
             break;
 
         case QSSearchModeSnap:
             [_snapToBest setState:NSOnState];
             [_filterResults setState:NSOffState];
             [_filterCatalog setState:NSOffState];
-            [_searchModeField setStringValue:snapToBestString];
+            [_searchModeField setStringValue:NSLocalizedString(@"Snap to Best", @"")];
             break;
     }
     [self didChangeValueForKey:@"searchMode"];

--- a/Quicksilver/Code-QuickStepInterface/QSResultController.m
+++ b/Quicksilver/Code-QuickStepInterface/QSResultController.m
@@ -230,16 +230,36 @@ NSMutableDictionary *kindDescriptions = nil;
         case QSSearchOrderByName:
             [_sortByName setState:NSOnState];
             [_sortByScore setState:NSOffState];
+			[_sortByDateA setState:NSOffState];
+			[_sortByDateD setState:NSOffState];
 			[_resultTable setSortDescriptors:[NSSortDescriptor descriptorArrayWithKey:@"name" ascending:YES selector:@selector(localizedCompare:)]];
             break;
 
         case QSSearchOrderByScore:
             [_sortByName setState:NSOffState];
             [_sortByScore setState:NSOnState];
+			[_sortByDateA setState:NSOffState];
+			[_sortByDateD setState:NSOffState];
 			[_resultTable setSortDescriptors:[NSSortDescriptor descriptorArrayWithKey:@"score" ascending:NO]];
             break;
 
-        default:
+		case QSSearchOrderByDateAscending:
+			[_sortByName setState:NSOffState];
+			[_sortByScore setState:NSOffState];
+			[_sortByDateA setState:NSOnState];
+			[_sortByDateD setState:NSOffState];
+			[_resultTable setSortDescriptors:[NSSortDescriptor descriptorArrayWithKey:@"date" ascending:YES]];
+			break;
+
+		case QSSearchOrderByDateDescending:
+			[_sortByName setState:NSOffState];
+			[_sortByScore setState:NSOffState];
+			[_sortByDateA setState:NSOffState];
+			[_sortByDateD setState:NSOnState];
+			[_resultTable setSortDescriptors:[NSSortDescriptor descriptorArrayWithKey:@"date" ascending:NO]];
+			break;
+			
+		default:
             _searchOrder = QSSearchOrderByScore;
             break;
     }

--- a/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.h
+++ b/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.h
@@ -11,10 +11,10 @@
 
 // These tags are set within Interface Builder, and are used to define the current search mode
 typedef NS_ENUM(NSUInteger, QSSearchMode) {
-	SearchFilterAll = 1, // Filter Catalog
-	SearchFilter = 2, // Filter Results
-	SearchSnap = 3, // Snap to Best
-	SearchShuffle = 4, // Not Sure (not used?)
+	QSSearchModeFilterAll = 1, // Filter Catalog
+	QSSearchModeFilter = 2, // Filter Results
+	QSSearchModeSnap = 3, // Snap to Best
+	QSSearchModeShuffle = 4, // Not Sure (not used?)
 };
 
 @class QSResultController;

--- a/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.h
+++ b/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.h
@@ -9,12 +9,12 @@
 - (void)searchView:(id)view resultsVisible:(BOOL)visible;
 @end
 
-// These tags are set within Interface Builder, and are used to define the current search mode
+
 typedef NS_ENUM(NSUInteger, QSSearchMode) {
-	QSSearchModeFilterAll = 1, // Filter Catalog
-	QSSearchModeFilter = 2, // Filter Results
-	QSSearchModeSnap = 3, // Snap to Best
-	QSSearchModeShuffle = 4, // Not Sure (not used?)
+    QSSearchModeAll = 1,     // Filter Catalog
+    QSSearchModeFilter = 2,  // Filter Results
+    QSSearchModeSnap = 3,    // Snap to Best
+//    QSSearchModeShuffle = 4, // Not Sure (not used?)
 };
 
 @class QSResultController;

--- a/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.h
+++ b/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.h
@@ -1,7 +1,8 @@
-#import <Foundation/Foundation.h>
-#import "QSObjectView.h"
 
+#import <AppKit/AppKit.h>
 #import <Quartz/Quartz.h>
+#import <QSInterface/QSObjectView.h>
+#import <QSInterface/QSInterfaceController.h>
 
 @interface NSObject (QSSearchViewController)
 - (void)searchView:(id)view changedResults:(id)array;
@@ -9,13 +10,6 @@
 - (void)searchView:(id)view resultsVisible:(BOOL)visible;
 @end
 
-
-typedef NS_ENUM(NSUInteger, QSSearchMode) {
-    QSSearchModeAll = 1,     // Filter Catalog
-    QSSearchModeFilter = 2,  // Filter Results
-    QSSearchModeSnap = 3,    // Snap to Best
-//    QSSearchModeShuffle = 4, // Not Sure (not used?)
-};
 
 @class QSResultController;
 @interface QSSearchObjectView : QSObjectView <NSTextInputClient, NSTextViewDelegate>

--- a/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.h
+++ b/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.h
@@ -147,8 +147,6 @@
 
 - (IBAction)transmogrify:sender;
 
-- (IBAction)sortByScore:(id)sender;
-- (IBAction)sortByName:(id)sender;
 - (void)reloadResultTable;
 - (BOOL)executeText:(NSEvent *)theEvent;
 - (void)performSearchFor:(NSString *)string from:(id)sender;

--- a/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
@@ -1404,20 +1404,6 @@ NSMutableDictionary *bindingsDict = nil;
 	[self transmogrifyWithText:nil];
 }
 
-- (IBAction)changeSearchOrder:(id)sender {
-	switch ([sender tag]) {
-		case QSSearchOrderByName:
-			[(NSMutableArray *)[self resultArray] sortUsingSelector:@selector(nameCompare:)];
-			break;
-
-		default:
-		case QSSearchOrderByScore:
-			[(NSMutableArray *)[self resultArray] sortUsingSelector:@selector(scoreCompare:)];
-			break;
-	}
-	[self reloadResultTable];
-}
-
 - (IBAction)grabSelection:(id)sender {
 	if (!allowNonActions) return;
 	QSObject *newSelection = [self externalSelection];

--- a/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
@@ -89,7 +89,7 @@ NSMutableDictionary *bindingsDict = nil;
     
     [[self textModeEditor] setAutomaticTextReplacementEnabled:YES];
     
-	searchMode = SearchFilter;
+	searchMode = QSSearchModeFilter;
 	[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(hideResultView:) name:@"NSWindowDidResignKeyNotification" object:[self window]];
 	[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(clearAll) name:QSReleaseAllNotification object:nil];
 
@@ -299,7 +299,7 @@ NSMutableDictionary *bindingsDict = nil;
 - (QSSearchMode)searchMode { return searchMode;  }
 - (void)setSearchMode:(QSSearchMode)newSearchMode {
 	// Do not allow the setting of 'Filter Catalog' when in the aSelector (action)
-	if (!((self == [self actionSelector]) && newSearchMode == SearchFilterAll)) {
+	if (!((self == [self actionSelector]) && newSearchMode == QSSearchModeAll)) {
 		searchMode = newSearchMode;
 	}
 	
@@ -308,10 +308,10 @@ NSMutableDictionary *bindingsDict = nil;
 	[[NSUserDefaults standardUserDefaults] setInteger:searchMode forKey:kBrowseMode];
 	}
 		switch (searchMode) {
-			case SearchSnap:
+			case QSSearchModeSnap:
 				[resultController setSearchSnapActivated];
 				break;
-			case SearchFilter:
+			case QSSearchModeFilter:
 				[resultController setSearchFilterActivated];
 				break;
 			default:
@@ -511,7 +511,7 @@ NSMutableDictionary *bindingsDict = nil;
 	[[resultController window] orderOut:self];
 	if (browsing) {
 		browsing = NO;
-		[self setSearchMode:SearchFilterAll];
+		[self setSearchMode:QSSearchModeAll];
 	}
 	if ([[self controller] respondsToSelector:@selector(searchView:resultsVisible:)])
 		[(id)[self controller] searchView:self resultsVisible:NO];
@@ -816,18 +816,18 @@ NSMutableDictionary *bindingsDict = nil;
 		[self setMatchedString:string];
 		//		[self setScoreData:scores];
 		validMnemonic = YES;
-		if ([self searchMode] == SearchFilterAll || [self searchMode] == SearchFilter) {
+		if ([self searchMode] == QSSearchModeAll || [self searchMode] == QSSearchModeFilter) {
 			[self setResultArray:newResultArray];
             [self setSearchArray:newResultArray];
         }
-		if ([self searchMode] == SearchFilterAll) {
+		if ([self searchMode] == QSSearchModeAll) {
 			// ! Don't search the entire catalog if we're in the aSelector (actions)
 			if (![[self class] isEqual:[QSSearchObjectView class]]) {
 			[parentStack removeAllObjects];
 			}
 		}
         
-		if ([self searchMode] == SearchSnap) {
+		if ([self searchMode] == QSSearchModeSnap) {
 			[self selectObject:[newResultArray objectAtIndex:0]];
             
             [self reloadResultTable];
@@ -851,7 +851,7 @@ NSMutableDictionary *bindingsDict = nil;
 			}
 		}
 	} else {
-        if ([[NSUserDefaults standardUserDefaults] boolForKey:@"QSTransformBadSearchToText"] && [self searchMode] == SearchFilterAll) {
+        if ([[NSUserDefaults standardUserDefaults] boolForKey:@"QSTransformBadSearchToText"] && [self searchMode] == QSSearchModeAll) {
             // activate text mode if the prefs setting is set and QS is in the 'Search Catalog' mode
 			[self transmogrifyWithText:partialString];
 		} else { 
@@ -893,7 +893,7 @@ NSMutableDictionary *bindingsDict = nil;
 	}
 	[searchTimer setFireDate:[NSDate dateWithTimeIntervalSinceNow:searchDelay]];
 	
-	if ([self searchMode] != SearchFilterAll) [searchTimer fire];
+	if ([self searchMode] != QSSearchModeAll) [searchTimer fire];
 	if (validSearch) {
 		[resultController.searchStringField setTextColor:[NSColor blueColor]];
 	}
@@ -1034,7 +1034,7 @@ NSMutableDictionary *bindingsDict = nil;
 	if ((resetDelay && delay > resetDelay) || [self shouldResetSearchString]) {
 		[partialString setString:@""];
 		validSearch = YES;
-		if ([self searchMode] == SearchFilterAll) {
+		if ([self searchMode] == QSSearchModeAll) {
 			[self setSourceArray:nil];
 		}
 		[self setShouldResetSearchString:NO];
@@ -1104,14 +1104,14 @@ NSMutableDictionary *bindingsDict = nil;
         // Set the new search mode depending on the direction:
         // Filter All → Filter → Snap to Best (left gives reverse direction)
         switch (searchMode) {
-            case SearchFilterAll:
-                aNewSearchMode = changeSearchModeRight ? SearchFilter : SearchSnap;
+            case QSSearchModeAll:
+                aNewSearchMode = changeSearchModeRight ? QSSearchModeFilter : QSSearchModeSnap;
                 break;
-            case SearchFilter:
-                aNewSearchMode = changeSearchModeRight ? SearchSnap : SearchFilterAll;
+            case QSSearchModeFilter:
+                aNewSearchMode = changeSearchModeRight ? QSSearchModeSnap : QSSearchModeAll;
                 break;
-            default:
-                aNewSearchMode = changeSearchModeRight ? SearchFilterAll : SearchFilter;
+            case QSSearchModeSnap:
+                aNewSearchMode = changeSearchModeRight ? QSSearchModeAll : QSSearchModeFilter;
                 break;
         }
         [self setSearchMode:aNewSearchMode];
@@ -1480,7 +1480,7 @@ NSMutableDictionary *bindingsDict = nil;
 	}
 	if (browsing) {
 		browsing = NO;
-		[self setSearchMode:SearchFilterAll];
+		[self setSearchMode:QSSearchModeAll];
 	}
 	[self setShouldResetSearchString:YES];
 	[resultTimer invalidate];
@@ -1853,7 +1853,7 @@ NSMutableDictionary *bindingsDict = nil;
         [self clearSearch];
 		historyIndex = -1;
         NSInteger defaultMode = [[NSUserDefaults standardUserDefaults] integerForKey:kBrowseMode];
-        [self setSearchMode:(defaultMode ? defaultMode : SearchFilter)];
+        [self setSearchMode:(defaultMode ? defaultMode : QSSearchModeFilter)];
         [self setResultArray:[newObjects mutableCopy]];
         [self setSourceArray:newObjects];
         

--- a/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
@@ -78,6 +78,8 @@ NSMutableDictionary *bindingsDict = nil;
     updatesSilently = NO;
     // FIXME: Look, a view that owns a controller...
 	resultController = [[QSResultController alloc] initWithObjectView:self];
+	resultController.nextResponder = self;
+
 	[self setTextCellFont:[NSFont systemFontOfSize:12.0]];
     [self setTextCellFontColor:[NSColor blackColor]];
     
@@ -296,7 +298,7 @@ NSMutableDictionary *bindingsDict = nil;
     }
 }
 
-- (QSSearchMode)searchMode { return searchMode;  }
+- (QSSearchMode)searchMode { return [[self resultController] searchMode]; }
 - (void)setSearchMode:(QSSearchMode)newSearchMode {
 	// Do not allow the setting of 'Filter Catalog' when in the aSelector (action)
 	if (!((self == [self actionSelector]) && newSearchMode == QSSearchModeAll)) {
@@ -305,20 +307,10 @@ NSMutableDictionary *bindingsDict = nil;
 	
     [resultController.resultTable setNeedsDisplay:YES];
 	if (browsing) {
-	[[NSUserDefaults standardUserDefaults] setInteger:searchMode forKey:kBrowseMode];
+        [[NSUserDefaults standardUserDefaults] setInteger:searchMode forKey:kBrowseMode];
 	}
-		switch (searchMode) {
-			case QSSearchModeSnap:
-				[resultController setSearchSnapActivated];
-				break;
-			case QSSearchModeFilter:
-				[resultController setSearchFilterActivated];
-				break;
-			default:
-				[resultController setSearchFilterAllActivated];
-				break;
-		}
 
+    [[self resultController] setSearchMode:searchMode];
 }
 
 - (NSText *)currentEditor {
@@ -1411,13 +1403,17 @@ NSMutableDictionary *bindingsDict = nil;
 	[self transmogrifyWithText:nil];
 }
 
-- (IBAction)sortByScore:(id)sender {
-	[(NSMutableArray *)[self resultArray] sortUsingSelector:@selector(scoreCompare:)];
-	[self reloadResultTable];
-}
+- (IBAction)changeSearchOrder:(id)sender {
+	switch ([sender tag]) {
+		case QSSearchOrderByName:
+			[(NSMutableArray *)[self resultArray] sortUsingSelector:@selector(nameCompare:)];
+			break;
 
-- (IBAction)sortByName:(id)sender {
-	[(NSMutableArray *)[self resultArray] sortUsingSelector:@selector(nameCompare:)];
+		default:
+		case QSSearchOrderByScore:
+			[(NSMutableArray *)[self resultArray] sortUsingSelector:@selector(scoreCompare:)];
+			break;
+	}
 	[self reloadResultTable];
 }
 

--- a/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
@@ -185,7 +185,7 @@ NSMutableDictionary *bindingsDict = nil;
 
 - (void)rescoreSelectedItem {
 	if (![self objectValue]) return;
-	//[[QSLibrarian sharedInstance] scoredArrayForString:[self matchedString] inSet:[NSArray arrayWithObject:[self objectValue]] mnemonicsOnly:![self matchedString]];
+    // FIXME: This leaks the fact that rank data is effectively global
 	[[QSLibrarian sharedInstance] scoredArrayForString:[self matchedString] inSet:[NSArray arrayWithObject:[self objectValue]]];
 	if ([[resultController window] isVisible])
 		[resultController.resultTable reloadData];

--- a/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
@@ -76,7 +76,8 @@ NSMutableDictionary *bindingsDict = nil;
 	allowNonActions = YES;
 	allowText = YES;
     updatesSilently = NO;
-	resultController = [[QSResultController alloc] initWithFocus:self];
+    // FIXME: Look, a view that owns a controller...
+	resultController = [[QSResultController alloc] initWithObjectView:self];
 	[self setTextCellFont:[NSFont systemFontOfSize:12.0]];
     [self setTextCellFontColor:[NSColor blackColor]];
     

--- a/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
@@ -1263,7 +1263,8 @@ NSMutableDictionary *bindingsDict = nil;
 	}
     
 	if (NSMouseInRect([NSEvent mouseLocation] , NSInsetRect([[resultController window] frame] , 0, 0), NO) ) {
-		[resultController scrollWheel:theEvent];
+		// FIXME: This stack-smashes because AppKit tries to forward through the responder chain
+//		[resultController scrollWheel:theEvent];
 		return;
 	}
 	CGFloat delta = [theEvent deltaY];

--- a/Quicksilver/Code-QuickStepInterface/QSTargetPickerPanel.m
+++ b/Quicksilver/Code-QuickStepInterface/QSTargetPickerPanel.m
@@ -31,7 +31,7 @@
     // populate and set up search
     [searchObjView setDropMode:QSSelectDropMode];
     [searchObjView setAllowText:NO];
-    [searchObjView setSearchMode:SearchFilterAll];
+    [searchObjView setSearchMode:QSSearchModeAll];
     [searchObjView setObjectValue:[wc representedObject]];
 }
 

--- a/Quicksilver/Nibs/ResultWindow.xib
+++ b/Quicksilver/Nibs/ResultWindow.xib
@@ -1,1512 +1,271 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<archive type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="8.00">
-	<data>
-		<int key="IBDocument.SystemTarget">1070</int>
-		<string key="IBDocument.SystemVersion">12D78</string>
-		<string key="IBDocument.InterfaceBuilderVersion">3084</string>
-		<string key="IBDocument.AppKitVersion">1187.37</string>
-		<string key="IBDocument.HIToolboxVersion">626.00</string>
-		<object class="NSMutableDictionary" key="IBDocument.PluginVersions">
-			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin</string>
-			<string key="NS.object.0">3084</string>
-		</object>
-		<array key="IBDocument.IntegratedClassDependencies">
-			<string>NSButton</string>
-			<string>NSButtonCell</string>
-			<string>NSCustomObject</string>
-			<string>NSCustomView</string>
-			<string>NSImageCell</string>
-			<string>NSMenu</string>
-			<string>NSMenuItem</string>
-			<string>NSScrollView</string>
-			<string>NSScroller</string>
-			<string>NSSplitView</string>
-			<string>NSTableColumn</string>
-			<string>NSTableView</string>
-			<string>NSTextField</string>
-			<string>NSTextFieldCell</string>
-			<string>NSUserDefaultsController</string>
-			<string>NSView</string>
-			<string>NSWindowTemplate</string>
-		</array>
-		<array key="IBDocument.PluginDependencies">
-			<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-		</array>
-		<object class="NSMutableDictionary" key="IBDocument.Metadata">
-			<string key="NS.key.0">PluginDependencyRecalculationVersion</string>
-			<integer value="1" key="NS.object.0"/>
-		</object>
-		<array class="NSMutableArray" key="IBDocument.RootObjects" id="698553342">
-			<object class="NSCustomObject" id="664008763">
-				<string key="NSClassName">QSResultController</string>
-			</object>
-			<object class="NSCustomObject" id="750813230">
-				<string key="NSClassName">FirstResponder</string>
-			</object>
-			<object class="NSCustomObject" id="1061651494">
-				<string key="NSClassName">NSApplication</string>
-			</object>
-			<object class="NSWindowTemplate" id="429486953">
-				<int key="NSWindowStyleMask">139</int>
-				<int key="NSWindowBacking">2</int>
-				<string key="NSWindowRect">{{48, 35}, {322, 198}}</string>
-				<int key="NSWTFlags">1618477056</int>
-				<string key="NSWindowTitle">Results</string>
-				<string key="NSWindowClass">QSResultWindow</string>
-				<object class="NSMutableString" key="NSViewClass">
-					<characters key="NS.bytes">View</characters>
-				</object>
-				<nil key="NSUserInterfaceItemIdentifier"/>
-				<string key="NSWindowContentMinSize">{200, 150}</string>
-				<object class="NSView" key="NSWindowView" id="419455219">
-					<reference key="NSNextResponder"/>
-					<int key="NSvFlags">256</int>
-					<array class="NSMutableArray" key="NSSubviews">
-						<object class="NSCustomView" id="1008095421">
-							<reference key="NSNextResponder" ref="419455219"/>
-							<int key="NSvFlags">266</int>
-							<string key="NSFrame">{{0, 182}, {324, 16}}</string>
-							<reference key="NSSuperview" ref="419455219"/>
-							<reference key="NSWindow"/>
-							<reference key="NSNextKeyView" ref="845282137"/>
-							<string key="NSClassName">QSBackgroundView</string>
-							<string key="NSExtension">NSView</string>
-						</object>
-						<object class="NSCustomView" id="952278619">
-							<reference key="NSNextResponder" ref="419455219"/>
-							<int key="NSvFlags">258</int>
-							<array class="NSMutableArray" key="NSSubviews"/>
-							<string key="NSFrame">{{-1, 0}, {323, 16}}</string>
-							<reference key="NSSuperview" ref="419455219"/>
-							<reference key="NSWindow"/>
-							<reference key="NSNextKeyView" ref="477699912"/>
-							<string key="NSClassName">QSBackgroundView</string>
-							<string key="NSExtension">NSView</string>
-						</object>
-						<object class="NSCustomView" id="744215896">
-							<reference key="NSNextResponder" ref="419455219"/>
-							<int key="NSvFlags">289</int>
-							<string key="NSFrame">{{306, 0}, {16, 16}}</string>
-							<reference key="NSSuperview" ref="419455219"/>
-							<reference key="NSWindow"/>
-							<reference key="NSNextKeyView"/>
-							<string key="NSClassName">BLTRResizeView</string>
-							<string key="NSExtension">NSView</string>
-						</object>
-						<object class="NSTextField" id="477699912">
-							<reference key="NSNextResponder" ref="419455219"/>
-							<int key="NSvFlags">290</int>
-							<string key="NSFrame">{{1, 1}, {304, 12}}</string>
-							<reference key="NSSuperview" ref="419455219"/>
-							<reference key="NSWindow"/>
-							<reference key="NSNextKeyView" ref="744215896"/>
-							<bool key="NSEnabled">YES</bool>
-							<object class="NSTextFieldCell" key="NSCell" id="676619987">
-								<int key="NSCellFlags">-2079326144</int>
-								<int key="NSCellFlags2">4199424</int>
-								<string key="NSContents">Details</string>
-								<object class="NSFont" key="NSSupport" id="25">
-									<string key="NSName">LucidaGrande-Bold</string>
-									<double key="NSSize">10</double>
-									<int key="NSfFlags">16</int>
-								</object>
-								<reference key="NSControlView" ref="477699912"/>
-								<object class="NSColor" key="NSBackgroundColor" id="600554789">
-									<int key="NSColorSpace">6</int>
-									<string key="NSCatalogName">System</string>
-									<string key="NSColorName">textBackgroundColor</string>
-									<object class="NSColor" key="NSColor" id="572056285">
-										<int key="NSColorSpace">3</int>
-										<bytes key="NSWhite">MQA</bytes>
-									</object>
-								</object>
-								<object class="NSColor" key="NSTextColor" id="1017052937">
-									<int key="NSColorSpace">6</int>
-									<string key="NSCatalogName">System</string>
-									<string key="NSColorName">textColor</string>
-									<object class="NSColor" key="NSColor" id="65086002">
-										<int key="NSColorSpace">3</int>
-										<bytes key="NSWhite">MAA</bytes>
-									</object>
-								</object>
-							</object>
-							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-						</object>
-						<object class="NSSplitView" id="157453347">
-							<reference key="NSNextResponder" ref="419455219"/>
-							<int key="NSvFlags">274</int>
-							<array class="NSMutableArray" key="NSSubviews">
-								<object class="NSScrollView" id="803386848">
-									<reference key="NSNextResponder" ref="157453347"/>
-									<int key="NSvFlags">274</int>
-									<array class="NSMutableArray" key="NSSubviews">
-										<object class="NSClipView" id="372521285">
-											<reference key="NSNextResponder" ref="803386848"/>
-											<int key="NSvFlags">2304</int>
-											<array class="NSMutableArray" key="NSSubviews">
-												<object class="NSTableView" id="569239575">
-													<reference key="NSNextResponder" ref="372521285"/>
-													<int key="NSvFlags">4354</int>
-													<string key="NSFrameSize">{155, 167}</string>
-													<reference key="NSSuperview" ref="372521285"/>
-													<reference key="NSWindow"/>
-													<reference key="NSNextKeyView" ref="415801822"/>
-													<bool key="NSEnabled">YES</bool>
-													<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-													<bool key="NSControlAllowsExpansionToolTips">YES</bool>
-													<object class="_NSCornerView" key="NSCornerView">
-														<nil key="NSNextResponder"/>
-														<int key="NSvFlags">-2147483392</int>
-														<string key="NSFrame">{{-32, -34}, {16, 17}}</string>
-													</object>
-													<array class="NSMutableArray" key="NSTableColumns">
-														<object class="NSTableColumn" id="426577701">
-															<string key="NSIdentifier">RankColumn</string>
-															<double key="NSWidth">24</double>
-															<double key="NSMinWidth">13.611000061035156</double>
-															<double key="NSMaxWidth">24</double>
-															<object class="NSTableHeaderCell" key="NSHeaderCell">
-																<int key="NSCellFlags">75497536</int>
-																<int key="NSCellFlags2">134219776</int>
-																<string key="NSContents">•</string>
-																<object class="NSFont" key="NSSupport" id="23">
-																	<string key="NSName">LucidaGrande-Bold</string>
-																	<double key="NSSize">9</double>
-																	<int key="NSfFlags">3871</int>
-																</object>
-																<object class="NSColor" key="NSBackgroundColor" id="253726276">
-																	<int key="NSColorSpace">6</int>
-																	<string key="NSCatalogName">System</string>
-																	<string key="NSColorName">headerColor</string>
-																	<reference key="NSColor" ref="572056285"/>
-																</object>
-																<object class="NSColor" key="NSTextColor" id="431042655">
-																	<int key="NSColorSpace">6</int>
-																	<string key="NSCatalogName">System</string>
-																	<string key="NSColorName">headerTextColor</string>
-																	<reference key="NSColor" ref="65086002"/>
-																</object>
-															</object>
-															<object class="NSTextFieldCell" key="NSDataCell" id="1034691857">
-																<int key="NSCellFlags">338690112</int>
-																<int key="NSCellFlags2">134218752</int>
-																<object class="NSFont" key="NSSupport" id="22">
-																	<string key="NSName">LucidaGrande</string>
-																	<double key="NSSize">9</double>
-																	<int key="NSfFlags">3614</int>
-																</object>
-																<reference key="NSControlView" ref="569239575"/>
-																<object class="NSColor" key="NSBackgroundColor">
-																	<int key="NSColorSpace">6</int>
-																	<string key="NSCatalogName">System</string>
-																	<string key="NSColorName">controlBackgroundColor</string>
-																	<object class="NSColor" key="NSColor">
-																		<int key="NSColorSpace">3</int>
-																		<bytes key="NSWhite">MC42NjY2NjY2NjY3AA</bytes>
-																	</object>
-																</object>
-																<object class="NSColor" key="NSTextColor" id="924694365">
-																	<int key="NSColorSpace">6</int>
-																	<string key="NSCatalogName">System</string>
-																	<string key="NSColorName">controlTextColor</string>
-																	<reference key="NSColor" ref="65086002"/>
-																</object>
-															</object>
-															<bool key="NSIsEditable">YES</bool>
-															<reference key="NSTableView" ref="569239575"/>
-														</object>
-														<object class="NSTableColumn" id="773215085">
-															<string key="NSIdentifier">NameColumn</string>
-															<double key="NSWidth">112.14500045776367</double>
-															<double key="NSMinWidth">42.145000457763672</double>
-															<double key="NSMaxWidth">1000</double>
-															<object class="NSTableHeaderCell" key="NSHeaderCell">
-																<int key="NSCellFlags">75497536</int>
-																<int key="NSCellFlags2">2048</int>
-																<string key="NSContents">Results</string>
-																<reference key="NSSupport" ref="23"/>
-																<object class="NSColor" key="NSBackgroundColor">
-																	<int key="NSColorSpace">3</int>
-																	<bytes key="NSWhite">MC4zMzMzMzI5OQA</bytes>
-																</object>
-																<reference key="NSTextColor" ref="431042655"/>
-															</object>
-															<object class="NSTextFieldCell" key="NSDataCell" id="864992102">
-																<int key="NSCellFlags">338690112</int>
-																<int key="NSCellFlags2">1024</int>
-																<reference key="NSSupport" ref="22"/>
-																<reference key="NSControlView" ref="569239575"/>
-																<reference key="NSBackgroundColor" ref="572056285"/>
-																<reference key="NSTextColor" ref="924694365"/>
-															</object>
-															<int key="NSResizingMask">3</int>
-															<bool key="NSIsResizeable">YES</bool>
-															<reference key="NSTableView" ref="569239575"/>
-														</object>
-														<object class="NSTableColumn" id="656249178">
-															<string key="NSIdentifier">hasChildren</string>
-															<double key="NSWidth">10</double>
-															<double key="NSMinWidth">4</double>
-															<double key="NSMaxWidth">1000</double>
-															<object class="NSTableHeaderCell" key="NSHeaderCell">
-																<int key="NSCellFlags">75497536</int>
-																<int key="NSCellFlags2">2048</int>
-																<string key="NSContents"/>
-																<object class="NSFont" key="NSSupport" id="26">
-																	<string key="NSName">LucidaGrande</string>
-																	<double key="NSSize">11</double>
-																	<int key="NSfFlags">3100</int>
-																</object>
-																<reference key="NSBackgroundColor" ref="253726276"/>
-																<reference key="NSTextColor" ref="431042655"/>
-															</object>
-															<object class="NSImageCell" key="NSDataCell" id="905081672">
-																<int key="NSCellFlags">134217728</int>
-																<int key="NSCellFlags2">33554432</int>
-																<int key="NSAlign">0</int>
-																<int key="NSScale">0</int>
-																<int key="NSStyle">0</int>
-																<bool key="NSAnimates">YES</bool>
-															</object>
-															<reference key="NSTableView" ref="569239575"/>
-														</object>
-													</array>
-													<double key="NSIntercellSpacingWidth">3</double>
-													<double key="NSIntercellSpacingHeight">3</double>
-													<object class="NSColor" key="NSBackgroundColor">
-														<int key="NSColorSpace">1</int>
-														<bytes key="NSRGB">MSAxIDEAA</bytes>
-													</object>
-													<object class="NSColor" key="NSGridColor" id="248833494">
-														<int key="NSColorSpace">3</int>
-														<bytes key="NSWhite">MC45NDc1ODA2NAA</bytes>
-													</object>
-													<double key="NSRowHeight">12</double>
-													<int key="NSTvFlags">373325824</int>
-													<reference key="NSDelegate"/>
-													<reference key="NSDataSource"/>
-													<int key="NSColumnAutoresizingStyle">1</int>
-													<int key="NSDraggingSourceMaskForLocal">15</int>
-													<int key="NSDraggingSourceMaskForNonLocal">0</int>
-													<bool key="NSAllowsTypeSelect">YES</bool>
-													<int key="NSTableViewDraggingDestinationStyle">0</int>
-													<int key="NSTableViewGroupRowStyle">1</int>
-												</object>
-											</array>
-											<string key="NSFrame">{{1, 1}, {155, 167}}</string>
-											<reference key="NSSuperview" ref="803386848"/>
-											<reference key="NSWindow"/>
-											<reference key="NSNextKeyView" ref="569239575"/>
-											<reference key="NSDocView" ref="569239575"/>
-											<object class="NSColor" key="NSBGColor">
-												<int key="NSColorSpace">1</int>
-												<bytes key="NSRGB">MSAxIDEgMC40OQA</bytes>
-											</object>
-											<int key="NScvFlags">2</int>
-										</object>
-										<object class="NSScroller" id="894678291">
-											<reference key="NSNextResponder" ref="803386848"/>
-											<int key="NSvFlags">-2147483392</int>
-											<string key="NSFrame">{{-30, 1}, {15, 167}}</string>
-											<reference key="NSSuperview" ref="803386848"/>
-											<reference key="NSWindow"/>
-											<reference key="NSNextKeyView" ref="372521285"/>
-											<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-											<reference key="NSTarget" ref="803386848"/>
-											<string key="NSAction">_doScroller:</string>
-											<double key="NSPercent">0.49702380952380953</double>
-										</object>
-										<object class="NSScroller" id="492224105">
-											<reference key="NSNextResponder" ref="803386848"/>
-											<int key="NSvFlags">-2147483392</int>
-											<string key="NSFrame">{{-100, -100}, {429, 15}}</string>
-											<reference key="NSSuperview" ref="803386848"/>
-											<reference key="NSWindow"/>
-											<reference key="NSNextKeyView" ref="894678291"/>
-											<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-											<int key="NSsFlags">1</int>
-											<reference key="NSTarget" ref="803386848"/>
-											<string key="NSAction">_doScroller:</string>
-											<double key="NSPercent">0.99047619104385376</double>
-										</object>
-									</array>
-									<string key="NSFrameSize">{157, 169}</string>
-									<reference key="NSSuperview" ref="157453347"/>
-									<reference key="NSWindow"/>
-									<reference key="NSNextKeyView" ref="492224105"/>
-									<int key="NSsFlags">133650</int>
-									<reference key="NSVScroller" ref="894678291"/>
-									<reference key="NSHScroller" ref="492224105"/>
-									<reference key="NSContentView" ref="372521285"/>
-									<bytes key="NSScrollAmts">QSAAAEEgAABBcAAAQXAAAA</bytes>
-									<double key="NSMinMagnification">0.25</double>
-									<double key="NSMaxMagnification">4</double>
-									<double key="NSMagnification">1</double>
-								</object>
-								<object class="NSScrollView" id="415801822">
-									<reference key="NSNextResponder" ref="157453347"/>
-									<int key="NSvFlags">256</int>
-									<array class="NSMutableArray" key="NSSubviews">
-										<object class="NSClipView" id="91778016">
-											<reference key="NSNextResponder" ref="415801822"/>
-											<int key="NSvFlags">2304</int>
-											<array class="NSMutableArray" key="NSSubviews">
-												<object class="NSTableView" id="608115155">
-													<reference key="NSNextResponder" ref="91778016"/>
-													<int key="NSvFlags">256</int>
-													<string key="NSFrameSize">{156, 167}</string>
-													<reference key="NSSuperview" ref="91778016"/>
-													<reference key="NSWindow"/>
-													<reference key="NSNextKeyView" ref="207404553"/>
-													<bool key="NSEnabled">YES</bool>
-													<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-													<bool key="NSControlAllowsExpansionToolTips">YES</bool>
-													<object class="_NSCornerView" key="NSCornerView">
-														<nil key="NSNextResponder"/>
-														<int key="NSvFlags">-2147483392</int>
-														<string key="NSFrame">{{-24, -34}, {12, 17}}</string>
-													</object>
-													<array class="NSMutableArray" key="NSTableColumns">
-														<object class="NSTableColumn" id="253696150">
-															<string key="NSIdentifier">NameColumn</string>
-															<double key="NSWidth">153</double>
-															<double key="NSMinWidth">8</double>
-															<double key="NSMaxWidth">1000</double>
-															<object class="NSTableHeaderCell" key="NSHeaderCell">
-																<int key="NSCellFlags">75497536</int>
-																<int key="NSCellFlags2">2048</int>
-																<string key="NSContents"/>
-																<reference key="NSSupport" ref="26"/>
-																<object class="NSColor" key="NSBackgroundColor">
-																	<int key="NSColorSpace">3</int>
-																	<bytes key="NSWhite">MC4zMzMzMzI5OQA</bytes>
-																</object>
-																<reference key="NSTextColor" ref="431042655"/>
-															</object>
-															<object class="NSTextFieldCell" key="NSDataCell" id="207462246">
-																<int key="NSCellFlags">338690112</int>
-																<int key="NSCellFlags2">1024</int>
-																<object class="NSFont" key="NSSupport" id="624217030">
-																	<string key="NSName">LucidaGrande</string>
-																	<double key="NSSize">13</double>
-																	<int key="NSfFlags">1044</int>
-																</object>
-																<reference key="NSControlView" ref="608115155"/>
-																<reference key="NSBackgroundColor" ref="572056285"/>
-																<reference key="NSTextColor" ref="924694365"/>
-															</object>
-															<int key="NSResizingMask">3</int>
-															<bool key="NSIsResizeable">YES</bool>
-															<reference key="NSTableView" ref="608115155"/>
-														</object>
-													</array>
-													<double key="NSIntercellSpacingWidth">3</double>
-													<double key="NSIntercellSpacingHeight">3</double>
-													<reference key="NSBackgroundColor" ref="572056285"/>
-													<reference key="NSGridColor" ref="248833494"/>
-													<double key="NSRowHeight">18</double>
-													<int key="NSTvFlags">843087872</int>
-													<reference key="NSDelegate"/>
-													<reference key="NSDataSource"/>
-													<int key="NSGridStyleMask">2</int>
-													<int key="NSColumnAutoresizingStyle">1</int>
-													<int key="NSDraggingSourceMaskForLocal">15</int>
-													<int key="NSDraggingSourceMaskForNonLocal">0</int>
-													<bool key="NSAllowsTypeSelect">YES</bool>
-													<int key="NSTableViewDraggingDestinationStyle">0</int>
-													<int key="NSTableViewGroupRowStyle">1</int>
-												</object>
-											</array>
-											<string key="NSFrame">{{1, 1}, {156, 167}}</string>
-											<reference key="NSSuperview" ref="415801822"/>
-											<reference key="NSWindow"/>
-											<reference key="NSNextKeyView" ref="608115155"/>
-											<reference key="NSDocView" ref="608115155"/>
-											<object class="NSColor" key="NSBGColor">
-												<int key="NSColorSpace">3</int>
-												<bytes key="NSWhite">MSAwLjk0OTk5OTk5AA</bytes>
-											</object>
-											<int key="NScvFlags">2</int>
-										</object>
-										<object class="NSScroller" id="462447871">
-											<reference key="NSNextResponder" ref="415801822"/>
-											<int key="NSvFlags">-2147483392</int>
-											<string key="NSFrame">{{-0, 1}, {0, 167}}</string>
-											<reference key="NSSuperview" ref="415801822"/>
-											<reference key="NSWindow"/>
-											<reference key="NSNextKeyView" ref="91778016"/>
-											<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-											<int key="NSsFlags">256</int>
-											<reference key="NSTarget" ref="415801822"/>
-											<string key="NSAction">_doScroller:</string>
-											<double key="NSPercent">0.77999997138977051</double>
-										</object>
-										<object class="NSScroller" id="246514212">
-											<reference key="NSNextResponder" ref="415801822"/>
-											<int key="NSvFlags">-2147483392</int>
-											<string key="NSFrame">{{-100, -100}, {429, 15}}</string>
-											<reference key="NSSuperview" ref="415801822"/>
-											<reference key="NSWindow"/>
-											<reference key="NSNextKeyView" ref="462447871"/>
-											<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-											<int key="NSsFlags">257</int>
-											<reference key="NSTarget" ref="415801822"/>
-											<string key="NSAction">_doScroller:</string>
-											<double key="NSPercent">0.99047619104385376</double>
-										</object>
-									</array>
-									<string key="NSFrame">{{166, 0}, {158, 169}}</string>
-									<reference key="NSSuperview" ref="157453347"/>
-									<reference key="NSWindow"/>
-									<reference key="NSNextKeyView" ref="246514212"/>
-									<int key="NSsFlags">133650</int>
-									<reference key="NSVScroller" ref="462447871"/>
-									<reference key="NSHScroller" ref="246514212"/>
-									<reference key="NSContentView" ref="91778016"/>
-									<bytes key="NSScrollAmts">QSAAAEEgAABBqAAAQagAAA</bytes>
-									<double key="NSMinMagnification">0.25</double>
-									<double key="NSMaxMagnification">4</double>
-									<double key="NSMagnification">1</double>
-								</object>
-							</array>
-							<string key="NSFrame">{{-1, 14}, {324, 169}}</string>
-							<reference key="NSSuperview" ref="419455219"/>
-							<reference key="NSWindow"/>
-							<reference key="NSNextKeyView" ref="803386848"/>
-							<bool key="NSIsVertical">YES</bool>
-						</object>
-						<object class="NSTextField" id="845282137">
-							<reference key="NSNextResponder" ref="419455219"/>
-							<int key="NSvFlags">270</int>
-							<string key="NSFrame">{{4, 183}, {220, 13}}</string>
-							<reference key="NSSuperview" ref="419455219"/>
-							<reference key="NSWindow"/>
-							<reference key="NSNextKeyView" ref="906943389"/>
-							<bool key="NSEnabled">YES</bool>
-							<object class="NSTextFieldCell" key="NSCell" id="240448356">
-								<int key="NSCellFlags">-1271922623</int>
-								<int key="NSCellFlags2">4457472</int>
-								<string key="NSContents">SEARCH</string>
-								<reference key="NSSupport" ref="25"/>
-								<reference key="NSControlView" ref="845282137"/>
-								<reference key="NSBackgroundColor" ref="600554789"/>
-								<reference key="NSTextColor" ref="1017052937"/>
-							</object>
-							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-						</object>
-						<object class="NSTextField" id="906943389">
-							<reference key="NSNextResponder" ref="419455219"/>
-							<int key="NSvFlags">265</int>
-							<string key="NSFrame">{{225, 183}, {72, 13}}</string>
-							<reference key="NSSuperview" ref="419455219"/>
-							<reference key="NSWindow"/>
-							<reference key="NSNextKeyView" ref="157453347"/>
-							<bool key="NSEnabled">YES</bool>
-							<object class="NSTextFieldCell" key="NSCell" id="856239706">
-								<int key="NSCellFlags">-1271922623</int>
-								<int key="NSCellFlags2">71566336</int>
-								<string key="NSContents">RESULTS MODE</string>
-								<reference key="NSSupport" ref="25"/>
-								<reference key="NSControlView" ref="906943389"/>
-								<reference key="NSBackgroundColor" ref="600554789"/>
-								<reference key="NSTextColor" ref="1017052937"/>
-							</object>
-							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-						</object>
-						<object class="NSButton" id="207404553">
-							<reference key="NSNextResponder" ref="419455219"/>
-							<int key="NSvFlags">265</int>
-							<string key="NSFrame">{{297, 180}, {25, 20}}</string>
-							<reference key="NSSuperview" ref="419455219"/>
-							<reference key="NSWindow"/>
-							<reference key="NSNextKeyView" ref="952278619"/>
-							<bool key="NSEnabled">YES</bool>
-							<object class="NSButtonCell" key="NSCell" id="854249939">
-								<int key="NSCellFlags">67108864</int>
-								<int key="NSCellFlags2">134217728</int>
-								<string key="NSContents"/>
-								<reference key="NSSupport" ref="624217030"/>
-								<reference key="NSControlView" ref="207404553"/>
-								<int key="NSButtonFlags">138690560</int>
-								<int key="NSButtonFlags2">402653190</int>
-								<object class="NSCustomResource" key="NSNormalImage">
-									<string key="NSClassName">NSImage</string>
-									<string key="NSResourceName">Button-GearMenu</string>
-								</object>
-								<string key="NSAlternateContents"/>
-								<string key="NSKeyEquivalent">7</string>
-								<int key="NSPeriodicDelay">200</int>
-								<int key="NSPeriodicInterval">25</int>
-							</object>
-							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-						</object>
-					</array>
-					<string key="NSFrameSize">{322, 198}</string>
-					<reference key="NSSuperview"/>
-					<reference key="NSWindow"/>
-					<reference key="NSNextKeyView" ref="1008095421"/>
-				</object>
-				<string key="NSScreenRect">{{0, 0}, {1280, 778}}</string>
-				<string key="NSMinSize">{200, 172}</string>
-				<string key="NSMaxSize">{10000000000000, 10000000000000}</string>
-				<bool key="NSWindowIsRestorable">YES</bool>
-			</object>
-			<object class="NSUserDefaultsController" id="830537305">
-				<bool key="NSSharedInstance">YES</bool>
-			</object>
-			<object class="NSMenu" id="761427125">
-				<string key="NSTitle">Menu</string>
-				<array class="NSMutableArray" key="NSMenuItems">
-					<object class="NSMenuItem" id="227093194">
-						<reference key="NSMenu" ref="761427125"/>
-						<string key="NSTitle">Search Mode ⌘←/⌘→</string>
-						<string key="NSKeyEquiv"/>
-						<int key="NSMnemonicLoc">2147483647</int>
-						<string key="NSAction">submenuAction:</string>
-						<object class="NSMenu" key="NSSubmenu" id="60097476">
-							<string key="NSTitle">Search Mode ⌘←/⌘→</string>
-							<array class="NSMutableArray" key="NSMenuItems">
-								<object class="NSMenuItem" id="129314767">
-									<reference key="NSMenu" ref="60097476"/>
-									<string key="NSTitle">Filter Catalog</string>
-									<string key="NSKeyEquiv"/>
-									<int key="NSMnemonicLoc">2147483647</int>
-									<object class="NSCustomResource" key="NSOnImage" id="569890057">
-										<string key="NSClassName">NSImage</string>
-										<string key="NSResourceName">NSMenuCheckmark</string>
-									</object>
-									<object class="NSCustomResource" key="NSMixedImage" id="730873069">
-										<string key="NSClassName">NSImage</string>
-										<string key="NSResourceName">NSMenuMixedState</string>
-									</object>
-									<int key="NSTag">1</int>
-								</object>
-								<object class="NSMenuItem" id="319773573">
-									<reference key="NSMenu" ref="60097476"/>
-									<string key="NSTitle">Filter Results</string>
-									<string key="NSKeyEquiv"/>
-									<int key="NSMnemonicLoc">2147483647</int>
-									<reference key="NSOnImage" ref="569890057"/>
-									<reference key="NSMixedImage" ref="730873069"/>
-									<int key="NSTag">2</int>
-								</object>
-								<object class="NSMenuItem" id="224214980">
-									<reference key="NSMenu" ref="60097476"/>
-									<string key="NSTitle">Snap to Best</string>
-									<string key="NSKeyEquiv"/>
-									<int key="NSMnemonicLoc">2147483647</int>
-									<reference key="NSOnImage" ref="569890057"/>
-									<reference key="NSMixedImage" ref="730873069"/>
-									<int key="NSTag">3</int>
-								</object>
-							</array>
-						</object>
-					</object>
-					<object class="NSMenuItem" id="150773358">
-						<reference key="NSMenu" ref="761427125"/>
-						<bool key="NSIsDisabled">YES</bool>
-						<bool key="NSIsSeparator">YES</bool>
-						<string key="NSTitle"/>
-						<string key="NSKeyEquiv"/>
-						<int key="NSKeyEquivModMask">1048576</int>
-						<int key="NSMnemonicLoc">2147483647</int>
-						<reference key="NSOnImage" ref="569890057"/>
-						<reference key="NSMixedImage" ref="730873069"/>
-					</object>
-					<object class="NSMenuItem" id="159129978">
-						<reference key="NSMenu" ref="761427125"/>
-						<string key="NSTitle">Sort by Score</string>
-						<string key="NSKeyEquiv"/>
-						<int key="NSMnemonicLoc">2147483647</int>
-						<int key="NSState">1</int>
-						<reference key="NSOnImage" ref="569890057"/>
-					</object>
-					<object class="NSMenuItem" id="821459113">
-						<reference key="NSMenu" ref="761427125"/>
-						<string key="NSTitle">Sort by Name</string>
-						<string key="NSKeyEquiv"/>
-						<int key="NSMnemonicLoc">2147483647</int>
-						<reference key="NSOnImage" ref="569890057"/>
-					</object>
-				</array>
-				<string key="NSName"/>
-			</object>
-		</array>
-		<object class="IBObjectContainer" key="IBDocument.Objects">
-			<array class="NSMutableArray" key="connectionRecords">
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">window</string>
-						<reference key="source" ref="664008763"/>
-						<reference key="destination" ref="429486953"/>
-					</object>
-					<int key="connectionID">33</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">searchStringField</string>
-						<reference key="source" ref="664008763"/>
-						<reference key="destination" ref="845282137"/>
-					</object>
-					<int key="connectionID">44</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">resultTable</string>
-						<reference key="source" ref="664008763"/>
-						<reference key="destination" ref="569239575"/>
-					</object>
-					<int key="connectionID">65</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">resultChildTable</string>
-						<reference key="source" ref="664008763"/>
-						<reference key="destination" ref="608115155"/>
-					</object>
-					<int key="connectionID">77</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">selectionView</string>
-						<reference key="source" ref="664008763"/>
-						<reference key="destination" ref="477699912"/>
-					</object>
-					<int key="connectionID">132</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">splitView</string>
-						<reference key="source" ref="664008763"/>
-						<reference key="destination" ref="157453347"/>
-					</object>
-					<int key="connectionID">142</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">sortByName:</string>
-						<reference key="source" ref="664008763"/>
-						<reference key="destination" ref="821459113"/>
-					</object>
-					<int key="connectionID">250</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">sortByScore:</string>
-						<reference key="source" ref="664008763"/>
-						<reference key="destination" ref="159129978"/>
-					</object>
-					<int key="connectionID">251</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">searchModeMenu</string>
-						<reference key="source" ref="664008763"/>
-						<reference key="destination" ref="60097476"/>
-					</object>
-					<int key="connectionID">280</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">filterCatalog</string>
-						<reference key="source" ref="664008763"/>
-						<reference key="destination" ref="129314767"/>
-					</object>
-					<int key="connectionID">295</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">filterResults</string>
-						<reference key="source" ref="664008763"/>
-						<reference key="destination" ref="319773573"/>
-					</object>
-					<int key="connectionID">296</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">snapToBest</string>
-						<reference key="source" ref="664008763"/>
-						<reference key="destination" ref="224214980"/>
-					</object>
-					<int key="connectionID">297</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">sortByScore</string>
-						<reference key="source" ref="664008763"/>
-						<reference key="destination" ref="159129978"/>
-					</object>
-					<int key="connectionID">302</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">sortByName</string>
-						<reference key="source" ref="664008763"/>
-						<reference key="destination" ref="821459113"/>
-					</object>
-					<int key="connectionID">303</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">setSearchMode:</string>
-						<reference key="source" ref="664008763"/>
-						<reference key="destination" ref="129314767"/>
-					</object>
-					<int key="connectionID">304</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">setSearchMode:</string>
-						<reference key="source" ref="664008763"/>
-						<reference key="destination" ref="319773573"/>
-					</object>
-					<int key="connectionID">305</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">setSearchMode:</string>
-						<reference key="source" ref="664008763"/>
-						<reference key="destination" ref="224214980"/>
-					</object>
-					<int key="connectionID">306</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">searchModeField</string>
-						<reference key="source" ref="664008763"/>
-						<reference key="destination" ref="906943389"/>
-					</object>
-					<int key="connectionID">309</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">delegate</string>
-						<reference key="source" ref="429486953"/>
-						<reference key="destination" ref="664008763"/>
-					</object>
-					<int key="connectionID">129</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">initialFirstResponder</string>
-						<reference key="source" ref="429486953"/>
-						<reference key="destination" ref="569239575"/>
-					</object>
-					<int key="connectionID">151</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">dataSource</string>
-						<reference key="source" ref="569239575"/>
-						<reference key="destination" ref="664008763"/>
-					</object>
-					<int key="connectionID">62</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">delegate</string>
-						<reference key="source" ref="569239575"/>
-						<reference key="destination" ref="664008763"/>
-					</object>
-					<int key="connectionID">63</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">rowHeight: values.QSResultViewRowHeight</string>
-						<reference key="source" ref="569239575"/>
-						<reference key="destination" ref="830537305"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="569239575"/>
-							<reference key="NSDestination" ref="830537305"/>
-							<string key="NSLabel">rowHeight: values.QSResultViewRowHeight</string>
-							<string key="NSBinding">rowHeight</string>
-							<string key="NSKeyPath">values.QSResultViewRowHeight</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">197</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">delegate</string>
-						<reference key="source" ref="608115155"/>
-						<reference key="destination" ref="664008763"/>
-					</object>
-					<int key="connectionID">114</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">dataSource</string>
-						<reference key="source" ref="608115155"/>
-						<reference key="destination" ref="664008763"/>
-					</object>
-					<int key="connectionID">115</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">rowHeight: values.QSResultViewRowHeight</string>
-						<reference key="source" ref="608115155"/>
-						<reference key="destination" ref="830537305"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="608115155"/>
-							<reference key="NSDestination" ref="830537305"/>
-							<string key="NSLabel">rowHeight: values.QSResultViewRowHeight</string>
-							<string key="NSBinding">rowHeight</string>
-							<string key="NSKeyPath">values.QSResultViewRowHeight</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">198</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">delegate</string>
-						<reference key="source" ref="157453347"/>
-						<reference key="destination" ref="664008763"/>
-					</object>
-					<int key="connectionID">133</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">menu</string>
-						<reference key="source" ref="207404553"/>
-						<reference key="destination" ref="761427125"/>
-					</object>
-					<int key="connectionID">249</int>
-				</object>
-			</array>
-			<object class="IBMutableOrderedSet" key="objectRecords">
-				<array key="orderedObjects">
-					<object class="IBObjectRecord">
-						<int key="objectID">0</int>
-						<array key="object" id="0"/>
-						<reference key="children" ref="698553342"/>
-						<nil key="parent"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">-2</int>
-						<reference key="object" ref="664008763"/>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">File's Owner</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">-1</int>
-						<reference key="object" ref="750813230"/>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">First Responder</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">9</int>
-						<reference key="object" ref="429486953"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="419455219"/>
-						</array>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">resultWindow</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">16</int>
-						<reference key="object" ref="419455219"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="845282137"/>
-							<reference ref="157453347"/>
-							<reference ref="952278619"/>
-							<reference ref="1008095421"/>
-							<reference ref="477699912"/>
-							<reference ref="207404553"/>
-							<reference ref="906943389"/>
-							<reference ref="744215896"/>
-						</array>
-						<reference key="parent" ref="429486953"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">43</int>
-						<reference key="object" ref="845282137"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="240448356"/>
-						</array>
-						<reference key="parent" ref="419455219"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">71</int>
-						<reference key="object" ref="157453347"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="803386848"/>
-							<reference ref="415801822"/>
-						</array>
-						<reference key="parent" ref="419455219"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">59</int>
-						<reference key="object" ref="803386848"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="569239575"/>
-							<reference ref="894678291"/>
-							<reference ref="492224105"/>
-						</array>
-						<reference key="parent" ref="157453347"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">58</int>
-						<reference key="object" ref="569239575"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="773215085"/>
-							<reference ref="426577701"/>
-							<reference ref="656249178"/>
-						</array>
-						<reference key="parent" ref="803386848"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">60</int>
-						<reference key="object" ref="773215085"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="864992102"/>
-						</array>
-						<reference key="parent" ref="569239575"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">143</int>
-						<reference key="object" ref="426577701"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="1034691857"/>
-						</array>
-						<reference key="parent" ref="569239575"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">157</int>
-						<reference key="object" ref="656249178"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="905081672"/>
-						</array>
-						<reference key="parent" ref="569239575"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">159</int>
-						<reference key="object" ref="905081672"/>
-						<reference key="parent" ref="656249178"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">69</int>
-						<reference key="object" ref="415801822"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="608115155"/>
-							<reference ref="462447871"/>
-							<reference ref="246514212"/>
-						</array>
-						<reference key="parent" ref="157453347"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">68</int>
-						<reference key="object" ref="608115155"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="253696150"/>
-						</array>
-						<reference key="parent" ref="415801822"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">67</int>
-						<reference key="object" ref="253696150"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="207462246"/>
-						</array>
-						<reference key="parent" ref="608115155"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">252</int>
-						<reference key="object" ref="952278619"/>
-						<array class="NSMutableArray" key="children"/>
-						<reference key="parent" ref="419455219"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">253</int>
-						<reference key="object" ref="1008095421"/>
-						<array class="NSMutableArray" key="children"/>
-						<reference key="parent" ref="419455219"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">195</int>
-						<reference key="object" ref="830537305"/>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">Shared Defaults</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">231</int>
-						<reference key="object" ref="761427125"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="821459113"/>
-							<reference ref="159129978"/>
-							<reference ref="150773358"/>
-							<reference ref="227093194"/>
-						</array>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">ResultsMenu</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">237</int>
-						<reference key="object" ref="821459113"/>
-						<reference key="parent" ref="761427125"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">238</int>
-						<reference key="object" ref="159129978"/>
-						<reference key="parent" ref="761427125"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">263</int>
-						<reference key="object" ref="150773358"/>
-						<reference key="parent" ref="761427125"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">266</int>
-						<reference key="object" ref="227093194"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="60097476"/>
-						</array>
-						<reference key="parent" ref="761427125"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">265</int>
-						<reference key="object" ref="60097476"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="224214980"/>
-							<reference ref="319773573"/>
-							<reference ref="129314767"/>
-						</array>
-						<reference key="parent" ref="227093194"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">267</int>
-						<reference key="object" ref="224214980"/>
-						<reference key="parent" ref="60097476"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">268</int>
-						<reference key="object" ref="319773573"/>
-						<reference key="parent" ref="60097476"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">269</int>
-						<reference key="object" ref="129314767"/>
-						<reference key="parent" ref="60097476"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">282</int>
-						<reference key="object" ref="240448356"/>
-						<reference key="parent" ref="845282137"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">285</int>
-						<reference key="object" ref="864992102"/>
-						<reference key="parent" ref="773215085"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">286</int>
-						<reference key="object" ref="1034691857"/>
-						<reference key="parent" ref="426577701"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">287</int>
-						<reference key="object" ref="207462246"/>
-						<reference key="parent" ref="253696150"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">288</int>
-						<reference key="object" ref="894678291"/>
-						<reference key="parent" ref="803386848"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">289</int>
-						<reference key="object" ref="492224105"/>
-						<reference key="parent" ref="803386848"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">290</int>
-						<reference key="object" ref="462447871"/>
-						<reference key="parent" ref="415801822"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">291</int>
-						<reference key="object" ref="246514212"/>
-						<reference key="parent" ref="415801822"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">-3</int>
-						<reference key="object" ref="1061651494"/>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">Application</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">130</int>
-						<reference key="object" ref="477699912"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="676619987"/>
-						</array>
-						<reference key="parent" ref="419455219"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">283</int>
-						<reference key="object" ref="676619987"/>
-						<reference key="parent" ref="477699912"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">248</int>
-						<reference key="object" ref="207404553"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="854249939"/>
-						</array>
-						<reference key="parent" ref="419455219"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">284</int>
-						<reference key="object" ref="854249939"/>
-						<reference key="parent" ref="207404553"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">307</int>
-						<reference key="object" ref="906943389"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="856239706"/>
-						</array>
-						<reference key="parent" ref="419455219"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">308</int>
-						<reference key="object" ref="856239706"/>
-						<reference key="parent" ref="906943389"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">314</int>
-						<reference key="object" ref="744215896"/>
-						<reference key="parent" ref="419455219"/>
-					</object>
-				</array>
-			</object>
-			<dictionary class="NSMutableDictionary" key="flattenedProperties">
-				<string key="-1.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="-2.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="-3.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<object class="NSMutableDictionary" key="130.IBAttributePlaceholdersKey">
-					<string key="NS.key.0">ToolTip</string>
-					<object class="IBToolTipAttribute" key="NS.object.0">
-						<string key="name">ToolTip</string>
-						<reference key="object" ref="477699912"/>
-						<string key="toolTip">Selected item information</string>
-					</object>
-				</object>
-				<string key="130.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="143.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="157.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="159.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="16.CustomClassName">QSBackgroundView</string>
-				<string key="16.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="195.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="231.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="237.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="238.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="248.CustomClassName">QSMenuButton</string>
-				<string key="248.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="252.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="253.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="263.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="265.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="266.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="267.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="268.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="269.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="282.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="283.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="284.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="285.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<boolean value="YES" key="285.IBShouldRemoveOnLegacySave"/>
-				<string key="286.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<boolean value="YES" key="286.IBShouldRemoveOnLegacySave"/>
-				<string key="287.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<boolean value="YES" key="287.IBShouldRemoveOnLegacySave"/>
-				<string key="288.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<boolean value="YES" key="288.IBShouldRemoveOnLegacySave"/>
-				<string key="289.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<boolean value="YES" key="289.IBShouldRemoveOnLegacySave"/>
-				<string key="290.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<boolean value="YES" key="290.IBShouldRemoveOnLegacySave"/>
-				<string key="291.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<boolean value="YES" key="291.IBShouldRemoveOnLegacySave"/>
-				<object class="NSMutableDictionary" key="307.IBAttributePlaceholdersKey">
-					<string key="NS.key.0">ToolTip</string>
-					<object class="IBToolTipAttribute" key="NS.object.0">
-						<string key="name">ToolTip</string>
-						<reference key="object" ref="906943389"/>
-						<string key="toolTip">Search string</string>
-					</object>
-				</object>
-				<string key="307.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="308.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="314.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<object class="NSMutableDictionary" key="43.IBAttributePlaceholdersKey">
-					<string key="NS.key.0">ToolTip</string>
-					<object class="IBToolTipAttribute" key="NS.object.0">
-						<string key="name">ToolTip</string>
-						<reference key="object" ref="845282137"/>
-						<string key="toolTip">Search string</string>
-					</object>
-				</object>
-				<string key="43.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="58.CustomClassName">QSTableView</string>
-				<string key="58.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="59.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="60.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="67.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="68.CustomClassName">QSTableView</string>
-				<string key="68.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="69.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="71.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="9.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="9.IBWindowTemplateEditedContentRect">{{727, 444}, {322, 203}}</string>
-			</dictionary>
-			<dictionary class="NSMutableDictionary" key="unlocalizedProperties"/>
-			<nil key="activeLocalization"/>
-			<dictionary class="NSMutableDictionary" key="localizations"/>
-			<nil key="sourceID"/>
-			<int key="maxID">314</int>
-		</object>
-		<object class="IBClassDescriber" key="IBDocument.Classes">
-			<array class="NSMutableArray" key="referencedPartialClassDescriptions">
-				<object class="IBPartialClassDescription">
-					<string key="className">BLTRResizeView</string>
-					<string key="superclassName">NSView</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">./Classes/BLTRResizeView.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSApplication</string>
-					<object class="NSMutableDictionary" key="actions">
-						<string key="NS.key.0">relaunch:</string>
-						<string key="NS.object.0">id</string>
-					</object>
-					<object class="NSMutableDictionary" key="actionInfosByName">
-						<string key="NS.key.0">relaunch:</string>
-						<object class="IBActionInfo" key="NS.object.0">
-							<string key="name">relaunch:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-					</object>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">./Classes/NSApplication.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">QSBackgroundView</string>
-					<string key="superclassName">NSView</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">./Classes/QSBackgroundView.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">QSBorderlessWindow</string>
-					<string key="superclassName">QSWindow</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">./Classes/QSBorderlessWindow.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">QSMenuButton</string>
-					<string key="superclassName">NSButton</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">./Classes/QSMenuButton.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">QSResultController</string>
-					<string key="superclassName">NSWindowController</string>
-					<dictionary class="NSMutableDictionary" key="actions">
-						<string key="assignAbbreviation:">id</string>
-						<string key="clearMnemonics:">id</string>
-						<string key="defineMnemonic:">id</string>
-						<string key="omitItem:">id</string>
-						<string key="setScore:">id</string>
-						<string key="setSearchMode:">id</string>
-						<string key="sortByName:">id</string>
-						<string key="sortByScore:">id</string>
-						<string key="tableViewAction:">id</string>
-						<string key="tableViewDoubleAction:">id</string>
-					</dictionary>
-					<dictionary class="NSMutableDictionary" key="actionInfosByName">
-						<object class="IBActionInfo" key="assignAbbreviation:">
-							<string key="name">assignAbbreviation:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="clearMnemonics:">
-							<string key="name">clearMnemonics:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="defineMnemonic:">
-							<string key="name">defineMnemonic:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="omitItem:">
-							<string key="name">omitItem:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="setScore:">
-							<string key="name">setScore:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="setSearchMode:">
-							<string key="name">setSearchMode:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="sortByName:">
-							<string key="name">sortByName:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="sortByScore:">
-							<string key="name">sortByScore:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="tableViewAction:">
-							<string key="name">tableViewAction:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="tableViewDoubleAction:">
-							<string key="name">tableViewDoubleAction:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-					</dictionary>
-					<dictionary class="NSMutableDictionary" key="outlets">
-						<string key="filterCatalog">NSMenuItem</string>
-						<string key="filterResults">NSMenuItem</string>
-						<string key="resultChildTable">NSTableView</string>
-						<string key="resultCountField">NSTextField</string>
-						<string key="resultTable">NSTableView</string>
-						<string key="searchModeField">NSTextField</string>
-						<string key="searchModeMenu">NSMenu</string>
-						<string key="searchStringField">NSTextField</string>
-						<string key="selectionView">NSTextField</string>
-						<string key="snapToBest">NSMenuItem</string>
-						<string key="sortByName">NSMenuItem</string>
-						<string key="sortByScore">NSMenuItem</string>
-						<string key="splitView">NSSplitView</string>
-					</dictionary>
-					<dictionary class="NSMutableDictionary" key="toOneOutletInfosByName">
-						<object class="IBToOneOutletInfo" key="filterCatalog">
-							<string key="name">filterCatalog</string>
-							<string key="candidateClassName">NSMenuItem</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="filterResults">
-							<string key="name">filterResults</string>
-							<string key="candidateClassName">NSMenuItem</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="resultChildTable">
-							<string key="name">resultChildTable</string>
-							<string key="candidateClassName">NSTableView</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="resultCountField">
-							<string key="name">resultCountField</string>
-							<string key="candidateClassName">NSTextField</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="resultTable">
-							<string key="name">resultTable</string>
-							<string key="candidateClassName">NSTableView</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="searchModeField">
-							<string key="name">searchModeField</string>
-							<string key="candidateClassName">NSTextField</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="searchModeMenu">
-							<string key="name">searchModeMenu</string>
-							<string key="candidateClassName">NSMenu</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="searchStringField">
-							<string key="name">searchStringField</string>
-							<string key="candidateClassName">NSTextField</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="selectionView">
-							<string key="name">selectionView</string>
-							<string key="candidateClassName">NSTextField</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="snapToBest">
-							<string key="name">snapToBest</string>
-							<string key="candidateClassName">NSMenuItem</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="sortByName">
-							<string key="name">sortByName</string>
-							<string key="candidateClassName">NSMenuItem</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="sortByScore">
-							<string key="name">sortByScore</string>
-							<string key="candidateClassName">NSMenuItem</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="splitView">
-							<string key="name">splitView</string>
-							<string key="candidateClassName">NSSplitView</string>
-						</object>
-					</dictionary>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">./Classes/QSResultController.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">QSResultWindow</string>
-					<string key="superclassName">QSBorderlessWindow</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">./Classes/QSResultWindow.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">QSTableView</string>
-					<string key="superclassName">NSTableView</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">./Classes/QSTableView.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">QSWindow</string>
-					<string key="superclassName">NSPanel</string>
-					<dictionary class="NSMutableDictionary" key="actions">
-						<string key="hideThreaded:">id</string>
-						<string key="showThreaded:">id</string>
-					</dictionary>
-					<dictionary class="NSMutableDictionary" key="actionInfosByName">
-						<object class="IBActionInfo" key="hideThreaded:">
-							<string key="name">hideThreaded:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="showThreaded:">
-							<string key="name">showThreaded:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-					</dictionary>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">./Classes/QSWindow.h</string>
-					</object>
-				</object>
-			</array>
-		</object>
-		<int key="IBDocument.localizationMode">0</int>
-		<string key="IBDocument.TargetRuntimeIdentifier">IBCocoaFramework</string>
-		<object class="NSMutableDictionary" key="IBDocument.PluginDeclaredDependencies">
-			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin.macosx</string>
-			<real value="1070" key="NS.object.0"/>
-		</object>
-		<object class="NSMutableDictionary" key="IBDocument.PluginDeclaredDevelopmentDependencies">
-			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin.InterfaceBuilder3</string>
-			<real value="4500" key="NS.object.0"/>
-		</object>
-		<bool key="IBDocument.PluginDeclaredDependenciesTrackSystemTargetVersion">YES</bool>
-		<int key="IBDocument.defaultPropertyAccessControl">3</int>
-		<dictionary class="NSMutableDictionary" key="IBDocument.LastKnownImageSizes">
-			<string key="Button-GearMenu">{20, 12}</string>
-			<string key="NSMenuCheckmark">{11, 11}</string>
-			<string key="NSMenuMixedState">{10, 3}</string>
-		</dictionary>
-	</data>
-</archive>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="10117" systemVersion="15D21" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+    <dependencies>
+        <deployment version="1070" identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="10117"/>
+    </dependencies>
+    <objects>
+        <customObject id="-2" userLabel="File's Owner" customClass="QSResultController">
+            <connections>
+                <outlet property="filterCatalog" destination="269" id="295"/>
+                <outlet property="filterResults" destination="268" id="296"/>
+                <outlet property="resultChildTable" destination="68" id="77"/>
+                <outlet property="resultTable" destination="58" id="65"/>
+                <outlet property="searchModeField" destination="307" id="309"/>
+                <outlet property="searchModeMenu" destination="265" id="280"/>
+                <outlet property="searchStringField" destination="43" id="44"/>
+                <outlet property="selectionView" destination="130" id="132"/>
+                <outlet property="snapToBest" destination="267" id="297"/>
+                <outlet property="sortByName" destination="237" id="317"/>
+                <outlet property="sortByScore" destination="238" id="302"/>
+                <outlet property="splitView" destination="71" id="142"/>
+                <outlet property="window" destination="9" id="33"/>
+            </connections>
+        </customObject>
+        <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
+        <customObject id="-3" userLabel="Application"/>
+        <window title="Results" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" oneShot="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="9" userLabel="resultWindow" customClass="QSResultWindow">
+            <windowStyleMask key="styleMask" titled="YES" closable="YES" resizable="YES" nonactivatingPanel="YES"/>
+            <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
+            <rect key="contentRect" x="48" y="35" width="322" height="198"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1027"/>
+            <value key="minSize" type="size" width="200" height="150"/>
+            <view key="contentView" id="16" customClass="QSBackgroundView">
+                <rect key="frame" x="0.0" y="0.0" width="322" height="198"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <customView id="253" customClass="QSBackgroundView">
+                        <rect key="frame" x="0.0" y="182" width="324" height="16"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                    </customView>
+                    <customView id="252" customClass="QSBackgroundView">
+                        <rect key="frame" x="-1" y="0.0" width="323" height="16"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES"/>
+                    </customView>
+                    <customView id="314" customClass="BLTRResizeView">
+                        <rect key="frame" x="306" y="0.0" width="16" height="16"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
+                    </customView>
+                    <textField toolTip="Selected item information" verticalHuggingPriority="750" id="130">
+                        <rect key="frame" x="1" y="1" width="304" height="12"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
+                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" state="on" alignment="left" title="Details" id="283">
+                            <font key="font" metaFont="systemBold" size="10"/>
+                            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
+                    <splitView vertical="YES" id="71">
+                        <rect key="frame" x="-1" y="14" width="324" height="169"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <scrollView autohidesScrollers="YES" horizontalLineScroll="15" horizontalPageScroll="10" verticalLineScroll="15" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" id="59">
+                                <rect key="frame" x="0.0" y="0.0" width="157" height="169"/>
+                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="IpO-bH-qiA">
+                                    <rect key="frame" x="1" y="1" width="155" height="167"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                    <subviews>
+                                        <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnReordering="NO" columnSelection="YES" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" rowHeight="12" id="58" customClass="QSTableView">
+                                            <rect key="frame" x="0.0" y="0.0" width="155" height="167"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES"/>
+                                            <size key="intercellSpacing" width="3" height="3"/>
+                                            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                            <color key="gridColor" white="0.94758063999999997" alpha="1" colorSpace="calibratedWhite"/>
+                                            <tableColumns>
+                                                <tableColumn identifier="RankColumn" width="24" minWidth="13.611000061035156" maxWidth="24" id="143">
+                                                    <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="center" title="•">
+                                                        <font key="font" metaFont="miniSystemBold"/>
+                                                        <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
+                                                    </tableHeaderCell>
+                                                    <textFieldCell key="dataCell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" alignment="center" id="286">
+                                                        <font key="font" metaFont="miniSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                </tableColumn>
+                                                <tableColumn identifier="NameColumn" editable="NO" width="112.14500045776367" minWidth="42.145000457763672" maxWidth="1000" id="60">
+                                                    <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Results">
+                                                        <font key="font" metaFont="miniSystemBold"/>
+                                                        <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" white="0.33333299" alpha="1" colorSpace="calibratedWhite"/>
+                                                    </tableHeaderCell>
+                                                    <textFieldCell key="dataCell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" alignment="left" id="285">
+                                                        <font key="font" metaFont="miniSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                                    </textFieldCell>
+                                                    <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                                </tableColumn>
+                                                <tableColumn identifier="hasChildren" editable="NO" width="10" minWidth="4" maxWidth="1000" id="157">
+                                                    <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
+                                                    </tableHeaderCell>
+                                                    <imageCell key="dataCell" refusesFirstResponder="YES" alignment="left" animates="YES" imageScaling="proportionallyDown" id="159"/>
+                                                </tableColumn>
+                                            </tableColumns>
+                                            <connections>
+                                                <binding destination="195" name="rowHeight" keyPath="values.QSResultViewRowHeight" id="197"/>
+                                                <outlet property="dataSource" destination="-2" id="62"/>
+                                                <outlet property="delegate" destination="-2" id="63"/>
+                                            </connections>
+                                        </tableView>
+                                    </subviews>
+                                    <color key="backgroundColor" red="1" green="1" blue="1" alpha="0.48999999999999999" colorSpace="calibratedRGB"/>
+                                </clipView>
+                                <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="YES" id="289">
+                                    <rect key="frame" x="-100" y="-100" width="429" height="15"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                </scroller>
+                                <scroller key="verticalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="NO" id="288">
+                                    <rect key="frame" x="-30" y="1" width="15" height="167"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                </scroller>
+                            </scrollView>
+                            <scrollView autohidesScrollers="YES" horizontalLineScroll="21" horizontalPageScroll="10" verticalLineScroll="21" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" id="69">
+                                <rect key="frame" x="166" y="0.0" width="158" height="169"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="1V2-b1-pqk">
+                                    <rect key="frame" x="1" y="1" width="156" height="167"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                    <subviews>
+                                        <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" rowHeight="18" id="68" customClass="QSTableView">
+                                            <rect key="frame" x="0.0" y="0.0" width="156" height="167"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <size key="intercellSpacing" width="3" height="3"/>
+                                            <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                            <tableViewGridLines key="gridStyleMask" horizontal="YES"/>
+                                            <color key="gridColor" white="0.94758063999999997" alpha="1" colorSpace="calibratedWhite"/>
+                                            <tableColumns>
+                                                <tableColumn identifier="NameColumn" editable="NO" width="153" minWidth="8" maxWidth="1000" id="67">
+                                                    <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" white="0.33333299" alpha="1" colorSpace="calibratedWhite"/>
+                                                    </tableHeaderCell>
+                                                    <textFieldCell key="dataCell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" alignment="left" id="287">
+                                                        <font key="font" metaFont="system"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                                    </textFieldCell>
+                                                    <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                                </tableColumn>
+                                            </tableColumns>
+                                            <connections>
+                                                <binding destination="195" name="rowHeight" keyPath="values.QSResultViewRowHeight" id="198"/>
+                                                <outlet property="dataSource" destination="-2" id="115"/>
+                                                <outlet property="delegate" destination="-2" id="114"/>
+                                            </connections>
+                                        </tableView>
+                                    </subviews>
+                                    <color key="backgroundColor" white="1" alpha="0.94999999000000002" colorSpace="calibratedWhite"/>
+                                </clipView>
+                                <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" controlSize="small" horizontal="YES" id="291">
+                                    <rect key="frame" x="-100" y="-100" width="429" height="15"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                </scroller>
+                                <scroller key="verticalScroller" hidden="YES" verticalHuggingPriority="750" controlSize="small" horizontal="NO" id="290">
+                                    <rect key="frame" x="0.0" y="1" width="0.0" height="167"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                </scroller>
+                            </scrollView>
+                        </subviews>
+                        <holdingPriorities>
+                            <real value="250"/>
+                            <real value="250"/>
+                        </holdingPriorities>
+                        <connections>
+                            <outlet property="delegate" destination="-2" id="133"/>
+                        </connections>
+                    </splitView>
+                    <textField toolTip="Search string" verticalHuggingPriority="750" id="43">
+                        <rect key="frame" x="4" y="183" width="220" height="13"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <textFieldCell key="cell" controlSize="mini" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" state="on" alignment="left" title="SEARCH" id="282">
+                            <font key="font" metaFont="systemBold" size="10"/>
+                            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
+                    <textField toolTip="Search string" verticalHuggingPriority="750" id="307">
+                        <rect key="frame" x="225" y="183" width="72" height="13"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
+                        <textFieldCell key="cell" controlSize="mini" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" state="on" alignment="right" title="RESULTS MODE" id="308">
+                            <font key="font" metaFont="systemBold" size="10"/>
+                            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
+                    <button id="248" customClass="QSMenuButton">
+                        <rect key="frame" x="297" y="180" width="25" height="20"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
+                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="Button-GearMenu" imagePosition="only" alignment="center" inset="2" id="284">
+                            <behavior key="behavior" lightByContents="YES"/>
+                            <font key="font" metaFont="system"/>
+                            <string key="keyEquivalent">7</string>
+                            <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                        </buttonCell>
+                        <connections>
+                            <outlet property="menu" destination="231" id="249"/>
+                        </connections>
+                    </button>
+                </subviews>
+            </view>
+            <connections>
+                <outlet property="delegate" destination="-2" id="129"/>
+                <outlet property="initialFirstResponder" destination="58" id="151"/>
+            </connections>
+        </window>
+        <userDefaultsController representsSharedInstance="YES" id="195" userLabel="Shared Defaults"/>
+        <menu title="Menu" id="231" userLabel="ResultsMenu">
+            <items>
+                <menuItem title="Search Mode ⌘←/⌘→" onStateImage="CFAD1900-87DD-4651-A763-D106A02A68B0" mixedStateImage="04E85643-A713-42B2-976D-46258E885ABA" id="266">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <menu key="submenu" title="Search Mode ⌘←/⌘→" id="265">
+                        <items>
+                            <menuItem title="Filter Catalog" tag="1" id="269">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="changeSearchMode:" target="-2" id="320"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Filter Results" tag="2" id="268">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="changeSearchMode:" target="-2" id="321"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Snap to Best" tag="3" id="267">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="changeSearchMode:" target="-2" id="322"/>
+                                </connections>
+                            </menuItem>
+                        </items>
+                    </menu>
+                </menuItem>
+                <menuItem isSeparatorItem="YES" id="263">
+                    <modifierMask key="keyEquivalentModifierMask" command="YES"/>
+                </menuItem>
+                <menuItem title="Sort by Score" state="on" mixedStateImage="93F9A635-5030-4F07-A53E-632B8AB0927C" tag="2" id="238">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <connections>
+                        <action selector="changeSearchOrder:" target="-2" id="318"/>
+                    </connections>
+                </menuItem>
+                <menuItem title="Sort by Name" mixedStateImage="89486AD8-704C-4B00-A789-989AB08E6724" tag="1" id="237">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <connections>
+                        <action selector="changeSearchOrder:" target="-2" id="319"/>
+                    </connections>
+                </menuItem>
+            </items>
+        </menu>
+    </objects>
+    <resources>
+        <image name="Button-GearMenu" width="20" height="12"/>
+    </resources>
+</document>

--- a/Quicksilver/Nibs/ResultWindow.xib
+++ b/Quicksilver/Nibs/ResultWindow.xib
@@ -224,7 +224,7 @@
         <userDefaultsController representsSharedInstance="YES" id="195" userLabel="Shared Defaults"/>
         <menu title="Menu" id="231" userLabel="ResultsMenu">
             <items>
-                <menuItem title="Search Mode ⌘←/⌘→" onStateImage="CFAD1900-87DD-4651-A763-D106A02A68B0" mixedStateImage="04E85643-A713-42B2-976D-46258E885ABA" id="266">
+                <menuItem title="Search Mode ⌘←/⌘→" id="266">
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <menu key="submenu" title="Search Mode ⌘←/⌘→" id="265">
                         <items>
@@ -280,8 +280,6 @@
         </menu>
     </objects>
     <resources>
-        <image name="04E85643-A713-42B2-976D-46258E885ABA" width="128" height="128"/>
         <image name="Button-GearMenu" width="20" height="12"/>
-        <image name="CFAD1900-87DD-4651-A763-D106A02A68B0" width="128" height="128"/>
     </resources>
 </document>

--- a/Quicksilver/Nibs/ResultWindow.xib
+++ b/Quicksilver/Nibs/ResultWindow.xib
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="10117" systemVersion="15G31" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
     <dependencies>
-        <deployment version="1070" identifier="macosx"/>
+        <deployment identifier="macosx"/>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="10117"/>
     </dependencies>
     <objects>

--- a/Quicksilver/Nibs/ResultWindow.xib
+++ b/Quicksilver/Nibs/ResultWindow.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="10117" systemVersion="15D21" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="10117" systemVersion="15G31" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
     <dependencies>
         <deployment version="1070" identifier="macosx"/>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="10117"/>
@@ -16,6 +16,8 @@
                 <outlet property="searchStringField" destination="43" id="44"/>
                 <outlet property="selectionView" destination="130" id="132"/>
                 <outlet property="snapToBest" destination="267" id="297"/>
+                <outlet property="sortByDateA" destination="uI4-Rw-qcw" id="gn0-6S-Db5"/>
+                <outlet property="sortByDateD" destination="7gG-tG-EMy" id="OAi-f3-OAa"/>
                 <outlet property="sortByName" destination="237" id="317"/>
                 <outlet property="sortByScore" destination="238" id="302"/>
                 <outlet property="splitView" destination="71" id="142"/>
@@ -23,7 +25,7 @@
             </connections>
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
-        <customObject id="-3" userLabel="Application"/>
+        <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <window title="Results" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" oneShot="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="9" userLabel="resultWindow" customClass="QSResultWindow">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" resizable="YES" nonactivatingPanel="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
@@ -67,7 +69,7 @@
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnReordering="NO" columnSelection="YES" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" rowHeight="12" id="58" customClass="QSTableView">
-                                            <rect key="frame" x="0.0" y="0.0" width="155" height="167"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="155" height="15"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES"/>
                                             <size key="intercellSpacing" width="3" height="3"/>
                                             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
@@ -133,7 +135,7 @@
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" rowHeight="18" id="68" customClass="QSTableView">
-                                            <rect key="frame" x="0.0" y="0.0" width="156" height="167"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="156" height="21"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <size key="intercellSpacing" width="3" height="3"/>
                                             <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -250,22 +252,36 @@
                 <menuItem isSeparatorItem="YES" id="263">
                     <modifierMask key="keyEquivalentModifierMask" command="YES"/>
                 </menuItem>
-                <menuItem title="Sort by Score" state="on" mixedStateImage="93F9A635-5030-4F07-A53E-632B8AB0927C" tag="2" id="238">
+                <menuItem title="Sort by Score" state="on" tag="2" id="238">
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <connections>
                         <action selector="changeSearchOrder:" target="-2" id="318"/>
                     </connections>
                 </menuItem>
-                <menuItem title="Sort by Name" mixedStateImage="89486AD8-704C-4B00-A789-989AB08E6724" tag="1" id="237">
+                <menuItem title="Sort by Name" tag="1" id="237">
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <connections>
                         <action selector="changeSearchOrder:" target="-2" id="319"/>
+                    </connections>
+                </menuItem>
+                <menuItem title="Sort by Date (Oldest First)" tag="3" id="uI4-Rw-qcw" userLabel="Sort by Date (Oldest First)">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <connections>
+                        <action selector="changeSearchOrder:" target="-2" id="L5B-qc-j7S"/>
+                    </connections>
+                </menuItem>
+                <menuItem title="Sort by Date (Newest First)" tag="4" id="7gG-tG-EMy" userLabel="Sort by Date (Newest First)">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <connections>
+                        <action selector="changeSearchOrder:" target="-2" id="ukE-Fv-3MH"/>
                     </connections>
                 </menuItem>
             </items>
         </menu>
     </objects>
     <resources>
+        <image name="04E85643-A713-42B2-976D-46258E885ABA" width="128" height="128"/>
         <image name="Button-GearMenu" width="20" height="12"/>
+        <image name="CFAD1900-87DD-4651-A763-D106A02A68B0" width="128" height="128"/>
     </resources>
 </document>

--- a/Quicksilver/PlugIns-Main/PrimerInterface/QSPrimerInterfaceController.m
+++ b/Quicksilver/PlugIns-Main/PrimerInterface/QSPrimerInterfaceController.m
@@ -168,19 +168,20 @@
 	}
 	[commandView setStringValue:[[self currentCommand] name]];
 }
+
 - (void)searchView:(QSSearchObjectView *)view changedString:(NSString *)string {
 	//	NSLog(@"string %@ %@", string, view);
 
-	if (string) {
-		if (view == dSelector)
-			[dSearchText setStringValue:string];
-		if (view == aSelector)
-			[aSearchText setStringValue:string];
-		if (view == iSelector)
-			[iSearchText setStringValue:string];
+    if (!string) return;
 
-	}
+    if (view == dSelector)
+        [dSearchText setStringValue:string];
+    if (view == aSelector)
+        [aSearchText setStringValue:string];
+    if (view == iSelector)
+        [iSearchText setStringValue:string];
 }
+
 - (void)searchView:(QSSearchObjectView *)view changedResults:(NSArray *)array {
 	//	NSLog(@"string %@ %@", string, view);
 	NSInteger count = [array count];


### PR DESCRIPTION
Taking pieces from both @tiennou and my branches.

Still to fix/discuss:
- If you change the sort order, then browse into something else, it goes back to sorting by name, but the menu still shows whatever you last selected as “checked”.
- The default sort order when results are populated is undefined. Users should be able to pick a default.
- There is no keyboard shortcut for changing the sort order
- Are we doing size?
- Are we doing a “folders first” option?
- Should we add “name” to every descriptors array so it will act as a fallback when the other criteria are missing? It seems to be doing this anyway, but maybe we should be explicit.

What _should_ happen if you set the sort order to “date (newest first)” then browse? Should it go back to the user-selected default? Should it continue sorting by date until the interface is dismissed? Should it continue sorting by date forever until the user picks something else (changing the default, in other words)?

As for the default, I’d like to add both an application-wide default, and a default per-type. Or leave the default as “name” and let the per-type thing handle it. (Most people will only care about files/folders.)

(The use case for a per-type default: The only reason I worked on this in the first place was so when I right-arrow into an artist, the albums can be sorted on release date by default, while everything else in QS gets sorted by name.)

fixes #178, fixes #1494
