### PR TITLE
don't check index validity during a scan

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSCatalogEntry.m
+++ b/Quicksilver/Code-QuickStepCore/QSCatalogEntry.m
@@ -573,6 +573,9 @@ NSString *const QSCatalogEntryInvalidatedNotification = @"QSCatalogEntryInvalida
 }
 
 - (BOOL)indexIsValid {
+	if (self.isScanning) {
+		return YES;
+	}
     __block BOOL isValid = YES;
     QSGCDQueueSync(scanQueue, ^{
         [[NSNotificationCenter defaultCenter] postNotificationName:QSCatalogEntryIsIndexingNotification object:self];


### PR DESCRIPTION
It turns out the validity check was already happening on the correct queue, but it could get stuck waiting for that queue, as shown in #2016.