### PR TITLE
avoid hang in stringValue

### DIFF
--- a/Quicksilver/Code-App/QSController.m
+++ b/Quicksilver/Code-App/QSController.m
@@ -97,28 +97,6 @@ static QSController *defaultController = nil;
 }
 #endif
 
-- (NSString *)applicationSupportFolder {
-    NSArray *userSupportPathArray = NSSearchPathForDirectoriesInDomains (NSApplicationSupportDirectory, NSUserDomainMask, YES);
-    if ([userSupportPathArray count]) {
-        return [[userSupportPathArray objectAtIndex:0] stringByAppendingPathComponent:@"Quicksilver"];
-    }
-    else {
-        NSLog(@"Unable to find user Application Support folder");
-        return nil;
-    }
-}
-
-- (id)init {
-	if (self = [super init]) {
-		/* Modifying this is not recommended. Consider adding your stuff in -applicationWill/DidFinishLaunching: */
-		QSApplicationSupportPath = [[[NSUserDefaults standardUserDefaults] stringForKey:@"QSApplicationSupportPath"] stringByStandardizingPath];
-
-		if (![QSApplicationSupportPath length])
-			QSApplicationSupportPath = [self applicationSupportFolder];
-	}
-	return self;
-}
-
 - (void)startMenuExtraConnection {
 	if (controllerConnection) return;
 	controllerConnection = [NSConnection serviceConnectionWithName:@"QuicksilverControllerConnection" rootObject:self];

--- a/Quicksilver/Code-App/QSSetupAssistant.m
+++ b/Quicksilver/Code-App/QSSetupAssistant.m
@@ -260,7 +260,7 @@
 - (IBAction)finish:(id)sender {
 	
 	// Create 'Actions' folder if it doesn't already exist
-	NSString *actionsFolder = [QSApplicationSupportPath stringByAppendingPathComponent:@"/Actions/"];
+	NSString *actionsFolder = [QSGetApplicationSupportFolder() stringByAppendingPathComponent:@"/Actions/"];
 	[[NSFileManager defaultManager] createDirectoryAtPath:actionsFolder withIntermediateDirectories:YES attributes:nil error:nil];
 	
 	[[NSUserDefaults standardUserDefaults] setBool:YES forKey:kSetupAssistantCompleted];

--- a/Quicksilver/Code-QuickStepCore/QSObject_StringHandling.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject_StringHandling.m
@@ -291,6 +291,9 @@
 	if ([self count] > 1) {
 		QSObject *obj = [self resolvedObject];
 		// get the string value for each object in the collection
+		/* NOTE: getting the splti objects directly from cache may return `nil` in some instances
+				 This avoids an infinite loop as exhibited in #2242, but it may cause unexpected behaviour in certain cases
+		 */
 		stringValue = [[[obj objectForCache:kQSObjectComponents] arrayByPerformingSelector:@selector(stringValue)] componentsJoinedByString:@"\n"];
 	}
     if (!stringValue) {

--- a/Quicksilver/Code-QuickStepCore/QSObject_StringHandling.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject_StringHandling.m
@@ -289,8 +289,9 @@
         stringValue = [[NSString alloc] initWithData:stringValue encoding:NSUTF8StringEncoding];
     }
 	if ([self count] > 1) {
+		QSObject *obj = [self resolvedObject];
 		// get the string value for each object in the collection
-		stringValue = [[[self splitObjects] arrayByPerformingSelector:@selector(stringValue)] componentsJoinedByString:@"\n"];
+		stringValue = [[[obj objectForCache:kQSObjectComponents] arrayByPerformingSelector:@selector(stringValue)] componentsJoinedByString:@"\n"];
 	}
     if (!stringValue) {
         // Backwards compatibility

--- a/Quicksilver/Code-QuickStepCore/QSPaths.h
+++ b/Quicksilver/Code-QuickStepCore/QSPaths.h
@@ -30,6 +30,20 @@
 // Wiki page detailing why we collect crash reports
 #define kCrashReportsWikiURL     @"https://qsapp.com/wiki/Crash_Reports"
 
+/**
+ * Get the path to a subdirectory in the Quicksilver 'Application Support' directory
+ *
+ *  @param subpath A string for the name of the subpath to return to be found int he QS Application Support directory
+ *	@param create A boolean indicating whether or not the subpath should be created if it doesn't exist
+ *
+ *  @return NSString giving the path of the application support subdirectory
+ */
 
 NSString *QSApplicationSupportSubPath(NSString *subpath, BOOL create);
+
+/**
+ * Get Quicksilver's 'Application Support' directory
+ *
+ *  @return NSString giving the of the path to the Quicksilver Application Support directory
+ */
 NSString *QSGetApplicationSupportFolder();

--- a/Quicksilver/Code-QuickStepCore/QSPaths.h
+++ b/Quicksilver/Code-QuickStepCore/QSPaths.h
@@ -30,5 +30,6 @@
 // Wiki page detailing why we collect crash reports
 #define kCrashReportsWikiURL     @"https://qsapp.com/wiki/Crash_Reports"
 
-extern NSString *QSApplicationSupportPath;
+
 NSString *QSApplicationSupportSubPath(NSString *subpath, BOOL create);
+NSString *QSGetApplicationSupportFolder();

--- a/Quicksilver/Code-QuickStepCore/QSPaths.m
+++ b/Quicksilver/Code-QuickStepCore/QSPaths.m
@@ -8,9 +8,29 @@
 
 #import "QSPaths.h"
 
-NSString *QSApplicationSupportPath;
+
+NSString *QSGetApplicationSupportFolder() {
+	static NSString *QSApplicationSupportPath = nil;
+	if (!QSApplicationSupportPath) {
+		NSString *path = [[[NSUserDefaults standardUserDefaults] stringForKey:@"QSApplicationSupportPath"] stringByStandardizingPath];
+		if (!path) {
+			NSArray *userSupportPathArray = NSSearchPathForDirectoriesInDomains (NSApplicationSupportDirectory, NSUserDomainMask, YES);
+			if ([userSupportPathArray count]) {
+				path = [[userSupportPathArray objectAtIndex:0] stringByAppendingPathComponent:@"Quicksilver"];
+			}
+			else {
+				NSLog(@"Unable to find user Application Support folder");
+				path = nil;
+			}
+		}
+		QSApplicationSupportPath = path;
+	}
+	return QSApplicationSupportPath;
+}
+
 NSString *QSApplicationSupportSubPath(NSString *subpath, BOOL createFolder) {
-	NSString *path = [QSApplicationSupportPath stringByAppendingPathComponent:subpath];
+
+	NSString *path = [QSGetApplicationSupportFolder() stringByAppendingPathComponent:subpath];
 	NSFileManager *manager = [NSFileManager defaultManager];
 	if (createFolder && ![manager fileExistsAtPath:path isDirectory:nil])
 		[manager createDirectoriesForPath:path];

--- a/Quicksilver/Code-QuickStepCore/QSTrigger.m
+++ b/Quicksilver/Code-QuickStepCore/QSTrigger.m
@@ -146,13 +146,13 @@
     QSCommand *cmd = [self command];
     // if a trigger loaded before the catalog, an identifier will appear as plain text
     if ([[[cmd dObject] primaryType] isEqualToString:QSTextType]) {
-        NSString *ident = [[cmd dObject] stringValue];
+        NSString *ident = [[cmd dObject] objectForType:QSTextType];
         QSObject *realObject = [[QSLibrarian sharedInstance] objectWithIdentifier:ident];
         // update the trigger with the real object
         [cmd setDirectObject:realObject];
     }
     if ([[[cmd iObject] primaryType] isEqualToString:QSTextType]) {
-        NSString *ident = [[cmd iObject] stringValue];
+        NSString *ident = [[cmd iObject] objectForType:QSTextType];
         QSObject *realObject = [[QSLibrarian sharedInstance] objectWithIdentifier:ident];
         // update the trigger with the real object
         [cmd setIndirectObject:realObject];

--- a/Quicksilver/Tests/Tests-QSCore/TestQSObject.m
+++ b/Quicksilver/Tests/Tests-QSCore/TestQSObject.m
@@ -31,6 +31,25 @@
     XCTAssertEqualObjects([object objectForType:QSTextType], exampleString, @"QSTextType mismatch");
 }
 
+- (void)testMultilineStringObject {
+	NSString *multiline = @"line1\nline2";
+	NSLog(@"Abc");
+	QSObject *object = [QSObject objectWithString:multiline];
+	XCTAssertEqualObjects([object stringValue], multiline, @"multi line string values mismatch");
+	XCTAssertEqualObjects([object objectForType:QSTextType], multiline, @"multiline QSTextType mismatch");
+	
+	NSString *multilineFiles = @"~/\n~/Desktop";
+	object = [QSObject objectWithString:multilineFiles];
+	XCTAssertEqualObjects([object stringValue], multilineFiles, @"multi line file string values mismatch");
+	XCTAssertEqualObjects([object objectForType:QSTextType], multilineFiles, @"multiline file QSTextType mismatch");
+	
+	NSString *mutlilineFakeFiles = @"~/ax03kjaj\n~/ak3p40kdj";
+	object = [QSObject objectWithString:mutlilineFakeFiles];
+	XCTAssertEqualObjects([object stringValue], mutlilineFakeFiles, @"multi line fake file string values mismatch");
+	XCTAssertEqualObjects([object objectForType:QSTextType], mutlilineFakeFiles, @"multiline fake file QSTextType mismatch");
+	
+}
+
 - (void)testURLObject
 {
     NSArray *exampleURLs = @[@"qsapp.com", @"http://www.qsapp.com/"];

--- a/Quicksilver/Tests/Tests-QSCore/TestQSObject.m
+++ b/Quicksilver/Tests/Tests-QSCore/TestQSObject.m
@@ -37,11 +37,14 @@
 	QSObject *object = [QSObject objectWithString:multiline];
 	XCTAssertEqualObjects([object stringValue], multiline, @"multi line string values mismatch");
 	XCTAssertEqualObjects([object objectForType:QSTextType], multiline, @"multiline QSTextType mismatch");
-	
-	NSString *multilineFiles = @"~/\n~/Desktop";
-	object = [QSObject objectWithString:multilineFiles];
-	XCTAssertEqualObjects([object stringValue], multilineFiles, @"multi line file string values mismatch.");
-	XCTAssertEqualObjects([object objectForType:QSTextType], multilineFiles, @"multiline file QSTextType mismatch");
+
+/*  These tests fail in a unit test environment, because QSReg is not loaded in unit tests and hence every object's handler is nil.
+	This indicates some kind of refactoring needs to be done at some point in the future
+*/
+//	NSString *multilineFiles = @"~/\n~/Desktop";
+//	object = [QSObject objectWithString:multilineFiles];
+//	XCTAssertEqualObjects([object stringValue], multilineFiles, @"multi line file string values mismatch.");
+//	XCTAssertEqualObjects([object objectForType:QSTextType], multilineFiles, @"multiline file QSTextType mismatch");
 	
 	NSString *mutlilineFakeFiles = @"~/ax03kjaj\n~/ak3p40kdj";
 	object = [QSObject objectWithString:mutlilineFakeFiles];

--- a/Quicksilver/Tests/Tests-QSCore/TestQSObject.m
+++ b/Quicksilver/Tests/Tests-QSCore/TestQSObject.m
@@ -32,15 +32,15 @@
 }
 
 - (void)testMultilineStringObject {
+
 	NSString *multiline = @"line1\nline2";
-	NSLog(@"Abc");
 	QSObject *object = [QSObject objectWithString:multiline];
 	XCTAssertEqualObjects([object stringValue], multiline, @"multi line string values mismatch");
 	XCTAssertEqualObjects([object objectForType:QSTextType], multiline, @"multiline QSTextType mismatch");
 	
 	NSString *multilineFiles = @"~/\n~/Desktop";
 	object = [QSObject objectWithString:multilineFiles];
-	XCTAssertEqualObjects([object stringValue], multilineFiles, @"multi line file string values mismatch");
+	XCTAssertEqualObjects([object stringValue], multilineFiles, @"multi line file string values mismatch.");
 	XCTAssertEqualObjects([object objectForType:QSTextType], multilineFiles, @"multiline file QSTextType mismatch");
 	
 	NSString *mutlilineFakeFiles = @"~/ax03kjaj\n~/ak3p40kdj";


### PR DESCRIPTION
I could never induce `splitObjects` to call `children`, even following the steps in #2242, but the potential for an infinite loop was undeniable. Good catch, @pjrobertson!

This should prevent such a loop. The second commit may or may not help as well, but at worst, it makes things more efficient.