### PR TITLE
Deprecate some delegate methods that have Cocoa replacements

### DIFF
--- a/Quicksilver/Code-QuickStepInterface/QSTableView.h
+++ b/Quicksilver/Code-QuickStepInterface/QSTableView.h
@@ -9,14 +9,14 @@
 - (BOOL)tableView:(QSTableView *)aTableView shouldDrawRow:(NSInteger)rowIndex inClipRect:(NSRect)clipRect;
 - (BOOL)tableView:(QSTableView *)aTableView rowIsSeparator:(NSInteger)rowIndex;
 - (NSMenu *)tableView:(QSTableView*)tableView menuForTableColumn:(NSTableColumn *)column row:(NSInteger)row;
-- (void)tableView:(QSTableView *)tv dropEndedWithOperation:(NSDragOperation)operation;
+- (void)tableView:(QSTableView *)tv dropEndedWithOperation:(NSDragOperation)operation QS_DEPRECATED_MSG("It has neved been called on the delegate");
 - (void)drawSeparatorForRow:(NSInteger)rowIndex clipRect:(NSRect)clipRect;
 @end
 
 @protocol QSTableViewDataSource <NSTableViewDataSource>
 
 @optional
-- (void)tableView:(QSTableView *)aTableView dropEndedWithOperation:(NSDragOperation)operation;
+- (void)tableView:(QSTableView *)aTableView dropEndedWithOperation:(NSDragOperation)operation QS_DEPRECATED_MSG("Use -tableView:draggingSession:... and friends");
 @end
 
 @interface QSTableView : NSTableView {
@@ -28,8 +28,8 @@
 }
 - (NSColor *)highlightColor;
 - (void)setHighlightColor:(NSColor *)aHighlightColor;
-- (id)draggingDelegate;
-- (void)setDraggingDelegate:(id)aDraggingDelegate;
+- (id)draggingDelegate QS_DEPRECATED_MSG("Use -tableView:draggingSession:... and friends");
+- (void)setDraggingDelegate:(id)aDraggingDelegate QS_DEPRECATED_MSG("Use -tableView:draggingSession:... and friends");;
 - (void)setOpaque:(BOOL)flag;
 - (id <QSTableViewDelegate>)delegate;
 - (id <QSTableViewDataSource>)dataSource;


### PR DESCRIPTION
I found those while looking at the Clipboard module — which looks like the only place it's used, along with Shelf (which already has it commented out).