### PR TITLE
Breaking object sources

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSObjectSource.h
+++ b/Quicksilver/Code-QuickStepCore/QSObjectSource.h
@@ -96,8 +96,18 @@
 
 /**
  * The settings view for the source.
+ *
+ * Calling this will cause the source's NIB file to be loaded from
+ * the source's NSBundle, with the source as its owner.
+ *
+ * It is expected that this will cause the settingsView outlet to be set.
  */
 @property (retain) IBOutlet NSView *settingsView;
+
+/** The NIB name used by -settingsView.
+ * Defaults to the name of the source's class, but can be overridden.
+ */
+@property (readonly, retain) NSString *settingsNibName;
 
 // Please use -selectedEntry instead of those
 // The rational being that between -currentEntry, -selection and direct Ivar

--- a/Quicksilver/Code-QuickStepCore/QSObjectSource.h
+++ b/Quicksilver/Code-QuickStepCore/QSObjectSource.h
@@ -75,12 +75,7 @@
 
 @class QSCatalogEntry;
 
-@interface QSObjectSource : NSObject <QSObjectSource> {
-	/* The following is deprecated because it duplicates -selection.
-	 * But it can't be removed because dyld will notice and plugins will fail to load
-	 */
-	NSMutableDictionary *currentEntry QS_DEPRECATED;
-}
+@interface QSObjectSource : NSObject <QSObjectSource>
 
 - (void)invalidateSelf;
 
@@ -112,7 +107,5 @@
 // Please use -selectedEntry instead of those
 // The rational being that between -currentEntry, -selection and direct Ivar
 // everything can go wrong.
-@property (retain) NSMutableDictionary *currentEntry QS_DEPRECATED;
-@property (retain) QSCatalogEntry *selection QS_DEPRECATED;
 
 @end

--- a/Quicksilver/Code-QuickStepCore/QSObjectSource.m
+++ b/Quicksilver/Code-QuickStepCore/QSObjectSource.m
@@ -9,6 +9,11 @@
 #import "QSCatalogEntry.h"
 #import "QSCatalogEntry_Private.h"
 
+@interface QSObjectSource () {
+	NSView *_settingsView;
+}
+@end
+
 @implementation QSObjectSource
 
 - (NSImage *)iconForEntry:(QSCatalogEntry *)theEntry {return nil;}
@@ -43,5 +48,22 @@
 
 - (QSCatalogEntry *)selection { return self.selectedEntry; }
 - (void)setSelection:(QSCatalogEntry *)selection { self.selectedEntry = selection; }
+
+- (NSString *)settingsNibName {
+	return NSStringFromClass([self class]);
+}
+
+- (NSView *)settingsView {
+	if (!_settingsView) {
+		[[NSBundle bundleForClass:[self class]] loadNibNamed:self.settingsNibName owner:self topLevelObjects:NULL];
+	}
+	NSAssert(_settingsView != nil, @"Unset source settings after loading");
+
+	return _settingsView;
+}
+
+- (void)setSettingsView:(NSView *)settingsView {
+	_settingsView = settingsView;
+}
 
 @end

--- a/Quicksilver/Code-QuickStepCore/QSObjectSource.m
+++ b/Quicksilver/Code-QuickStepCore/QSObjectSource.m
@@ -36,18 +36,11 @@
 }
 - (void)populateFields {return;}
 
-- (NSMutableDictionary *)currentEntry {
-	return self.selection.info;
-}
-
-- (void)setCurrentEntry:(NSMutableDictionary *)currentEntry {}
 
 - (void)updateCurrentEntryModificationDate {
 	self.selectedEntry.sourceSettings[kItemModificationDate] = @([NSDate timeIntervalSinceReferenceDate]);
 }
 
-- (QSCatalogEntry *)selection { return self.selectedEntry; }
-- (void)setSelection:(QSCatalogEntry *)selection { self.selectedEntry = selection; }
 
 - (NSString *)settingsNibName {
 	return NSStringFromClass([self class]);


### PR DESCRIPTION
This is the breaking part of #2255. Settings view will go missing because the 1st commit, and plugins _will_ fail to load because of 0e22a18 (at least not the core ones. I think).
