### PR TITLE
improve appearance for multiple dropped files

### DIFF
--- a/Quicksilver/Code-QuickStepInterface/QSObjectView.h
+++ b/Quicksilver/Code-QuickStepInterface/QSObjectView.h
@@ -47,6 +47,13 @@ typedef enum {
 - (id)objectValue;
 - (void)setObjectValue:(QSBasicObject *)newObject;
 
+/**
+ Identical to setObjectValue: in this class. See the interface for
+ QSCollectingSearchObjectView, where this does something useful.
+ @param newObject the object to select
+ **/
+- (void)redisplayObjectValue:(QSObject *)newObject;
+
 - (QSObject *)previousObjectValue;
 - (void)setPreviousObjectValue:(QSObject *)aValue;
 

--- a/Quicksilver/Code-QuickStepInterface/QSObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSObjectView.m
@@ -192,6 +192,11 @@
 	[self setNeedsDisplay:YES];
 }
 
+- (void)redisplayObjectValue:(QSBasicObject *)newObject
+{
+	[self setObjectValue:newObject];
+}
+
 - (QSObjectDropMode) dropMode { return dropMode;  }
 - (void)setDropMode:(QSObjectDropMode)aDropMode {
 	dropMode = aDropMode;
@@ -307,7 +312,7 @@
 		}
 		[NSCursor pop];
 		[[self window] selectNextKeyView:self];
-		[self setObjectValue:[self draggedObject]];
+		[self redisplayObjectValue:[self draggedObject]];
 		[self setDraggedObject:nil];
 	} else {
 		return NO;


### PR DESCRIPTION
I thought I had found all the places. Here’s one more.

That `redisplay` method keeps creeping outward, when we really only need it on the one class. If anyone has an idea on a cleaner way to handle this, let me know.
