### PR TITLE
save mnemonics again

### DIFF
--- a/Quicksilver/Code-QuickStepInterface/QSInterfaceController.m
+++ b/Quicksilver/Code-QuickStepInterface/QSInterfaceController.m
@@ -226,7 +226,6 @@
         }
     }
 	[self setHiding:NO];
-	[dSelector clearSearch];
 	[[NSNotificationCenter defaultCenter] postNotificationName:QSReleaseOldCachesNotification object:self];
     
 }


### PR DESCRIPTION
Revert "Clear last search when closing interface"

This reverts commit aeaa261352e3caa42838e3a1f4caa2a9ef90953c.

It seems that this was wiping out the search string faster than we could save it, so QS stopped “learning”. 😢 

It *may* have been related to this comment https://github.com/quicksilver/Quicksilver/pull/2249#issuecomment-236476810

But I can’t reproduce that problem after reverting the commit. Can someone confirm?