### PR TITLE
declare build version in the interface

### DIFF
--- a/Quicksilver/Code-QuickStepFoundation/NSApplication_BLTRExtensions.h
+++ b/Quicksilver/Code-QuickStepFoundation/NSApplication_BLTRExtensions.h
@@ -11,6 +11,7 @@
 #define QSApplicationWillRelaunchNotification @"QSApplicationWillRelaunchNotification"
 @interface NSApplication (Info)
 - (BOOL)wasLaunchedAtLogin;
+- (NSString *)buildVersion;
 - (NSString *)versionString;
 - (NSDictionary *)processInformation;
 - (NSDictionary *)parentProcessInformation;


### PR DESCRIPTION
There will surely be other changes necessary, but this is the only thing completely preventing QS from building under Xcode 8.