### PR TITLE
Another go at ensuring search string is cleared when closing interface

### DIFF
--- a/Quicksilver/Code-QuickStepInterface/QSInterfaceController.m
+++ b/Quicksilver/Code-QuickStepInterface/QSInterfaceController.m
@@ -663,8 +663,6 @@
     }
 	if (cont) {
         [[self window] makeFirstResponder:aSelector];
-	} else {
-		[self hideMainWindowFromExecution:self]; // *** this should only hide if no result comes in like 2 seconds
 	}
 }
 


### PR DESCRIPTION
The problem is that clearing the search string too early means mnemonics are not saved, so if we move the mnemonic saving code earlier this fixes it.
The reason we want to clear the search string on interface close is a UI thing. See this comment: https://github.com/quicksilver/Quicksilver/pull/2249#issuecomment-236476810
Fixes #2302
Fixes #2300
Related to #2268 #2269 

------

OK guys take a look at this. Basically, I took a look at what @tiennou had done in 2b2cc2dfe4b7a3d4270581527d9ddd130bd8ce6f but realised that that `if (!cont) {}` code is needed but understood why Etienne was doing this - because closing the interface meant the search string was cleared, which meant mnemonics could not be saved (since that was done later on).

Instead, what I did was to make saving the mnemonics happen earlier. Now I'm not sure of the consequences of saving mnemonics *before* an action has been run. Does anybody know?

I've just done some testing, and in fact saving the mnemonics *too late* caused other bugs. 
For example take the an action that accepts an iObject, e.g. `[some folder] ⇥ [make new...] ⇥ [my folder]`

This action returns an object (the newly created folder) and displays it in the interface. The new object is created and returned when the action is executed (see `-[QSInterfaceController executeCommandThreaded] -> -[QSCommand execute] ->` which leads to [here](https://github.com/quicksilver/Quicksilver/blob/master/Quicksilver/Code-QuickStepCore/QSCommand.m#L474) where the interface is cleared), which is *before* the mnemonics were originally saved. This way the mnemonic would never be saved for the original `[some folder]` object, since it's already been cleared for the newly created folder.

Make sense?

In short - we need to be sure that saving the mnemonic before executing the command doesn't cause more harm than good