### PR TITLE
String dance

### DIFF
--- a/Quicksilver/Code-QuickStepInterface/QSCollectingSearchObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSCollectingSearchObjectView.m
@@ -180,6 +180,10 @@
 }
 - (void)deleteBackward:(id)sender {
 	if ([collection count] && ![partialString length]) {
+		if (![collection containsObject:[super objectValue]]) {
+			// search string cleared, but main object was never added to the collection
+			[collection addObject:[super objectValue]];
+		}
 		[self uncollect:sender];
 	} else {
 		[super deleteBackward:sender];

--- a/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
@@ -906,7 +906,7 @@ NSMutableDictionary *bindingsDict = nil;
 		if ([resetTimer isValid]) {
 			[resetTimer setFireDate:[NSDate dateWithTimeIntervalSinceNow:resetDelay]];
 		} else {
-			resetTimer = [NSTimer scheduledTimerWithTimeInterval:resetDelay target:self selector:@selector(clearSearch) userInfo:nil repeats:NO];
+			resetTimer = [NSTimer scheduledTimerWithTimeInterval:resetDelay target:self selector:@selector(resetString) userInfo:nil repeats:NO];
 		}
 	}
 }


### PR DESCRIPTION
Right now, “Reset search after” is crippling the training/learning process. (And it’s enabled by default, so this probably affects a lot of people.) Possible solutions:

  1. Keep the matched string until the interface is dismissed or the selection is explicitly cleared
  2. Rip out the “Reset search after” feature entirely
  3. Add a yet another string (a 4th?) to keep track of the abbreviation until the interface is dismissed

I’ve attempted 1. Thoughts?

The first commit fixes a bug I ran across while working on this. (You couldn’t clear the selection when using the comma trick unless the current object was in the collection.) Seemed like the best solution.

Fixes #2301