### PR TITLE
speed up QSObject comparisons

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSObject.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject.m
@@ -764,18 +764,22 @@ NSSize QSMaxIconSize;
 }
 
 - (NSString *)primaryType {
+	if (primaryType) {
+		return primaryType;
+	}
     if (!primaryType)
         primaryType = [meta objectForKey:kQSObjectPrimaryType];
 	if (!primaryType)
 		primaryType = [self guessPrimaryType];
-	if (!primaryType)
-		[self setPrimaryType:QSUTIForAnyTypeString(primaryType)];
+	if (primaryType)
+		[self setPrimaryType:primaryType];
 	return primaryType;
 }
 - (void)setPrimaryType:(NSString *)newPrimaryType {
     if (primaryType != newPrimaryType) {
         primaryType = newPrimaryType;
     }
+	newPrimaryType = QSUTIForAnyTypeString(newPrimaryType);
     [self setObject:newPrimaryType forMeta:kQSObjectPrimaryType];
 }
 

--- a/Quicksilver/Code-QuickStepCore/QSObject.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject.m
@@ -44,17 +44,16 @@ NSSize QSMaxIconSize;
         tempChildSet = [childLoadedSet copy];
     }
 
-    [tempIconSet enumerateObjectsWithOptions:NSEnumerationConcurrent usingBlock:^(QSObject *obj, BOOL *stop) {
-        if (obj->lastAccess && obj->lastAccess < (tempLastAccess - interval)) {
-            [obj unloadIcon];
-        }
-    }];
-
-    [tempChildSet enumerateObjectsWithOptions:NSEnumerationConcurrent usingBlock:^(QSObject *obj, BOOL *stop) {
-        if (obj->lastAccess && obj->lastAccess < (tempLastAccess - interval)) {
-            [obj unloadChildren];
-        }
-    }];
+	for (QSObject *obj in tempIconSet) {
+		if (obj->lastAccess && obj->lastAccess < (tempLastAccess - interval)) {
+			[obj unloadIcon];
+		}
+	}
+	for (QSObject *obj in tempChildSet) {
+		if (obj->lastAccess && obj->lastAccess < (tempLastAccess - interval)) {
+			[obj unloadChildren];
+		}
+	}
 }
 
 + (void)interfaceChanged {

--- a/Quicksilver/Code-QuickStepCore/QSObject.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject.m
@@ -769,7 +769,9 @@ NSSize QSMaxIconSize;
         primaryType = [meta objectForKey:kQSObjectPrimaryType];
 	if (!primaryType)
 		primaryType = [self guessPrimaryType];
-    return QSUTIForAnyTypeString(primaryType);
+	if (!primaryType)
+		[self setPrimaryType:QSUTIForAnyTypeString(primaryType)];
+	return primaryType;
 }
 - (void)setPrimaryType:(NSString *)newPrimaryType {
     if (primaryType != newPrimaryType) {

--- a/Quicksilver/Code-QuickStepCore/QSObject.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject.m
@@ -104,7 +104,7 @@ NSSize QSMaxIconSize;
 		}
 	} else {
 		for(NSString *key in data) {
-			if (![[data objectForKey:key] isEqual:[anObject objectForType:key]]) return NO;
+			if (![[data objectForKey:key] isEqual:[anObject->data objectForKey:key]]) return NO;
 		}
 	}
 	return YES;

--- a/Quicksilver/Code-QuickStepCore/QSObject.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject.m
@@ -80,11 +80,10 @@ NSSize QSMaxIconSize;
 
 - (NSUInteger)hash
 {
-	NSString *ident = [self identifier];
-	if (!ident) {
-		ident = [self stringValue];
+	if (!identifier) {
+		return (NSUInteger)self;
 	}
-	return [ident hash];
+	return [identifier hash];
 }
 
 - (BOOL)isEqual:(id)anObject {

--- a/Quicksilver/Code-QuickStepCore/QSObject.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject.m
@@ -92,19 +92,20 @@ NSSize QSMaxIconSize;
     anObject = [anObject object];
   }
 	if (self == anObject) return YES;
-	if (([self identifier] || [anObject identifier]) && ![[self identifier] isEqualToString:[anObject identifier]]) return NO;
+	QSObject *otherObject = (QSObject *)anObject;
+	if ((identifier || otherObject->identifier) && ![identifier isEqualToString:otherObject->identifier]) return NO;
 	if ([self count] > 1) {
-		if ([self count] != [(QSObject *)anObject count]) {
+		if ([self count] != [otherObject count]) {
 			return NO;
 		}
 		NSSet *myObjects = [NSSet setWithArray:[self splitObjects]];
-		NSSet *otherObjects = [NSSet setWithArray:[anObject splitObjects]];
+		NSSet *otherObjects = [NSSet setWithArray:[otherObject splitObjects]];
 		if (![myObjects isEqualToSet:otherObjects]) {
 			return NO;
 		}
 	} else {
 		for(NSString *key in data) {
-			if (![[data objectForKey:key] isEqual:[anObject objectForType:key]]) return NO;
+			if (![[data objectForKey:key] isEqual:[otherObject objectForType:key]]) return NO;
 		}
 	}
 	return YES;

--- a/Quicksilver/Code-QuickStepCore/QSObject.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject.m
@@ -85,26 +85,26 @@ NSSize QSMaxIconSize;
 	return [identifier hash];
 }
 
-- (BOOL)isEqual:(id)anObject {
+- (BOOL)isEqual:(QSObject *)anObject {
 	if (!anObject) return NO;
-  if (self != anObject && [anObject isKindOfClass:[QSRankedObject class]]) {
-    anObject = [anObject object];
-  }
+	if (self != anObject && [anObject isKindOfClass:[QSRankedObject class]]) {
+		anObject = [(QSRankedObject *)anObject object];
+	}
 	if (self == anObject) return YES;
-	QSObject *otherObject = (QSObject *)anObject;
-	if ((identifier || otherObject->identifier) && ![identifier isEqualToString:otherObject->identifier]) return NO;
+	NSString *otherIdentifier = anObject->identifier;
+	if ((identifier || otherIdentifier) && ![identifier isEqualToString:otherIdentifier]) return NO;
 	if ([self count] > 1) {
-		if ([self count] != [otherObject count]) {
+		if ([self count] != [anObject count]) {
 			return NO;
 		}
 		NSSet *myObjects = [NSSet setWithArray:[self splitObjects]];
-		NSSet *otherObjects = [NSSet setWithArray:[otherObject splitObjects]];
+		NSSet *otherObjects = [NSSet setWithArray:[anObject splitObjects]];
 		if (![myObjects isEqualToSet:otherObjects]) {
 			return NO;
 		}
 	} else {
 		for(NSString *key in data) {
-			if (![[data objectForKey:key] isEqual:[otherObject objectForType:key]]) return NO;
+			if (![[data objectForKey:key] isEqual:[anObject objectForType:key]]) return NO;
 		}
 	}
 	return YES;

--- a/Quicksilver/Code-QuickStepCore/QSObject.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject.m
@@ -87,6 +87,7 @@ NSSize QSMaxIconSize;
 }
 
 - (BOOL)isEqual:(id)anObject {
+	if (!anObject) return NO;
   if (self != anObject && [anObject isKindOfClass:[QSRankedObject class]]) {
     anObject = [anObject object];
   }

--- a/Quicksilver/Code-QuickStepCore/QSObject.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject.m
@@ -79,10 +79,7 @@ NSSize QSMaxIconSize;
 
 - (NSUInteger)hash
 {
-	if (!identifier) {
-		return (NSUInteger)self;
-	}
-	return [identifier hash];
+	return identifier.hash ^ data.hash;
 }
 
 - (BOOL)isEqual:(QSObject *)anObject {
@@ -92,7 +89,9 @@ NSSize QSMaxIconSize;
 	}
 	if (self == anObject) return YES;
 	NSString *otherIdentifier = anObject->identifier;
-	if ((identifier || otherIdentifier) && ![identifier isEqualToString:otherIdentifier]) return NO;
+	if ((identifier || otherIdentifier) && [identifier isEqualToString:otherIdentifier]) {
+		return YES;
+	}
 	if ([self count] > 1) {
 		if ([self count] != [anObject count]) {
 			return NO;
@@ -103,8 +102,8 @@ NSSize QSMaxIconSize;
 			return NO;
 		}
 	} else {
-		for(NSString *key in data) {
-			if (![[data objectForKey:key] isEqual:[anObject->data objectForKey:key]]) return NO;
+		if (![data isEqualToDictionary:anObject->data]) {
+			return NO;
 		}
 	}
 	return YES;
@@ -397,9 +396,6 @@ NSSize QSMaxIconSize;
 }
 
 - (id)objectForType:(id)aKey {
-	//	if ([aKey isEqualToString:NSFilenamesPboardType]) return [self arrayForType:QSFilePathType];
-	//	if ([aKey isEqualToString:NSStringPboardType]) return [self objectForType:QSTextType];
-	//	if ([aKey isEqualToString:NSURLPboardType]) return [self objectForType:QSURLType];
 	id object = [self _safeObjectForType:aKey];
 	if ([object isKindOfClass:[NSArray class]]) {
 		if ([(NSArray *) object count] == 1) return [object lastObject];

--- a/Quicksilver/Code-QuickStepCore/QSObject_PropertyList.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject_PropertyList.m
@@ -99,19 +99,6 @@
     id dup = [QSLib objectWithIdentifier:identifier];
     if (dup) return dup;
 
-    // Backwards compatibility: make sure all dict keys are UTIs (where applicable)
-    for (NSMutableDictionary *dict in @[data, meta]) {
-        // Create a temp dict to add any new UTI key/value pairs to. We can't add them directly to data/meta in the enumerate block (cannot mutate whilst enumerating)
-        NSMutableDictionary *tempDict = [NSMutableDictionary dictionary];
-        [dict enumerateKeysAndObjectsUsingBlock:^(NSString *key, id obj, BOOL *stop) {
-            NSString *UTIString = QSUTIForAnyTypeString(key);
-            if (UTIString && ![key isEqualToString:UTIString]) {
-                [tempDict setObject:obj forKey:UTIString];
-            }
-        }];
-        [dict addEntriesFromDictionary:tempDict];
-    }
-
     if ([self containsType:QSFilePathType] || [self containsType:NSFilenamesPboardType]) {
         [self changeFilesToPaths];
     }

--- a/Quicksilver/Code-QuickStepCore/QSObject_PropertyList.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject_PropertyList.m
@@ -96,7 +96,7 @@
 
     // Check immediately if we already have loaded that object
     // ***warning  * should this update the name for files?
-    id dup = [QSLib objectWithIdentifier:self.identifier];
+    id dup = [QSLib objectWithIdentifier:identifier];
     if (dup) return dup;
 
     // Backwards compatibility: make sure all dict keys are UTIs (where applicable)

--- a/Quicksilver/Quicksilver.xcodeproj/project.pbxproj
+++ b/Quicksilver/Quicksilver.xcodeproj/project.pbxproj
@@ -3893,7 +3893,6 @@
 				66448D9114F42790000FA2E2 /* Resources */,
 				66448D9214F42790000FA2E2 /* Sources */,
 				66448D9314F42790000FA2E2 /* Frameworks */,
-				66448D9414F42790000FA2E2 /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -3912,7 +3911,6 @@
 				666E45E9150225EA0034E60A /* Resources */,
 				666E45EA150225EA0034E60A /* Sources */,
 				666E45EB150225EA0034E60A /* Frameworks */,
-				666E45EC150225EA0034E60A /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -4478,32 +4476,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		66448D9414F42790000FA2E2 /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "# Run the unit tests in this test bundle.\n\"${SYSTEM_DEVELOPER_DIR}/Tools/RunUnitTests\"\n";
-		};
-		666E45EC150225EA0034E60A /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "# Run the unit tests in this test bundle.\n\"${SYSTEM_DEVELOPER_DIR}/Tools/RunUnitTests\"\n";
-		};
 		66CAE628153EF9AE0021BC65 /* Adjust Version-String */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;

--- a/Quicksilver/Tests/Tests-QSCore/TestQSObject.m
+++ b/Quicksilver/Tests/Tests-QSCore/TestQSObject.m
@@ -249,6 +249,12 @@
 	XCTAssertEqualObjects(combined4, combined5);
 	QSObject *combined6 = [QSObject objectByMergingObjects:@[data1, data2] withObject:data4];
 	XCTAssertEqualObjects(combined4, combined6);
+	// string objects
+	QSObject *string1 = [QSObject objectWithString:@"a b c d e f"];
+	QSObject *string2 = [QSObject objectWithString:@"a b c d e f"];
+	QSObject *string3 = [QSObject objectWithString:@"f e d c b a"];
+	XCTAssertEqualObjects(string1, string2);
+	XCTAssertNotEqualObjects(string1, string3);
 }
 
 @end


### PR DESCRIPTION
An attempt to alleviate some of the delays we’ve seen related to UTI look-ups.

I also tried to more generally speed up comparisons between QSObjects since they seem to be far more common than I thought.

(One example: When an `NSSet` is copied, the objects aren’t just blindly thrown into a new set. As they get added, the new set checks *again* to make sure there are no duplicates, which triggers calls to `isEqual:` for everything in the set. This happens twice in `purgeImagesAndChildrenOlderThan` alone.)

I look forward to hearing how terrible some of these changes are and why. 😝 I was just going for raw speed, OK?