### PR TITLE
clean up some old stuff

### DIFF
--- a/Quicksilver/PlugIns-Main/Bezel/QSBezelInterface.xib
+++ b/Quicksilver/PlugIns-Main/Bezel/QSBezelInterface.xib
@@ -1,496 +1,91 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<archive type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="8.00">
-	<data>
-		<int key="IBDocument.SystemTarget">1070</int>
-		<string key="IBDocument.SystemVersion">12C3012</string>
-		<string key="IBDocument.InterfaceBuilderVersion">3084</string>
-		<string key="IBDocument.AppKitVersion">1187.34</string>
-		<string key="IBDocument.HIToolboxVersion">625.00</string>
-		<object class="NSMutableDictionary" key="IBDocument.PluginVersions">
-			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin</string>
-			<string key="NS.object.0">3084</string>
-		</object>
-		<array key="IBDocument.IntegratedClassDependencies">
-			<string>NSButton</string>
-			<string>NSButtonCell</string>
-			<string>NSCustomObject</string>
-			<string>NSCustomView</string>
-			<string>NSProgressIndicator</string>
-			<string>NSTextField</string>
-			<string>NSTextFieldCell</string>
-			<string>NSView</string>
-			<string>NSWindowTemplate</string>
-		</array>
-		<array key="IBDocument.PluginDependencies">
-			<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-		</array>
-		<object class="NSMutableDictionary" key="IBDocument.Metadata">
-			<string key="NS.key.0">PluginDependencyRecalculationVersion</string>
-			<integer value="1" key="NS.object.0"/>
-		</object>
-		<array class="NSMutableArray" key="IBDocument.RootObjects" id="119495798">
-			<object class="NSCustomObject" id="697079896">
-				<string key="NSClassName">QSBezelInterfaceController</string>
-			</object>
-			<object class="NSCustomObject" id="107842024">
-				<string key="NSClassName">FirstResponder</string>
-			</object>
-			<object class="NSCustomObject" id="233649634">
-				<string key="NSClassName">NSApplication</string>
-			</object>
-			<object class="NSWindowTemplate" id="592495052">
-				<int key="NSWindowStyleMask">131</int>
-				<int key="NSWindowBacking">2</int>
-				<string key="NSWindowRect">{{530, 653}, {530, 202}}</string>
-				<int key="NSWTFlags">-529006592</int>
-				<string key="NSWindowTitle">Bezel Interface</string>
-				<string key="NSWindowClass">QSBorderlessWindow</string>
-				<object class="NSMutableString" key="NSViewClass">
-					<characters key="NS.bytes">View</characters>
-				</object>
-				<nil key="NSUserInterfaceItemIdentifier"/>
-				<string key="NSWindowContentMinSize">{213, 107}</string>
-				<object class="NSView" key="NSWindowView" id="708947105">
-					<reference key="NSNextResponder"/>
-					<int key="NSvFlags">256</int>
-					<array class="NSMutableArray" key="NSSubviews">
-						<object class="NSCustomView" id="238152217">
-							<reference key="NSNextResponder" ref="708947105"/>
-							<int key="NSvFlags">260</int>
-							<string key="NSFrame">{{353, 25}, {160, 160}}</string>
-							<reference key="NSSuperview" ref="708947105"/>
-							<reference key="NSNextKeyView" ref="887944203"/>
-							<string key="NSClassName">QSCollectingSearchObjectView</string>
-							<string key="NSExtension">NSImageView</string>
-						</object>
-						<object class="NSCustomView" id="205745587">
-							<reference key="NSNextResponder" ref="708947105"/>
-							<int key="NSvFlags">260</int>
-							<string key="NSFrame">{{185, 25}, {160, 160}}</string>
-							<reference key="NSSuperview" ref="708947105"/>
-							<reference key="NSNextKeyView" ref="238152217"/>
-							<string key="NSClassName">QSSearchObjectView</string>
-							<string key="NSExtension">NSImageView</string>
-						</object>
-						<object class="NSCustomView" id="805529078">
-							<reference key="NSNextResponder" ref="708947105"/>
-							<int key="NSvFlags">260</int>
-							<string key="NSFrame">{{17, 25}, {160, 160}}</string>
-							<reference key="NSSuperview" ref="708947105"/>
-							<reference key="NSNextKeyView" ref="205745587"/>
-							<string key="NSClassName">QSCollectingSearchObjectView</string>
-							<string key="NSExtension">NSImageView</string>
-						</object>
-						<object class="NSTextField" id="887944203">
-							<reference key="NSNextResponder" ref="708947105"/>
-							<int key="NSvFlags">265</int>
-							<string key="NSFrame">{{499, 183}, {27, 17}}</string>
-							<reference key="NSSuperview" ref="708947105"/>
-							<reference key="NSNextKeyView" ref="220680343"/>
-							<bool key="NSEnabled">YES</bool>
-							<object class="NSTextFieldCell" key="NSCell" id="684642459">
-								<int key="NSCellFlags">-2079326144</int>
-								<int key="NSCellFlags2">138413056</int>
-								<string key="NSContents">▾</string>
-								<object class="NSFont" key="NSSupport">
-									<string key="NSName">LucidaGrande-Bold</string>
-									<double key="NSSize">13</double>
-									<int key="NSfFlags">2072</int>
-								</object>
-								<reference key="NSControlView" ref="887944203"/>
-								<object class="NSColor" key="NSBackgroundColor">
-									<int key="NSColorSpace">6</int>
-									<string key="NSCatalogName">System</string>
-									<string key="NSColorName">textBackgroundColor</string>
-									<object class="NSColor" key="NSColor">
-										<int key="NSColorSpace">3</int>
-										<bytes key="NSWhite">MQA</bytes>
-									</object>
-								</object>
-								<object class="NSColor" key="NSTextColor" id="22562272">
-									<int key="NSColorSpace">3</int>
-									<bytes key="NSWhite">MAA</bytes>
-								</object>
-							</object>
-							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-						</object>
-						<object class="NSProgressIndicator" id="541557247">
-							<reference key="NSNextResponder" ref="708947105"/>
-							<int key="NSvFlags">1281</int>
-							<string key="NSFrame">{{505, 4}, {16, 16}}</string>
-							<reference key="NSSuperview" ref="708947105"/>
-							<int key="NSpiFlags">28938</int>
-							<double key="NSMaxValue">100</double>
-						</object>
-						<object class="NSTextField" id="177189960">
-							<reference key="NSNextResponder" ref="708947105"/>
-							<int key="NSvFlags">258</int>
-							<string key="NSFrame">{{15, 5}, {493, 13}}</string>
-							<reference key="NSSuperview" ref="708947105"/>
-							<reference key="NSNextKeyView" ref="541557247"/>
-							<bool key="NSEnabled">YES</bool>
-							<object class="NSTextFieldCell" key="NSCell" id="106227149">
-								<int key="NSCellFlags">67108928</int>
-								<int key="NSCellFlags2">138414592</int>
-								<string key="NSContents">Small System Font Text</string>
-								<object class="NSFont" key="NSSupport">
-									<string key="NSName">LucidaGrande</string>
-									<double key="NSSize">9</double>
-									<int key="NSfFlags">3614</int>
-								</object>
-								<reference key="NSControlView" ref="177189960"/>
-								<object class="NSColor" key="NSBackgroundColor">
-									<int key="NSColorSpace">6</int>
-									<string key="NSCatalogName">System</string>
-									<string key="NSColorName">controlColor</string>
-									<object class="NSColor" key="NSColor">
-										<int key="NSColorSpace">3</int>
-										<bytes key="NSWhite">MC42NjY2NjY2NjY3AA</bytes>
-									</object>
-								</object>
-								<object class="NSColor" key="NSTextColor">
-									<int key="NSColorSpace">6</int>
-									<string key="NSCatalogName">System</string>
-									<string key="NSColorName">controlTextColor</string>
-									<reference key="NSColor" ref="22562272"/>
-								</object>
-							</object>
-							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-						</object>
-						<object class="NSButton" id="220680343">
-							<reference key="NSNextResponder" ref="708947105"/>
-							<int key="NSvFlags">265</int>
-							<string key="NSFrame">{{502, 183}, {21, 17}}</string>
-							<reference key="NSSuperview" ref="708947105"/>
-							<reference key="NSNextKeyView" ref="177189960"/>
-							<bool key="NSEnabled">YES</bool>
-							<object class="NSButtonCell" key="NSCell" id="875065009">
-								<int key="NSCellFlags">67108864</int>
-								<int key="NSCellFlags2">134217728</int>
-								<string key="NSContents">▾</string>
-								<object class="NSFont" key="NSSupport" id="267833496">
-									<string key="NSName">LucidaGrande</string>
-									<double key="NSSize">13</double>
-									<int key="NSfFlags">1044</int>
-								</object>
-								<reference key="NSControlView" ref="220680343"/>
-								<int key="NSButtonFlags">134660096</int>
-								<int key="NSButtonFlags2">6</int>
-								<reference key="NSAlternateImage" ref="267833496"/>
-								<string key="NSAlternateContents"/>
-								<object class="NSMutableString" key="NSKeyEquivalent">
-									<characters key="NS.bytes"/>
-								</object>
-								<int key="NSPeriodicDelay">200</int>
-								<int key="NSPeriodicInterval">25</int>
-							</object>
-							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-						</object>
-					</array>
-					<string key="NSFrameSize">{530, 202}</string>
-					<reference key="NSSuperview"/>
-					<reference key="NSNextKeyView" ref="805529078"/>
-				</object>
-				<string key="NSScreenRect">{{0, 0}, {1680, 1028}}</string>
-				<string key="NSMinSize">{213, 129}</string>
-				<string key="NSMaxSize">{10000000000000, 10000000000000}</string>
-				<bool key="NSWindowIsRestorable">YES</bool>
-			</object>
-		</array>
-		<object class="IBObjectContainer" key="IBDocument.Objects">
-			<array class="NSMutableArray" key="connectionRecords">
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">dSelector</string>
-						<reference key="source" ref="697079896"/>
-						<reference key="destination" ref="805529078"/>
-					</object>
-					<int key="connectionID">75</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">window</string>
-						<reference key="source" ref="697079896"/>
-						<reference key="destination" ref="592495052"/>
-					</object>
-					<int key="connectionID">78</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">aSelector</string>
-						<reference key="source" ref="697079896"/>
-						<reference key="destination" ref="205745587"/>
-					</object>
-					<int key="connectionID">79</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">iSelector</string>
-						<reference key="source" ref="697079896"/>
-						<reference key="destination" ref="238152217"/>
-					</object>
-					<int key="connectionID">80</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">details</string>
-						<reference key="source" ref="697079896"/>
-						<reference key="destination" ref="177189960"/>
-					</object>
-					<int key="connectionID">206</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">commandView</string>
-						<reference key="source" ref="697079896"/>
-						<reference key="destination" ref="887944203"/>
-					</object>
-					<int key="connectionID">207</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">menuButton</string>
-						<reference key="source" ref="697079896"/>
-						<reference key="destination" ref="220680343"/>
-					</object>
-					<int key="connectionID">210</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">progressIndicator</string>
-						<reference key="source" ref="697079896"/>
-						<reference key="destination" ref="541557247"/>
-					</object>
-					<int key="connectionID">211</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">delegate</string>
-						<reference key="source" ref="592495052"/>
-						<reference key="destination" ref="697079896"/>
-					</object>
-					<int key="connectionID">81</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">initialFirstResponder</string>
-						<reference key="source" ref="592495052"/>
-						<reference key="destination" ref="805529078"/>
-					</object>
-					<int key="connectionID">111</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">nextKeyView</string>
-						<reference key="source" ref="805529078"/>
-						<reference key="destination" ref="205745587"/>
-					</object>
-					<int key="connectionID">105</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">nextKeyView</string>
-						<reference key="source" ref="205745587"/>
-						<reference key="destination" ref="238152217"/>
-					</object>
-					<int key="connectionID">106</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">nextKeyView</string>
-						<reference key="source" ref="238152217"/>
-						<reference key="destination" ref="805529078"/>
-					</object>
-					<int key="connectionID">104</int>
-				</object>
-			</array>
-			<object class="IBMutableOrderedSet" key="objectRecords">
-				<array key="orderedObjects">
-					<object class="IBObjectRecord">
-						<int key="objectID">0</int>
-						<array key="object" id="0"/>
-						<reference key="children" ref="119495798"/>
-						<nil key="parent"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">-2</int>
-						<reference key="object" ref="697079896"/>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">File's Owner</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">-1</int>
-						<reference key="object" ref="107842024"/>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">First Responder</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">9</int>
-						<reference key="object" ref="592495052"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="708947105"/>
-						</array>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">mainWindow</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">6</int>
-						<reference key="object" ref="708947105"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="805529078"/>
-							<reference ref="205745587"/>
-							<reference ref="238152217"/>
-							<reference ref="887944203"/>
-							<reference ref="541557247"/>
-							<reference ref="220680343"/>
-							<reference ref="177189960"/>
-						</array>
-						<reference key="parent" ref="592495052"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">68</int>
-						<reference key="object" ref="805529078"/>
-						<reference key="parent" ref="708947105"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">69</int>
-						<reference key="object" ref="205745587"/>
-						<reference key="parent" ref="708947105"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">70</int>
-						<reference key="object" ref="238152217"/>
-						<reference key="parent" ref="708947105"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">191</int>
-						<reference key="object" ref="887944203"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="684642459"/>
-						</array>
-						<reference key="parent" ref="708947105"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">192</int>
-						<reference key="object" ref="541557247"/>
-						<reference key="parent" ref="708947105"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">205</int>
-						<reference key="object" ref="177189960"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="106227149"/>
-						</array>
-						<reference key="parent" ref="708947105"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">209</int>
-						<reference key="object" ref="220680343"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="875065009"/>
-						</array>
-						<reference key="parent" ref="708947105"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">214</int>
-						<reference key="object" ref="684642459"/>
-						<reference key="parent" ref="887944203"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">215</int>
-						<reference key="object" ref="106227149"/>
-						<reference key="parent" ref="177189960"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">216</int>
-						<reference key="object" ref="875065009"/>
-						<reference key="parent" ref="220680343"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">-3</int>
-						<reference key="object" ref="233649634"/>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">Application</string>
-					</object>
-				</array>
-			</object>
-			<dictionary class="NSMutableDictionary" key="flattenedProperties">
-				<string key="-1.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="-2.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="-3.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="191.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="192.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="205.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="209.CustomClassName">QSMenuButton</string>
-				<string key="209.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="214.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="215.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="216.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="6.CustomClassName">QSBezelBackgroundView</string>
-				<string key="6.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="68.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="69.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="70.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="9.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="9.IBWindowTemplateEditedContentRect">{{499, 326}, {536, 218}}</string>
-			</dictionary>
-			<dictionary class="NSMutableDictionary" key="unlocalizedProperties"/>
-			<nil key="activeLocalization"/>
-			<dictionary class="NSMutableDictionary" key="localizations"/>
-			<nil key="sourceID"/>
-			<int key="maxID">216</int>
-		</object>
-		<object class="IBClassDescriber" key="IBDocument.Classes">
-			<array class="NSMutableArray" key="referencedPartialClassDescriptions">
-				<object class="IBPartialClassDescription">
-					<string key="className">FirstResponder</string>
-					<dictionary class="NSMutableDictionary" key="actions">
-						<string key="rescanItems:">id</string>
-						<string key="showAbout:">id</string>
-						<string key="showActivityViewer:">id</string>
-						<string key="showPreferences:">id</string>
-						<string key="showShelf:">id</string>
-					</dictionary>
-					<dictionary class="NSMutableDictionary" key="actionInfosByName">
-						<object class="IBActionInfo" key="rescanItems:">
-							<string key="name">rescanItems:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="showAbout:">
-							<string key="name">showAbout:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="showActivityViewer:">
-							<string key="name">showActivityViewer:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="showPreferences:">
-							<string key="name">showPreferences:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-						<object class="IBActionInfo" key="showShelf:">
-							<string key="name">showShelf:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-					</dictionary>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBUserSource</string>
-						<string key="minorKey"/>
-					</object>
-				</object>
-			</array>
-		</object>
-		<int key="IBDocument.localizationMode">0</int>
-		<string key="IBDocument.TargetRuntimeIdentifier">IBCocoaFramework</string>
-		<object class="NSMutableDictionary" key="IBDocument.PluginDeclaredDependencies">
-			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin.macosx</string>
-			<real value="1070" key="NS.object.0"/>
-		</object>
-		<object class="NSMutableDictionary" key="IBDocument.PluginDeclaredDevelopmentDependencies">
-			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin.InterfaceBuilder3</string>
-			<real value="4500" key="NS.object.0"/>
-		</object>
-		<bool key="IBDocument.PluginDeclaredDependenciesTrackSystemTargetVersion">YES</bool>
-		<int key="IBDocument.defaultPropertyAccessControl">3</int>
-	</data>
-</archive>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="11762" systemVersion="16D32" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11762"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <customObject id="-2" userLabel="File's Owner" customClass="QSBezelInterfaceController">
+            <connections>
+                <outlet property="aSelector" destination="69" id="79"/>
+                <outlet property="commandView" destination="191" id="207"/>
+                <outlet property="dSelector" destination="68" id="75"/>
+                <outlet property="details" destination="205" id="206"/>
+                <outlet property="iSelector" destination="70" id="80"/>
+                <outlet property="menuButton" destination="209" id="210"/>
+                <outlet property="progressIndicator" destination="192" id="211"/>
+                <outlet property="window" destination="9" id="78"/>
+            </connections>
+        </customObject>
+        <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
+        <customObject id="-3" userLabel="Application"/>
+        <window title="Bezel Interface" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" hidesOnDeactivate="YES" oneShot="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="9" userLabel="mainWindow" customClass="QSBorderlessWindow">
+            <windowStyleMask key="styleMask" titled="YES" closable="YES" nonactivatingPanel="YES"/>
+            <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
+            <rect key="contentRect" x="530" y="653" width="530" height="202"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1028"/>
+            <value key="minSize" type="size" width="213" height="107"/>
+            <view key="contentView" id="6" customClass="QSBezelBackgroundView">
+                <rect key="frame" x="0.0" y="0.0" width="530" height="202"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <customView id="70" customClass="QSCollectingSearchObjectView">
+                        <rect key="frame" x="353" y="25" width="160" height="160"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES"/>
+                        <connections>
+                            <outlet property="nextKeyView" destination="68" id="104"/>
+                        </connections>
+                    </customView>
+                    <customView id="69" customClass="QSSearchObjectView">
+                        <rect key="frame" x="185" y="25" width="160" height="160"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES"/>
+                        <connections>
+                            <outlet property="nextKeyView" destination="70" id="106"/>
+                        </connections>
+                    </customView>
+                    <customView id="68" customClass="QSCollectingSearchObjectView">
+                        <rect key="frame" x="17" y="25" width="160" height="160"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES"/>
+                        <connections>
+                            <outlet property="nextKeyView" destination="69" id="105"/>
+                        </connections>
+                    </customView>
+                    <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="NO" id="191">
+                        <rect key="frame" x="499" y="183" width="27" height="17"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
+                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" state="on" alignment="center" title="▾" id="214">
+                            <font key="font" metaFont="systemBold"/>
+                            <color key="textColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
+                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
+                    <progressIndicator horizontalHuggingPriority="750" verticalHuggingPriority="750" maxValue="100" displayedWhenStopped="NO" bezeled="NO" indeterminate="YES" controlSize="small" style="spinning" id="192">
+                        <rect key="frame" x="505" y="4" width="16" height="16"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES"/>
+                    </progressIndicator>
+                    <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="NO" id="205">
+                        <rect key="frame" x="15" y="5" width="493" height="13"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES"/>
+                        <textFieldCell key="cell" lineBreakMode="truncatingMiddle" sendsActionOnEndEditing="YES" alignment="center" title="Small System Font Text" id="215">
+                            <font key="font" metaFont="miniSystem"/>
+                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
+                    <button id="209" customClass="QSMenuButton">
+                        <rect key="frame" x="502" y="183" width="21" height="17"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
+                        <buttonCell key="cell" type="square" title="▾" bezelStyle="shadowlessSquare" alignment="center" transparent="YES" inset="2" id="216">
+                            <behavior key="behavior" lightByContents="YES"/>
+                            <font key="font" metaFont="system"/>
+                        </buttonCell>
+                    </button>
+                </subviews>
+            </view>
+            <connections>
+                <outlet property="delegate" destination="-2" id="81"/>
+                <outlet property="initialFirstResponder" destination="68" id="111"/>
+            </connections>
+        </window>
+    </objects>
+</document>

--- a/Quicksilver/PlugIns-Main/PrimerInterface/Primer.xib
+++ b/Quicksilver/PlugIns-Main/PrimerInterface/Primer.xib
@@ -1,1178 +1,254 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<archive type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="8.00">
-	<data>
-		<int key="IBDocument.SystemTarget">1070</int>
-		<string key="IBDocument.SystemVersion">12C3012</string>
-		<string key="IBDocument.InterfaceBuilderVersion">3084</string>
-		<string key="IBDocument.AppKitVersion">1187.34</string>
-		<string key="IBDocument.HIToolboxVersion">625.00</string>
-		<object class="NSMutableDictionary" key="IBDocument.PluginVersions">
-			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin</string>
-			<string key="NS.object.0">3084</string>
-		</object>
-		<array key="IBDocument.IntegratedClassDependencies">
-			<string>NSBox</string>
-			<string>NSButton</string>
-			<string>NSButtonCell</string>
-			<string>NSCustomObject</string>
-			<string>NSCustomView</string>
-			<string>NSProgressIndicator</string>
-			<string>NSTextField</string>
-			<string>NSTextFieldCell</string>
-			<string>NSView</string>
-			<string>NSWindowTemplate</string>
-		</array>
-		<array key="IBDocument.PluginDependencies">
-			<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-		</array>
-		<object class="NSMutableDictionary" key="IBDocument.Metadata">
-			<string key="NS.key.0">PluginDependencyRecalculationVersion</string>
-			<integer value="1" key="NS.object.0"/>
-		</object>
-		<array class="NSMutableArray" key="IBDocument.RootObjects" id="522116785">
-			<object class="NSCustomObject" id="646497389">
-				<string key="NSClassName">QSPrimerInterfaceController</string>
-			</object>
-			<object class="NSCustomObject" id="479228864">
-				<string key="NSClassName">FirstResponder</string>
-			</object>
-			<object class="NSCustomObject" id="145340383">
-				<string key="NSClassName">NSApplication</string>
-			</object>
-			<object class="NSWindowTemplate" id="965040855">
-				<int key="NSWindowStyleMask">147</int>
-				<int key="NSWindowBacking">2</int>
-				<string key="NSWindowRect">{{258, 217}, {466, 301}}</string>
-				<int key="NSWTFlags">-260571136</int>
-				<string key="NSWindowTitle">Command</string>
-				<string key="NSWindowClass">QSBorderlessWindow</string>
-				<object class="NSMutableString" key="NSViewClass">
-					<characters key="NS.bytes">View</characters>
-				</object>
-				<nil key="NSUserInterfaceItemIdentifier"/>
-				<string key="NSWindowContentMinSize">{213, 113}</string>
-				<object class="NSView" key="NSWindowView" id="344399352">
-					<reference key="NSNextResponder"/>
-					<int key="NSvFlags">256</int>
-					<array class="NSMutableArray" key="NSSubviews">
-						<object class="NSBox" id="846378900">
-							<reference key="NSNextResponder" ref="344399352"/>
-							<int key="NSvFlags">274</int>
-							<array class="NSMutableArray" key="NSSubviews">
-								<object class="NSView" id="114493222">
-									<reference key="NSNextResponder" ref="846378900"/>
-									<int key="NSvFlags">274</int>
-									<string key="NSFrame">{{2, 2}, {40, 491}}</string>
-									<reference key="NSSuperview" ref="846378900"/>
-								</object>
-							</array>
-							<string key="NSFrame">{{438, -172}, {44, 495}}</string>
-							<reference key="NSSuperview" ref="344399352"/>
-							<string key="NSOffsets">{0, 0}</string>
-							<object class="NSTextFieldCell" key="NSTitleCell">
-								<int key="NSCellFlags">67108864</int>
-								<int key="NSCellFlags2">0</int>
-								<string key="NSContents">Indirect Object</string>
-								<object class="NSFont" key="NSSupport" id="26">
-									<string key="NSName">LucidaGrande</string>
-									<double key="NSSize">11</double>
-									<int key="NSfFlags">3100</int>
-								</object>
-								<object class="NSColor" key="NSBackgroundColor" id="832510457">
-									<int key="NSColorSpace">6</int>
-									<string key="NSCatalogName">System</string>
-									<string key="NSColorName">textBackgroundColor</string>
-									<object class="NSColor" key="NSColor">
-										<int key="NSColorSpace">3</int>
-										<bytes key="NSWhite">MQA</bytes>
-									</object>
-								</object>
-								<object class="NSColor" key="NSTextColor">
-									<int key="NSColorSpace">3</int>
-									<bytes key="NSWhite">MCAwLjgwMDAwMDAxAA</bytes>
-								</object>
-							</object>
-							<reference key="NSContentView" ref="114493222"/>
-							<int key="NSBorderType">3</int>
-							<int key="NSBoxType">0</int>
-							<int key="NSTitlePosition">0</int>
-							<bool key="NSTransparent">NO</bool>
-						</object>
-						<object class="NSBox" id="988889065">
-							<reference key="NSNextResponder" ref="344399352"/>
-							<int key="NSvFlags">274</int>
-							<array class="NSMutableArray" key="NSSubviews">
-								<object class="NSView" id="834870996">
-									<reference key="NSNextResponder" ref="988889065"/>
-									<int key="NSvFlags">274</int>
-									<string key="NSFrame">{{2, 2}, {40, 491}}</string>
-									<reference key="NSSuperview" ref="988889065"/>
-								</object>
-							</array>
-							<string key="NSFrame">{{-14, -182}, {44, 495}}</string>
-							<reference key="NSSuperview" ref="344399352"/>
-							<string key="NSOffsets">{0, 0}</string>
-							<object class="NSTextFieldCell" key="NSTitleCell">
-								<int key="NSCellFlags">67108864</int>
-								<int key="NSCellFlags2">0</int>
-								<string key="NSContents">Indirect Object</string>
-								<reference key="NSSupport" ref="26"/>
-								<reference key="NSBackgroundColor" ref="832510457"/>
-								<object class="NSColor" key="NSTextColor">
-									<int key="NSColorSpace">3</int>
-									<bytes key="NSWhite">MCAwLjgwMDAwMDAxAA</bytes>
-								</object>
-							</object>
-							<reference key="NSContentView" ref="834870996"/>
-							<int key="NSBorderType">3</int>
-							<int key="NSBoxType">0</int>
-							<int key="NSTitlePosition">0</int>
-							<bool key="NSTransparent">NO</bool>
-						</object>
-						<object class="NSButton" id="672786589">
-							<reference key="NSNextResponder" ref="344399352"/>
-							<int key="NSvFlags">-2147483388</int>
-							<string key="NSFrame">{{55, 13}, {25, 25}}</string>
-							<reference key="NSSuperview" ref="344399352"/>
-							<bool key="NSEnabled">YES</bool>
-							<object class="NSButtonCell" key="NSCell" id="91345171">
-								<int key="NSCellFlags">67108864</int>
-								<int key="NSCellFlags2">134217728</int>
-								<string key="NSContents"/>
-								<object class="NSFont" key="NSSupport" id="84530557">
-									<string key="NSName">LucidaGrande</string>
-									<double key="NSSize">13</double>
-									<int key="NSfFlags">1044</int>
-								</object>
-								<reference key="NSControlView" ref="672786589"/>
-								<int key="NSButtonFlags">-2038284288</int>
-								<int key="NSButtonFlags2">33</int>
-								<reference key="NSAlternateImage" ref="84530557"/>
-								<string key="NSAlternateContents"/>
-								<object class="NSMutableString" key="NSKeyEquivalent">
-									<characters key="NS.bytes"/>
-								</object>
-								<int key="NSPeriodicDelay">200</int>
-								<int key="NSPeriodicInterval">25</int>
-							</object>
-							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-						</object>
-						<object class="NSBox" id="1042758065">
-							<reference key="NSNextResponder" ref="344399352"/>
-							<int key="NSvFlags">266</int>
-							<array class="NSMutableArray" key="NSSubviews">
-								<object class="NSView" id="985536997">
-									<reference key="NSNextResponder" ref="1042758065"/>
-									<int key="NSvFlags">274</int>
-									<string key="NSFrame">{{2, 2}, {356, 62}}</string>
-									<reference key="NSSuperview" ref="1042758065"/>
-								</object>
-							</array>
-							<string key="NSFrame">{{51, 211}, {360, 66}}</string>
-							<reference key="NSSuperview" ref="344399352"/>
-							<string key="NSOffsets">{0, 0}</string>
-							<object class="NSTextFieldCell" key="NSTitleCell">
-								<int key="NSCellFlags">67108864</int>
-								<int key="NSCellFlags2">0</int>
-								<string key="NSContents">Object</string>
-								<reference key="NSSupport" ref="26"/>
-								<reference key="NSBackgroundColor" ref="832510457"/>
-								<object class="NSColor" key="NSTextColor">
-									<int key="NSColorSpace">3</int>
-									<bytes key="NSWhite">MCAwLjgwMDAwMDAxAA</bytes>
-								</object>
-							</object>
-							<reference key="NSContentView" ref="985536997"/>
-							<int key="NSBorderType">3</int>
-							<int key="NSBoxType">0</int>
-							<int key="NSTitlePosition">0</int>
-							<bool key="NSTransparent">NO</bool>
-						</object>
-						<object class="NSBox" id="621118328">
-							<reference key="NSNextResponder" ref="344399352"/>
-							<int key="NSvFlags">266</int>
-							<array class="NSMutableArray" key="NSSubviews">
-								<object class="NSView" id="808920712">
-									<reference key="NSNextResponder" ref="621118328"/>
-									<int key="NSvFlags">274</int>
-									<string key="NSFrame">{{2, 2}, {356, 62}}</string>
-									<reference key="NSSuperview" ref="621118328"/>
-								</object>
-							</array>
-							<string key="NSFrame">{{51, 128}, {360, 66}}</string>
-							<reference key="NSSuperview" ref="344399352"/>
-							<string key="NSOffsets">{0, 0}</string>
-							<object class="NSTextFieldCell" key="NSTitleCell">
-								<int key="NSCellFlags">67108864</int>
-								<int key="NSCellFlags2">0</int>
-								<string key="NSContents">Action</string>
-								<reference key="NSSupport" ref="26"/>
-								<reference key="NSBackgroundColor" ref="832510457"/>
-								<object class="NSColor" key="NSTextColor">
-									<int key="NSColorSpace">3</int>
-									<bytes key="NSWhite">MCAwLjgwMDAwMDAxAA</bytes>
-								</object>
-							</object>
-							<reference key="NSContentView" ref="808920712"/>
-							<int key="NSBorderType">3</int>
-							<int key="NSBoxType">0</int>
-							<int key="NSTitlePosition">0</int>
-							<bool key="NSTransparent">NO</bool>
-						</object>
-						<object class="NSButton" id="685324230">
-							<reference key="NSNextResponder" ref="344399352"/>
-							<int key="NSvFlags">257</int>
-							<string key="NSFrame">{{339, 11}, {74, 28}}</string>
-							<reference key="NSSuperview" ref="344399352"/>
-							<bool key="NSEnabled">YES</bool>
-							<object class="NSButtonCell" key="NSCell" id="491131027">
-								<int key="NSCellFlags">67108864</int>
-								<int key="NSCellFlags2">134348800</int>
-								<string key="NSContents">Execute</string>
-								<reference key="NSSupport" ref="26"/>
-								<reference key="NSControlView" ref="685324230"/>
-								<int key="NSButtonFlags">-2038284288</int>
-								<int key="NSButtonFlags2">1</int>
-								<reference key="NSAlternateImage" ref="26"/>
-								<string key="NSAlternateContents"/>
-								<string type="base64-UTF8" key="NSKeyEquivalent">DQ</string>
-								<int key="NSPeriodicDelay">200</int>
-								<int key="NSPeriodicInterval">25</int>
-							</object>
-							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-						</object>
-						<object class="NSButton" id="790719224">
-							<reference key="NSNextResponder" ref="344399352"/>
-							<int key="NSvFlags">265</int>
-							<string key="NSFrame">{{395, 282}, {13, 13}}</string>
-							<reference key="NSSuperview" ref="344399352"/>
-							<bool key="NSEnabled">YES</bool>
-							<object class="NSButtonCell" key="NSCell" id="391022038">
-								<int key="NSCellFlags">67108864</int>
-								<int key="NSCellFlags2">0</int>
-								<string key="NSContents"/>
-								<reference key="NSSupport" ref="84530557"/>
-								<reference key="NSControlView" ref="790719224"/>
-								<int key="NSButtonFlags">-1198637056</int>
-								<int key="NSButtonFlags2">5</int>
-								<reference key="NSAlternateImage" ref="84530557"/>
-								<string key="NSAlternateContents"/>
-								<object class="NSMutableString" key="NSKeyEquivalent">
-									<characters key="NS.bytes"/>
-								</object>
-								<int key="NSPeriodicDelay">200</int>
-								<int key="NSPeriodicInterval">25</int>
-							</object>
-							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-						</object>
-						<object class="NSButton" id="355703656">
-							<reference key="NSNextResponder" ref="344399352"/>
-							<int key="NSvFlags">265</int>
-							<string key="NSFrame">{{395, 196}, {13, 13}}</string>
-							<reference key="NSSuperview" ref="344399352"/>
-							<bool key="NSEnabled">YES</bool>
-							<object class="NSButtonCell" key="NSCell" id="712460501">
-								<int key="NSCellFlags">67108864</int>
-								<int key="NSCellFlags2">0</int>
-								<string key="NSContents"/>
-								<reference key="NSSupport" ref="84530557"/>
-								<reference key="NSControlView" ref="355703656"/>
-								<int key="NSButtonFlags">-1198637056</int>
-								<int key="NSButtonFlags2">5</int>
-								<reference key="NSAlternateImage" ref="84530557"/>
-								<string key="NSAlternateContents"/>
-								<object class="NSMutableString" key="NSKeyEquivalent">
-									<characters key="NS.bytes"/>
-								</object>
-								<int key="NSPeriodicDelay">200</int>
-								<int key="NSPeriodicInterval">25</int>
-							</object>
-							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-						</object>
-						<object class="NSCustomView" id="248048979">
-							<reference key="NSNextResponder" ref="344399352"/>
-							<int key="NSvFlags">266</int>
-							<string key="NSFrame">{{58, 219}, {346, 52}}</string>
-							<reference key="NSSuperview" ref="344399352"/>
-							<string key="NSClassName">QSCollectingSearchObjectView</string>
-							<string key="NSExtension">NSImageView</string>
-						</object>
-						<object class="NSCustomView" id="760989611">
-							<reference key="NSNextResponder" ref="344399352"/>
-							<int key="NSvFlags">266</int>
-							<string key="NSFrame">{{58, 136}, {346, 52}}</string>
-							<reference key="NSSuperview" ref="344399352"/>
-							<string key="NSClassName">QSSearchObjectView</string>
-							<string key="NSExtension">NSImageView</string>
-						</object>
-						<object class="NSTextField" id="654659167">
-							<reference key="NSNextResponder" ref="344399352"/>
-							<int key="NSvFlags">265</int>
-							<string key="NSFrame">{{262, 195}, {129, 14}}</string>
-							<reference key="NSSuperview" ref="344399352"/>
-							<bool key="NSEnabled">YES</bool>
-							<object class="NSTextFieldCell" key="NSCell" id="226309914">
-								<int key="NSCellFlags">67108864</int>
-								<int key="NSCellFlags2">71303168</int>
-								<string key="NSContents">No items</string>
-								<object class="NSFont" key="NSSupport" id="27">
-									<string key="NSName">LucidaGrande-Bold</string>
-									<double key="NSSize">11</double>
-									<int key="NSfFlags">3357</int>
-								</object>
-								<reference key="NSControlView" ref="654659167"/>
-								<object class="NSColor" key="NSBackgroundColor" id="610329714">
-									<int key="NSColorSpace">6</int>
-									<string key="NSCatalogName">System</string>
-									<string key="NSColorName">controlColor</string>
-									<object class="NSColor" key="NSColor">
-										<int key="NSColorSpace">3</int>
-										<bytes key="NSWhite">MC42NjY2NjY2NjY3AA</bytes>
-									</object>
-								</object>
-								<object class="NSColor" key="NSTextColor" id="767109633">
-									<int key="NSColorSpace">6</int>
-									<string key="NSCatalogName">System</string>
-									<string key="NSColorName">controlShadowColor</string>
-									<object class="NSColor" key="NSColor">
-										<int key="NSColorSpace">3</int>
-										<bytes key="NSWhite">MC4zMzMzMzMzMzMzAA</bytes>
-									</object>
-								</object>
-							</object>
-							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-						</object>
-						<object class="NSTextField" id="677328365">
-							<reference key="NSNextResponder" ref="344399352"/>
-							<int key="NSvFlags">265</int>
-							<string key="NSFrame">{{262, 281}, {129, 14}}</string>
-							<reference key="NSSuperview" ref="344399352"/>
-							<bool key="NSEnabled">YES</bool>
-							<object class="NSTextFieldCell" key="NSCell" id="2602445">
-								<int key="NSCellFlags">67108864</int>
-								<int key="NSCellFlags2">71303168</int>
-								<string key="NSContents">No items</string>
-								<reference key="NSSupport" ref="27"/>
-								<reference key="NSControlView" ref="677328365"/>
-								<reference key="NSBackgroundColor" ref="610329714"/>
-								<reference key="NSTextColor" ref="767109633"/>
-							</object>
-							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-						</object>
-						<object class="NSTextField" id="895121182">
-							<reference key="NSNextResponder" ref="344399352"/>
-							<int key="NSvFlags">258</int>
-							<string key="NSFrame">{{54, 17}, {285, 16}}</string>
-							<reference key="NSSuperview" ref="344399352"/>
-							<bool key="NSEnabled">YES</bool>
-							<object class="NSTextFieldCell" key="NSCell" id="429435902">
-								<int key="NSCellFlags">67108864</int>
-								<int key="NSCellFlags2">71303168</int>
-								<string key="NSContents">Command Summary</string>
-								<reference key="NSSupport" ref="26"/>
-								<reference key="NSControlView" ref="895121182"/>
-								<reference key="NSBackgroundColor" ref="610329714"/>
-								<object class="NSColor" key="NSTextColor">
-									<int key="NSColorSpace">3</int>
-									<bytes key="NSWhite">MCAwLjUAA</bytes>
-								</object>
-							</object>
-							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-						</object>
-						<object class="NSButton" id="26744920">
-							<reference key="NSNextResponder" ref="344399352"/>
-							<int key="NSvFlags">265</int>
-							<string key="NSFrame">{{442, 281}, {24, 20}}</string>
-							<reference key="NSSuperview" ref="344399352"/>
-							<bool key="NSEnabled">YES</bool>
-							<object class="NSButtonCell" key="NSCell" id="582010572">
-								<int key="NSCellFlags">67108864</int>
-								<int key="NSCellFlags2">134217728</int>
-								<string key="NSContents"/>
-								<object class="NSFont" key="NSSupport">
-									<string key="NSName">LucidaGrande</string>
-									<double key="NSSize">10</double>
-									<int key="NSfFlags">2843</int>
-								</object>
-								<reference key="NSControlView" ref="26744920"/>
-								<int key="NSButtonFlags">105136128</int>
-								<int key="NSButtonFlags2">2</int>
-								<object class="NSCustomResource" key="NSNormalImage">
-									<string key="NSClassName">NSImage</string>
-									<string key="NSResourceName">Button-GearMenu</string>
-								</object>
-								<string key="NSAlternateContents"/>
-								<string key="NSKeyEquivalent"/>
-								<int key="NSPeriodicDelay">400</int>
-								<int key="NSPeriodicInterval">75</int>
-							</object>
-							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-						</object>
-						<object class="NSProgressIndicator" id="6815613">
-							<reference key="NSNextResponder" ref="344399352"/>
-							<int key="NSvFlags">1280</int>
-							<string key="NSFrame">{{4, 5}, {16, 16}}</string>
-							<reference key="NSSuperview" ref="344399352"/>
-							<int key="NSpiFlags">20746</int>
-							<double key="NSMaxValue">100</double>
-						</object>
-						<object class="NSTextField" id="59233846">
-							<reference key="NSNextResponder" ref="344399352"/>
-							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{55, 195}, {91, 16}}</string>
-							<reference key="NSSuperview" ref="344399352"/>
-							<bool key="NSEnabled">YES</bool>
-							<object class="NSTextFieldCell" key="NSCell" id="657260612">
-								<int key="NSCellFlags">-2079326144</int>
-								<int key="NSCellFlags2">4326400</int>
-								<string key="NSContents"/>
-								<reference key="NSSupport" ref="27"/>
-								<string key="NSPlaceholderString">Action</string>
-								<reference key="NSControlView" ref="59233846"/>
-								<reference key="NSBackgroundColor" ref="832510457"/>
-								<object class="NSColor" key="NSTextColor" id="1007409126">
-									<int key="NSColorSpace">6</int>
-									<string key="NSCatalogName">System</string>
-									<string key="NSColorName">textColor</string>
-									<object class="NSColor" key="NSColor">
-										<int key="NSColorSpace">3</int>
-										<bytes key="NSWhite">MAA</bytes>
-									</object>
-								</object>
-							</object>
-							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-						</object>
-						<object class="NSTextField" id="495815545">
-							<reference key="NSNextResponder" ref="344399352"/>
-							<int key="NSvFlags">264</int>
-							<string key="NSFrame">{{55, 280}, {91, 15}}</string>
-							<reference key="NSSuperview" ref="344399352"/>
-							<bool key="NSEnabled">YES</bool>
-							<object class="NSTextFieldCell" key="NSCell" id="33020444">
-								<int key="NSCellFlags">-2079326144</int>
-								<int key="NSCellFlags2">4326400</int>
-								<string key="NSContents"/>
-								<reference key="NSSupport" ref="27"/>
-								<string key="NSPlaceholderString">Subject</string>
-								<reference key="NSControlView" ref="495815545"/>
-								<reference key="NSBackgroundColor" ref="832510457"/>
-								<reference key="NSTextColor" ref="1007409126"/>
-							</object>
-							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-						</object>
-						<object class="NSCustomView" id="1005869978">
-							<reference key="NSNextResponder" ref="344399352"/>
-							<int key="NSvFlags">256</int>
-							<array class="NSMutableArray" key="NSSubviews">
-								<object class="NSButton" id="178239895">
-									<reference key="NSNextResponder" ref="1005869978"/>
-									<int key="NSvFlags">256</int>
-									<string key="NSFrame">{{343, 71}, {13, 13}}</string>
-									<reference key="NSSuperview" ref="1005869978"/>
-									<bool key="NSEnabled">YES</bool>
-									<object class="NSButtonCell" key="NSCell" id="118598461">
-										<int key="NSCellFlags">67108864</int>
-										<int key="NSCellFlags2">0</int>
-										<string key="NSContents"/>
-										<reference key="NSSupport" ref="84530557"/>
-										<reference key="NSControlView" ref="178239895"/>
-										<int key="NSButtonFlags">-1198637056</int>
-										<int key="NSButtonFlags2">5</int>
-										<reference key="NSAlternateImage" ref="84530557"/>
-										<string key="NSAlternateContents"/>
-										<object class="NSMutableString" key="NSKeyEquivalent">
-											<characters key="NS.bytes"/>
-										</object>
-										<int key="NSPeriodicDelay">200</int>
-										<int key="NSPeriodicInterval">25</int>
-									</object>
-									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-								</object>
-								<object class="NSTextField" id="414753935">
-									<reference key="NSNextResponder" ref="1005869978"/>
-									<int key="NSvFlags">256</int>
-									<string key="NSFrame">{{210, 70}, {129, 14}}</string>
-									<reference key="NSSuperview" ref="1005869978"/>
-									<bool key="NSEnabled">YES</bool>
-									<object class="NSTextFieldCell" key="NSCell" id="350628420">
-										<int key="NSCellFlags">67108864</int>
-										<int key="NSCellFlags2">71303168</int>
-										<string key="NSContents">No items</string>
-										<reference key="NSSupport" ref="27"/>
-										<reference key="NSControlView" ref="414753935"/>
-										<reference key="NSBackgroundColor" ref="610329714"/>
-										<reference key="NSTextColor" ref="767109633"/>
-									</object>
-									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-								</object>
-								<object class="NSTextField" id="781615070">
-									<reference key="NSNextResponder" ref="1005869978"/>
-									<int key="NSvFlags">256</int>
-									<string key="NSFrame">{{3, 69}, {96, 16}}</string>
-									<reference key="NSSuperview" ref="1005869978"/>
-									<bool key="NSEnabled">YES</bool>
-									<object class="NSTextFieldCell" key="NSCell" id="928140627">
-										<int key="NSCellFlags">-2079326144</int>
-										<int key="NSCellFlags2">4326400</int>
-										<string key="NSContents"/>
-										<reference key="NSSupport" ref="27"/>
-										<string key="NSPlaceholderString">Object</string>
-										<reference key="NSControlView" ref="781615070"/>
-										<reference key="NSBackgroundColor" ref="832510457"/>
-										<reference key="NSTextColor" ref="1007409126"/>
-									</object>
-									<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-								</object>
-								<object class="NSBox" id="620642503">
-									<reference key="NSNextResponder" ref="1005869978"/>
-									<int key="NSvFlags">256</int>
-									<array class="NSMutableArray" key="NSSubviews">
-										<object class="NSView" id="475413901">
-											<reference key="NSNextResponder" ref="620642503"/>
-											<int key="NSvFlags">274</int>
-											<array class="NSMutableArray" key="NSSubviews">
-												<object class="NSCustomView" id="880186097">
-													<reference key="NSNextResponder" ref="475413901"/>
-													<int key="NSvFlags">256</int>
-													<string key="NSFrame">{{5, 6}, {346, 52}}</string>
-													<reference key="NSSuperview" ref="475413901"/>
-													<string key="NSClassName">QSCollectingSearchObjectView</string>
-													<string key="NSExtension">NSImageView</string>
-												</object>
-											</array>
-											<string key="NSFrame">{{2, 2}, {356, 62}}</string>
-											<reference key="NSSuperview" ref="620642503"/>
-										</object>
-									</array>
-									<string key="NSFrame">{{-1, 2}, {360, 66}}</string>
-									<reference key="NSSuperview" ref="1005869978"/>
-									<string key="NSOffsets">{0, 0}</string>
-									<object class="NSTextFieldCell" key="NSTitleCell">
-										<int key="NSCellFlags">67108864</int>
-										<int key="NSCellFlags2">0</int>
-										<string key="NSContents">Title</string>
-										<object class="NSFont" key="NSSupport">
-											<string key="NSName">LucidaGrande</string>
-											<double key="NSSize">11</double>
-											<int key="NSfFlags">16</int>
-										</object>
-										<reference key="NSBackgroundColor" ref="832510457"/>
-										<object class="NSColor" key="NSTextColor">
-											<int key="NSColorSpace">3</int>
-											<bytes key="NSWhite">MCAwLjgwMDAwMDAxAA</bytes>
-										</object>
-									</object>
-									<reference key="NSContentView" ref="475413901"/>
-									<int key="NSBorderType">3</int>
-									<int key="NSBoxType">0</int>
-									<int key="NSTitlePosition">0</int>
-									<bool key="NSTransparent">NO</bool>
-								</object>
-							</array>
-							<string key="NSFrame">{{52, 43}, {361, 87}}</string>
-							<reference key="NSSuperview" ref="344399352"/>
-							<string key="NSClassName">QSFadingView</string>
-							<string key="NSExtension">NSView</string>
-						</object>
-					</array>
-					<string key="NSFrameSize">{466, 301}</string>
-					<reference key="NSSuperview"/>
-				</object>
-				<string key="NSScreenRect">{{0, 0}, {1680, 1028}}</string>
-				<string key="NSMinSize">{213, 135}</string>
-				<string key="NSMaxSize">{10000000000000, 10000000000000}</string>
-				<bool key="NSWindowIsRestorable">YES</bool>
-			</object>
-		</array>
-		<object class="IBObjectContainer" key="IBDocument.Objects">
-			<array class="NSMutableArray" key="connectionRecords">
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">window</string>
-						<reference key="source" ref="646497389"/>
-						<reference key="destination" ref="965040855"/>
-					</object>
-					<int key="connectionID">48</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">dSelector</string>
-						<reference key="source" ref="646497389"/>
-						<reference key="destination" ref="248048979"/>
-					</object>
-					<int key="connectionID">49</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">aSelector</string>
-						<reference key="source" ref="646497389"/>
-						<reference key="destination" ref="760989611"/>
-					</object>
-					<int key="connectionID">52</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">commandView</string>
-						<reference key="source" ref="646497389"/>
-						<reference key="destination" ref="895121182"/>
-					</object>
-					<int key="connectionID">53</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">executeCommand:</string>
-						<reference key="source" ref="646497389"/>
-						<reference key="destination" ref="685324230"/>
-					</object>
-					<int key="connectionID">56</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">menuButton</string>
-						<reference key="source" ref="646497389"/>
-						<reference key="destination" ref="26744920"/>
-					</object>
-					<int key="connectionID">72</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">progressIndicator</string>
-						<reference key="source" ref="646497389"/>
-						<reference key="destination" ref="6815613"/>
-					</object>
-					<int key="connectionID">100</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">executeButton</string>
-						<reference key="source" ref="646497389"/>
-						<reference key="destination" ref="685324230"/>
-					</object>
-					<int key="connectionID">103</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">aSearchResultDisclosure</string>
-						<reference key="source" ref="646497389"/>
-						<reference key="destination" ref="355703656"/>
-					</object>
-					<int key="connectionID">109</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">aSearchCount</string>
-						<reference key="source" ref="646497389"/>
-						<reference key="destination" ref="654659167"/>
-					</object>
-					<int key="connectionID">110</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">dSearchResultDisclosure</string>
-						<reference key="source" ref="646497389"/>
-						<reference key="destination" ref="790719224"/>
-					</object>
-					<int key="connectionID">111</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">dSearchCount</string>
-						<reference key="source" ref="646497389"/>
-						<reference key="destination" ref="677328365"/>
-					</object>
-					<int key="connectionID">112</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">iSearchCount</string>
-						<reference key="source" ref="646497389"/>
-						<reference key="destination" ref="414753935"/>
-					</object>
-					<int key="connectionID">114</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">iSearchResultDisclosure</string>
-						<reference key="source" ref="646497389"/>
-						<reference key="destination" ref="178239895"/>
-					</object>
-					<int key="connectionID">115</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">dSearchText</string>
-						<reference key="source" ref="646497389"/>
-						<reference key="destination" ref="495815545"/>
-					</object>
-					<int key="connectionID">120</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">aSearchText</string>
-						<reference key="source" ref="646497389"/>
-						<reference key="destination" ref="59233846"/>
-					</object>
-					<int key="connectionID">121</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">iSearchText</string>
-						<reference key="source" ref="646497389"/>
-						<reference key="destination" ref="781615070"/>
-					</object>
-					<int key="connectionID">122</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">iSelector</string>
-						<reference key="source" ref="646497389"/>
-						<reference key="destination" ref="880186097"/>
-					</object>
-					<int key="connectionID">138</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">indirectView</string>
-						<reference key="source" ref="646497389"/>
-						<reference key="destination" ref="1005869978"/>
-					</object>
-					<int key="connectionID">139</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">initialFirstResponder</string>
-						<reference key="source" ref="965040855"/>
-						<reference key="destination" ref="248048979"/>
-					</object>
-					<int key="connectionID">97</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">delegate</string>
-						<reference key="source" ref="965040855"/>
-						<reference key="destination" ref="646497389"/>
-					</object>
-					<int key="connectionID">98</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">nextKeyView</string>
-						<reference key="source" ref="685324230"/>
-						<reference key="destination" ref="248048979"/>
-					</object>
-					<int key="connectionID">102</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">nextKeyView</string>
-						<reference key="source" ref="248048979"/>
-						<reference key="destination" ref="760989611"/>
-					</object>
-					<int key="connectionID">95</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">toggleResultView:</string>
-						<reference key="source" ref="248048979"/>
-						<reference key="destination" ref="790719224"/>
-					</object>
-					<int key="connectionID">127</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">nextKeyView</string>
-						<reference key="source" ref="760989611"/>
-						<reference key="destination" ref="880186097"/>
-					</object>
-					<int key="connectionID">96</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">toggleResultView:</string>
-						<reference key="source" ref="760989611"/>
-						<reference key="destination" ref="355703656"/>
-					</object>
-					<int key="connectionID">126</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">nextKeyView</string>
-						<reference key="source" ref="880186097"/>
-						<reference key="destination" ref="685324230"/>
-					</object>
-					<int key="connectionID">101</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">toggleResultView:</string>
-						<reference key="source" ref="880186097"/>
-						<reference key="destination" ref="178239895"/>
-					</object>
-					<int key="connectionID">125</int>
-				</object>
-			</array>
-			<object class="IBMutableOrderedSet" key="objectRecords">
-				<array key="orderedObjects">
-					<object class="IBObjectRecord">
-						<int key="objectID">0</int>
-						<array key="object" id="0"/>
-						<reference key="children" ref="522116785"/>
-						<nil key="parent"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">-2</int>
-						<reference key="object" ref="646497389"/>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">File's Owner</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">-1</int>
-						<reference key="object" ref="479228864"/>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">First Responder</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">6</int>
-						<reference key="object" ref="965040855"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="344399352"/>
-						</array>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">Panel</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">5</int>
-						<reference key="object" ref="344399352"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="672786589"/>
-							<reference ref="1042758065"/>
-							<reference ref="621118328"/>
-							<reference ref="685324230"/>
-							<reference ref="790719224"/>
-							<reference ref="355703656"/>
-							<reference ref="248048979"/>
-							<reference ref="760989611"/>
-							<reference ref="988889065"/>
-							<reference ref="654659167"/>
-							<reference ref="677328365"/>
-							<reference ref="895121182"/>
-							<reference ref="26744920"/>
-							<reference ref="6815613"/>
-							<reference ref="59233846"/>
-							<reference ref="495815545"/>
-							<reference ref="846378900"/>
-							<reference ref="1005869978"/>
-						</array>
-						<reference key="parent" ref="965040855"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">10</int>
-						<reference key="object" ref="672786589"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="91345171"/>
-						</array>
-						<reference key="parent" ref="344399352"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">16</int>
-						<reference key="object" ref="1042758065"/>
-						<array class="NSMutableArray" key="children"/>
-						<reference key="parent" ref="344399352"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">18</int>
-						<reference key="object" ref="621118328"/>
-						<array class="NSMutableArray" key="children"/>
-						<reference key="parent" ref="344399352"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">22</int>
-						<reference key="object" ref="685324230"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="491131027"/>
-						</array>
-						<reference key="parent" ref="344399352"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">29</int>
-						<reference key="object" ref="790719224"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="391022038"/>
-						</array>
-						<reference key="parent" ref="344399352"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">30</int>
-						<reference key="object" ref="355703656"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="712460501"/>
-						</array>
-						<reference key="parent" ref="344399352"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">32</int>
-						<reference key="object" ref="248048979"/>
-						<reference key="parent" ref="344399352"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">33</int>
-						<reference key="object" ref="760989611"/>
-						<reference key="parent" ref="344399352"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">37</int>
-						<reference key="object" ref="988889065"/>
-						<array class="NSMutableArray" key="children"/>
-						<reference key="parent" ref="344399352"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">45</int>
-						<reference key="object" ref="654659167"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="226309914"/>
-						</array>
-						<reference key="parent" ref="344399352"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">46</int>
-						<reference key="object" ref="677328365"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="2602445"/>
-						</array>
-						<reference key="parent" ref="344399352"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">47</int>
-						<reference key="object" ref="895121182"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="429435902"/>
-						</array>
-						<reference key="parent" ref="344399352"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">55</int>
-						<reference key="object" ref="26744920"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="582010572"/>
-						</array>
-						<reference key="parent" ref="344399352"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">99</int>
-						<reference key="object" ref="6815613"/>
-						<reference key="parent" ref="344399352"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">117</int>
-						<reference key="object" ref="59233846"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="657260612"/>
-						</array>
-						<reference key="parent" ref="344399352"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">118</int>
-						<reference key="object" ref="495815545"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="33020444"/>
-						</array>
-						<reference key="parent" ref="344399352"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">124</int>
-						<reference key="object" ref="846378900"/>
-						<array class="NSMutableArray" key="children"/>
-						<reference key="parent" ref="344399352"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">137</int>
-						<reference key="object" ref="1005869978"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="178239895"/>
-							<reference ref="414753935"/>
-							<reference ref="781615070"/>
-							<reference ref="620642503"/>
-						</array>
-						<reference key="parent" ref="344399352"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">31</int>
-						<reference key="object" ref="178239895"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="118598461"/>
-						</array>
-						<reference key="parent" ref="1005869978"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">44</int>
-						<reference key="object" ref="414753935"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="350628420"/>
-						</array>
-						<reference key="parent" ref="1005869978"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">116</int>
-						<reference key="object" ref="781615070"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="928140627"/>
-						</array>
-						<reference key="parent" ref="1005869978"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">177</int>
-						<reference key="object" ref="620642503"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="880186097"/>
-						</array>
-						<reference key="parent" ref="1005869978"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">180</int>
-						<reference key="object" ref="91345171"/>
-						<reference key="parent" ref="672786589"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">181</int>
-						<reference key="object" ref="491131027"/>
-						<reference key="parent" ref="685324230"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">182</int>
-						<reference key="object" ref="391022038"/>
-						<reference key="parent" ref="790719224"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">183</int>
-						<reference key="object" ref="712460501"/>
-						<reference key="parent" ref="355703656"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">184</int>
-						<reference key="object" ref="226309914"/>
-						<reference key="parent" ref="654659167"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">185</int>
-						<reference key="object" ref="2602445"/>
-						<reference key="parent" ref="677328365"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">186</int>
-						<reference key="object" ref="429435902"/>
-						<reference key="parent" ref="895121182"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">187</int>
-						<reference key="object" ref="582010572"/>
-						<reference key="parent" ref="26744920"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">188</int>
-						<reference key="object" ref="657260612"/>
-						<reference key="parent" ref="59233846"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">189</int>
-						<reference key="object" ref="33020444"/>
-						<reference key="parent" ref="495815545"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">190</int>
-						<reference key="object" ref="118598461"/>
-						<reference key="parent" ref="178239895"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">191</int>
-						<reference key="object" ref="350628420"/>
-						<reference key="parent" ref="414753935"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">192</int>
-						<reference key="object" ref="928140627"/>
-						<reference key="parent" ref="781615070"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">-3</int>
-						<reference key="object" ref="145340383"/>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">Application</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">34</int>
-						<reference key="object" ref="880186097"/>
-						<reference key="parent" ref="620642503"/>
-					</object>
-				</array>
-			</object>
-			<dictionary class="NSMutableDictionary" key="flattenedProperties">
-				<string key="-1.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="-2.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="-3.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="10.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="116.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="117.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="118.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="124.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="137.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="16.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="177.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="18.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="180.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="181.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="182.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="183.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="184.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="185.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="186.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="187.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="188.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="189.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="190.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="191.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="192.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="22.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="29.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="30.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="31.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="32.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="33.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="34.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="37.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="44.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="45.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="46.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="47.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5.CustomClassName">QSBackgroundView</string>
-				<string key="5.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="55.CustomClassName">QSMenuButton</string>
-				<string key="55.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="6.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="6.IBWindowTemplateEditedContentRect">{{651, 126}, {466, 301}}</string>
-				<string key="99.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-			</dictionary>
-			<dictionary class="NSMutableDictionary" key="unlocalizedProperties"/>
-			<nil key="activeLocalization"/>
-			<dictionary class="NSMutableDictionary" key="localizations"/>
-			<nil key="sourceID"/>
-			<int key="maxID">192</int>
-		</object>
-		<object class="IBClassDescriber" key="IBDocument.Classes"/>
-		<int key="IBDocument.localizationMode">0</int>
-		<string key="IBDocument.TargetRuntimeIdentifier">IBCocoaFramework</string>
-		<object class="NSMutableDictionary" key="IBDocument.PluginDeclaredDependencies">
-			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin.macosx</string>
-			<real value="1070" key="NS.object.0"/>
-		</object>
-		<object class="NSMutableDictionary" key="IBDocument.PluginDeclaredDevelopmentDependencies">
-			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin.InterfaceBuilder3</string>
-			<real value="4500" key="NS.object.0"/>
-		</object>
-		<bool key="IBDocument.PluginDeclaredDependenciesTrackSystemTargetVersion">YES</bool>
-		<int key="IBDocument.defaultPropertyAccessControl">3</int>
-		<object class="NSMutableDictionary" key="IBDocument.LastKnownImageSizes">
-			<string key="NS.key.0">Button-GearMenu</string>
-			<string key="NS.object.0">{20, 12}</string>
-		</object>
-	</data>
-</archive>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="11762" systemVersion="16D32" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11762"/>
+        <capability name="box content view" minToolsVersion="7.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <customObject id="-2" userLabel="File's Owner" customClass="QSPrimerInterfaceController">
+            <connections>
+                <outlet property="aSearchCount" destination="45" id="110"/>
+                <outlet property="aSearchResultDisclosure" destination="30" id="109"/>
+                <outlet property="aSearchText" destination="117" id="121"/>
+                <outlet property="aSelector" destination="33" id="52"/>
+                <outlet property="commandView" destination="47" id="53"/>
+                <outlet property="dSearchCount" destination="46" id="112"/>
+                <outlet property="dSearchResultDisclosure" destination="29" id="111"/>
+                <outlet property="dSearchText" destination="118" id="120"/>
+                <outlet property="dSelector" destination="32" id="49"/>
+                <outlet property="executeButton" destination="22" id="103"/>
+                <outlet property="iSearchCount" destination="44" id="114"/>
+                <outlet property="iSearchResultDisclosure" destination="31" id="115"/>
+                <outlet property="iSearchText" destination="116" id="122"/>
+                <outlet property="iSelector" destination="34" id="138"/>
+                <outlet property="indirectView" destination="137" id="139"/>
+                <outlet property="menuButton" destination="55" id="72"/>
+                <outlet property="progressIndicator" destination="99" id="100"/>
+                <outlet property="window" destination="6" id="48"/>
+            </connections>
+        </customObject>
+        <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
+        <customObject id="-3" userLabel="Application"/>
+        <window title="Command" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" hidesOnDeactivate="YES" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="6" userLabel="Panel" customClass="QSBorderlessWindow">
+            <windowStyleMask key="styleMask" titled="YES" closable="YES" utility="YES" nonactivatingPanel="YES"/>
+            <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
+            <rect key="contentRect" x="258" y="217" width="466" height="301"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1028"/>
+            <value key="minSize" type="size" width="213" height="113"/>
+            <view key="contentView" id="5" customClass="QSBackgroundView">
+                <rect key="frame" x="0.0" y="0.0" width="466" height="301"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <box title="Indirect Object" titlePosition="noTitle" id="124">
+                        <rect key="frame" x="438" y="-172" width="44" height="495"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <view key="contentView" id="uvz-jN-CvG">
+                            <rect key="frame" x="2" y="2" width="40" height="491"/>
+                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        </view>
+                    </box>
+                    <box title="Indirect Object" titlePosition="noTitle" id="37">
+                        <rect key="frame" x="-14" y="-182" width="44" height="495"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <view key="contentView" id="qkZ-lu-DLt">
+                            <rect key="frame" x="2" y="2" width="40" height="491"/>
+                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        </view>
+                    </box>
+                    <button hidden="YES" horizontalHuggingPriority="750" verticalHuggingPriority="750" id="10">
+                        <rect key="frame" x="55" y="13" width="25" height="25"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES"/>
+                        <buttonCell key="cell" type="help" bezelStyle="helpButton" alignment="center" borderStyle="border" inset="2" id="180">
+                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                            <font key="font" metaFont="system"/>
+                        </buttonCell>
+                    </button>
+                    <box title="Object" titlePosition="noTitle" id="16">
+                        <rect key="frame" x="51" y="211" width="360" height="66"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                        <view key="contentView" id="Ubl-86-BeX">
+                            <rect key="frame" x="2" y="2" width="356" height="62"/>
+                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        </view>
+                    </box>
+                    <box title="Action" titlePosition="noTitle" id="18">
+                        <rect key="frame" x="51" y="128" width="360" height="66"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                        <view key="contentView" id="6rc-Js-t4y">
+                            <rect key="frame" x="2" y="2" width="356" height="62"/>
+                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        </view>
+                    </box>
+                    <button verticalHuggingPriority="750" id="22">
+                        <rect key="frame" x="339" y="11" width="74" height="28"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES"/>
+                        <buttonCell key="cell" type="push" title="Execute" bezelStyle="rounded" alignment="center" controlSize="small" borderStyle="border" inset="2" id="181">
+                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                            <font key="font" metaFont="smallSystem"/>
+                            <string key="keyEquivalent" base64-UTF8="YES">
+DQ
+</string>
+                        </buttonCell>
+                        <connections>
+                            <action selector="executeCommand:" target="-2" id="56"/>
+                            <outlet property="nextKeyView" destination="32" id="102"/>
+                        </connections>
+                    </button>
+                    <button horizontalHuggingPriority="750" verticalHuggingPriority="750" id="29">
+                        <rect key="frame" x="395" y="282" width="13" height="13"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
+                        <buttonCell key="cell" type="disclosureTriangle" bezelStyle="disclosure" imagePosition="above" alignment="left" borderStyle="border" inset="2" id="182">
+                            <behavior key="behavior" pushIn="YES" changeBackground="YES" changeGray="YES" lightByContents="YES"/>
+                            <font key="font" metaFont="system"/>
+                        </buttonCell>
+                        <connections>
+                            <action selector="toggleResultView:" target="32" id="127"/>
+                        </connections>
+                    </button>
+                    <button horizontalHuggingPriority="750" verticalHuggingPriority="750" id="30">
+                        <rect key="frame" x="395" y="196" width="13" height="13"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
+                        <buttonCell key="cell" type="disclosureTriangle" bezelStyle="disclosure" imagePosition="above" alignment="left" borderStyle="border" inset="2" id="183">
+                            <behavior key="behavior" pushIn="YES" changeBackground="YES" changeGray="YES" lightByContents="YES"/>
+                            <font key="font" metaFont="system"/>
+                        </buttonCell>
+                        <connections>
+                            <action selector="toggleResultView:" target="33" id="126"/>
+                        </connections>
+                    </button>
+                    <customView id="32" customClass="QSCollectingSearchObjectView">
+                        <rect key="frame" x="58" y="219" width="346" height="52"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                        <connections>
+                            <outlet property="nextKeyView" destination="33" id="95"/>
+                        </connections>
+                    </customView>
+                    <customView id="33" customClass="QSSearchObjectView">
+                        <rect key="frame" x="58" y="136" width="346" height="52"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                        <connections>
+                            <outlet property="nextKeyView" destination="34" id="96"/>
+                        </connections>
+                    </customView>
+                    <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="NO" id="45">
+                        <rect key="frame" x="262" y="195" width="129" height="14"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
+                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="No items" id="184">
+                            <font key="font" metaFont="smallSystemBold"/>
+                            <color key="textColor" name="controlShadowColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
+                    <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="NO" id="46">
+                        <rect key="frame" x="262" y="281" width="129" height="14"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
+                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="No items" id="185">
+                            <font key="font" metaFont="smallSystemBold"/>
+                            <color key="textColor" name="controlShadowColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
+                    <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="NO" id="47">
+                        <rect key="frame" x="54" y="17" width="285" height="16"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES"/>
+                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Command Summary" id="186">
+                            <font key="font" metaFont="smallSystem"/>
+                            <color key="textColor" white="0.0" alpha="0.5" colorSpace="calibratedWhite"/>
+                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
+                    <button id="55" customClass="QSMenuButton">
+                        <rect key="frame" x="442" y="281" width="24" height="20"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
+                        <buttonCell key="cell" type="bevel" bezelStyle="regularSquare" image="Button-GearMenu" imagePosition="only" alignment="center" inset="2" id="187">
+                            <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
+                            <font key="font" metaFont="label"/>
+                        </buttonCell>
+                    </button>
+                    <progressIndicator horizontalHuggingPriority="750" verticalHuggingPriority="750" maxValue="100" bezeled="NO" indeterminate="YES" controlSize="small" style="spinning" id="99">
+                        <rect key="frame" x="4" y="5" width="16" height="16"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </progressIndicator>
+                    <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="NO" id="117">
+                        <rect key="frame" x="55" y="195" width="91" height="16"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" state="on" alignment="left" placeholderString="Action" id="188">
+                            <font key="font" metaFont="smallSystemBold"/>
+                            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
+                    <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="NO" id="118">
+                        <rect key="frame" x="55" y="280" width="91" height="15"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                        <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" state="on" alignment="left" placeholderString="Subject" id="189">
+                            <font key="font" metaFont="smallSystemBold"/>
+                            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
+                    <customView id="137" customClass="QSFadingView">
+                        <rect key="frame" x="52" y="43" width="361" height="87"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                        <subviews>
+                            <box title="Title" titlePosition="noTitle" id="177">
+                                <rect key="frame" x="-1" y="2" width="360" height="66"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <view key="contentView" id="ylH-Ac-HN4">
+                                    <rect key="frame" x="2" y="2" width="356" height="62"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                    <subviews>
+                                        <customView id="34" customClass="QSCollectingSearchObjectView">
+                                            <rect key="frame" x="5" y="6" width="346" height="52"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <connections>
+                                                <outlet property="nextKeyView" destination="22" id="101"/>
+                                            </connections>
+                                        </customView>
+                                    </subviews>
+                                </view>
+                            </box>
+                            <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="NO" id="116">
+                                <rect key="frame" x="3" y="69" width="96" height="16"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" state="on" alignment="left" placeholderString="Object" id="192">
+                                    <font key="font" metaFont="smallSystemBold"/>
+                                    <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
+                            <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="NO" id="44">
+                                <rect key="frame" x="210" y="70" width="129" height="14"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="No items" id="191">
+                                    <font key="font" metaFont="smallSystemBold"/>
+                                    <color key="textColor" name="controlShadowColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
+                            <button horizontalHuggingPriority="750" verticalHuggingPriority="750" id="31">
+                                <rect key="frame" x="343" y="71" width="13" height="13"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <buttonCell key="cell" type="disclosureTriangle" bezelStyle="disclosure" imagePosition="above" alignment="left" borderStyle="border" inset="2" id="190">
+                                    <behavior key="behavior" pushIn="YES" changeBackground="YES" changeGray="YES" lightByContents="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                                <connections>
+                                    <action selector="toggleResultView:" target="34" id="125"/>
+                                </connections>
+                            </button>
+                        </subviews>
+                    </customView>
+                </subviews>
+            </view>
+            <connections>
+                <outlet property="delegate" destination="-2" id="98"/>
+                <outlet property="initialFirstResponder" destination="32" id="97"/>
+            </connections>
+        </window>
+    </objects>
+    <resources>
+        <image name="Button-GearMenu" width="20" height="12"/>
+    </resources>
+</document>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/ca-ES.lproj/QSCatalogPreset.name.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/ca-ES.lproj/QSCatalogPreset.name.strings
@@ -114,12 +114,6 @@
     <string>Comandaments interns</string>
     <key>QSPresetInternalObjects</key>
     <string>Objectes interns</string>
-    <key>QSPresetIEBookmarks</key>
-    <string>Marcadors de l&apos;Internet Explorer</string>
-    <key>QSPresetIEGroup</key>
-    <string>Internet Explorer</string>
-    <key>QSPresetIEHistory</key>
-    <string>Historial de l&apos;Internet Explorer</string>
     <key>QSPresetILifeGroup</key>
     <string>iLife</string>
     <key>QSPresetITunesGroup</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/cs.lproj/QSCatalogPreset.name.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/cs.lproj/QSCatalogPreset.name.strings
@@ -114,12 +114,6 @@
     <string>Vnitřní příkazy</string>
     <key>QSPresetInternalObjects</key>
     <string>Vnitřní objekty</string>
-    <key>QSPresetIEBookmarks</key>
-    <string>Záložky Internet Explorer</string>
-    <key>QSPresetIEGroup</key>
-    <string>Internet Explorer</string>
-    <key>QSPresetIEHistory</key>
-    <string>Historie Internet Explorer</string>
     <key>QSPresetILifeGroup</key>
     <string>iLife</string>
     <key>QSPresetITunesGroup</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/de.lproj/QSCatalogPreset.name.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/de.lproj/QSCatalogPreset.name.strings
@@ -114,12 +114,6 @@
     <string>Interne Befehle</string>
     <key>QSPresetInternalObjects</key>
     <string>Interne Objekte</string>
-    <key>QSPresetIEBookmarks</key>
-    <string>Internet Explorer Lesezeichen</string>
-    <key>QSPresetIEGroup</key>
-    <string>Internet Explorer</string>
-    <key>QSPresetIEHistory</key>
-    <string>Internet Explorer Verlauf</string>
     <key>QSPresetILifeGroup</key>
     <string>iLife</string>
     <key>QSPresetITunesGroup</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/en-GB.lproj/QSCatalogPreset.name.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/en-GB.lproj/QSCatalogPreset.name.strings
@@ -112,12 +112,6 @@
 	<string>Internal Commands</string>
     <key>QSPresetInternalObjects</key>
     <string>Internal Objects</string>
-	<key>QSPresetIEBookmarks</key>
-	<string>Internet Explorer Bookmarks</string>
-	<key>QSPresetIEGroup</key>
-	<string>Internet Explorer</string>
-	<key>QSPresetIEHistory</key>
-	<string>Internet Explorer History</string>
 	<key>QSPresetILifeGroup</key>
 	<string>iLife</string>
 	<key>QSPresetITunesGroup</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/en.lproj/QSCatalogPreset.name.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/en.lproj/QSCatalogPreset.name.strings
@@ -112,12 +112,6 @@
 	<string>Internal Commands</string>
     <key>QSPresetInternalObjects</key>
     <string>Internal Objects</string>
-	<key>QSPresetIEBookmarks</key>
-	<string>Internet Explorer Bookmarks</string>
-	<key>QSPresetIEGroup</key>
-	<string>Internet Explorer</string>
-	<key>QSPresetIEHistory</key>
-	<string>Internet Explorer History</string>
 	<key>QSPresetILifeGroup</key>
 	<string>iLife</string>
 	<key>QSPresetITunesGroup</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/es-ES.lproj/QSCatalogPreset.name.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/es-ES.lproj/QSCatalogPreset.name.strings
@@ -114,12 +114,6 @@
     <string>Comandos Internos</string>
     <key>QSPresetInternalObjects</key>
     <string>Objetos Internos</string>
-    <key>QSPresetIEBookmarks</key>
-    <string>Marcadores de Internet Explorer</string>
-    <key>QSPresetIEGroup</key>
-    <string>Internet Explorer</string>
-    <key>QSPresetIEHistory</key>
-    <string>Historia de Internet Explorer</string>
     <key>QSPresetILifeGroup</key>
     <string>iLife</string>
     <key>QSPresetITunesGroup</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/es-MX.lproj/QSCatalogPreset.name.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/es-MX.lproj/QSCatalogPreset.name.strings
@@ -112,12 +112,6 @@
 	<string>Internal Commands</string>
     <key>QSPresetInternalObjects</key>
     <string>Internal Objects</string>
-	<key>QSPresetIEBookmarks</key>
-	<string>Internet Explorer Bookmarks</string>
-	<key>QSPresetIEGroup</key>
-	<string>Internet Explorer</string>
-	<key>QSPresetIEHistory</key>
-	<string>Internet Explorer History</string>
 	<key>QSPresetILifeGroup</key>
 	<string>iLife</string>
 	<key>QSPresetITunesGroup</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/es.lproj/QSCatalogPreset.name.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/es.lproj/QSCatalogPreset.name.strings
@@ -114,12 +114,6 @@
     <string>Comandos Internos</string>
     <key>QSPresetInternalObjects</key>
     <string>Objetos Internos</string>
-    <key>QSPresetIEBookmarks</key>
-    <string>Marcadores de Internet Explorer</string>
-    <key>QSPresetIEGroup</key>
-    <string>Internet Explorer</string>
-    <key>QSPresetIEHistory</key>
-    <string>Historia de Internet Explorer</string>
     <key>QSPresetILifeGroup</key>
     <string>iLife</string>
     <key>QSPresetITunesGroup</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/et.lproj/QSCatalogPreset.name.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/et.lproj/QSCatalogPreset.name.strings
@@ -112,12 +112,6 @@
 	<string>Internal Commands</string>
     <key>QSPresetInternalObjects</key>
     <string>Internal Objects</string>
-	<key>QSPresetIEBookmarks</key>
-	<string>Internet Explorer Bookmarks</string>
-	<key>QSPresetIEGroup</key>
-	<string>Internet Explorer</string>
-	<key>QSPresetIEHistory</key>
-	<string>Internet Explorer History</string>
 	<key>QSPresetILifeGroup</key>
 	<string>iLife</string>
 	<key>QSPresetITunesGroup</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/fi.lproj/QSCatalogPreset.name.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/fi.lproj/QSCatalogPreset.name.strings
@@ -112,12 +112,6 @@
 	<string>Internal Commands</string>
     <key>QSPresetInternalObjects</key>
     <string>Internal Objects</string>
-	<key>QSPresetIEBookmarks</key>
-	<string>Internet Explorer Bookmarks</string>
-	<key>QSPresetIEGroup</key>
-	<string>Internet Explorer</string>
-	<key>QSPresetIEHistory</key>
-	<string>Internet Explorer History</string>
 	<key>QSPresetILifeGroup</key>
 	<string>iLife</string>
 	<key>QSPresetITunesGroup</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/fr.lproj/QSCatalogPreset.name.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/fr.lproj/QSCatalogPreset.name.strings
@@ -114,12 +114,6 @@
     <string>Commandes internes</string>
     <key>QSPresetInternalObjects</key>
     <string>Objets internes</string>
-    <key>QSPresetIEBookmarks</key>
-    <string>Favoris d&apos;Internet Explorer</string>
-    <key>QSPresetIEGroup</key>
-    <string>Internet Explorer</string>
-    <key>QSPresetIEHistory</key>
-    <string>Historique d&apos;Internet Explorer</string>
     <key>QSPresetILifeGroup</key>
     <string>iLife</string>
     <key>QSPresetITunesGroup</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/id.lproj/QSCatalogPreset.name.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/id.lproj/QSCatalogPreset.name.strings
@@ -114,12 +114,6 @@
     <string>Perintah Dalam</string>
     <key>QSPresetInternalObjects</key>
     <string>Obyek Dalam</string>
-    <key>QSPresetIEBookmarks</key>
-    <string>Penanda Internet Explorer</string>
-    <key>QSPresetIEGroup</key>
-    <string>Internet Explorer</string>
-    <key>QSPresetIEHistory</key>
-    <string>Riwayat Internet Explorer</string>
     <key>QSPresetILifeGroup</key>
     <string>iLife</string>
     <key>QSPresetITunesGroup</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/it.lproj/QSCatalogPreset.name.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/it.lproj/QSCatalogPreset.name.strings
@@ -114,12 +114,6 @@
     <string>Comandi Interni</string>
     <key>QSPresetInternalObjects</key>
     <string>Oggetti Interni</string>
-    <key>QSPresetIEBookmarks</key>
-    <string>Preferiti Internet Explorer</string>
-    <key>QSPresetIEGroup</key>
-    <string>Internet Explorer</string>
-    <key>QSPresetIEHistory</key>
-    <string>Cronologia Internet Explorer</string>
     <key>QSPresetILifeGroup</key>
     <string>iLife</string>
     <key>QSPresetITunesGroup</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/ja.lproj/QSCatalogPreset.name.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/ja.lproj/QSCatalogPreset.name.strings
@@ -112,12 +112,6 @@
 	<string>Internal Commands</string>
     <key>QSPresetInternalObjects</key>
     <string>Internal Objects</string>
-	<key>QSPresetIEBookmarks</key>
-	<string>Internet Explorer Bookmarks</string>
-	<key>QSPresetIEGroup</key>
-	<string>Internet Explorer</string>
-	<key>QSPresetIEHistory</key>
-	<string>Internet Explorer History</string>
 	<key>QSPresetILifeGroup</key>
 	<string>iLife</string>
 	<key>QSPresetITunesGroup</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/ko.lproj/QSCatalogPreset.name.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/ko.lproj/QSCatalogPreset.name.strings
@@ -114,12 +114,6 @@
     <string>내부 명령</string>
     <key>QSPresetInternalObjects</key>
     <string>내부 객체</string>
-    <key>QSPresetIEBookmarks</key>
-    <string>Internet Explorer 책갈피</string>
-    <key>QSPresetIEGroup</key>
-    <string>Internet Explorer</string>
-    <key>QSPresetIEHistory</key>
-    <string>Internet Explorer 방문 기록</string>
     <key>QSPresetILifeGroup</key>
     <string>iLife</string>
     <key>QSPresetITunesGroup</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/nb-NO.lproj/QSCatalogPreset.name.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/nb-NO.lproj/QSCatalogPreset.name.strings
@@ -112,12 +112,6 @@
 	<string>Internal Commands</string>
     <key>QSPresetInternalObjects</key>
     <string>Internal Objects</string>
-	<key>QSPresetIEBookmarks</key>
-	<string>Internet Explorer Bookmarks</string>
-	<key>QSPresetIEGroup</key>
-	<string>Internet Explorer</string>
-	<key>QSPresetIEHistory</key>
-	<string>Internet Explorer History</string>
 	<key>QSPresetILifeGroup</key>
 	<string>iLife</string>
 	<key>QSPresetITunesGroup</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/nl.lproj/QSCatalogPreset.name.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/nl.lproj/QSCatalogPreset.name.strings
@@ -112,12 +112,6 @@
 	<string>Internal Commands</string>
     <key>QSPresetInternalObjects</key>
     <string>Internal Objects</string>
-	<key>QSPresetIEBookmarks</key>
-	<string>Internet Explorer Bookmarks</string>
-	<key>QSPresetIEGroup</key>
-	<string>Internet Explorer</string>
-	<key>QSPresetIEHistory</key>
-	<string>Internet Explorer History</string>
 	<key>QSPresetILifeGroup</key>
 	<string>iLife</string>
 	<key>QSPresetITunesGroup</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/pl.lproj/QSCatalogPreset.name.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/pl.lproj/QSCatalogPreset.name.strings
@@ -114,12 +114,6 @@
     <string>Polecenia wewnętrzne</string>
     <key>QSPresetInternalObjects</key>
     <string>Objekty wewnętrzne</string>
-    <key>QSPresetIEBookmarks</key>
-    <string>Zakładki Internet Explorera</string>
-    <key>QSPresetIEGroup</key>
-    <string>Internet Explorer</string>
-    <key>QSPresetIEHistory</key>
-    <string>Historia Internet Explorera</string>
     <key>QSPresetILifeGroup</key>
     <string>iLife</string>
     <key>QSPresetITunesGroup</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/pt-BR.lproj/QSCatalogPreset.name.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/pt-BR.lproj/QSCatalogPreset.name.strings
@@ -112,12 +112,6 @@
 	<string>Internal Commands</string>
     <key>QSPresetInternalObjects</key>
     <string>Internal Objects</string>
-	<key>QSPresetIEBookmarks</key>
-	<string>Internet Explorer Bookmarks</string>
-	<key>QSPresetIEGroup</key>
-	<string>Internet Explorer</string>
-	<key>QSPresetIEHistory</key>
-	<string>Internet Explorer History</string>
 	<key>QSPresetILifeGroup</key>
 	<string>iLife</string>
 	<key>QSPresetITunesGroup</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/ru.lproj/QSCatalogPreset.name.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/ru.lproj/QSCatalogPreset.name.strings
@@ -114,12 +114,6 @@
     <string>Внутренние команды</string>
     <key>QSPresetInternalObjects</key>
     <string>Внутренние объекты</string>
-    <key>QSPresetIEBookmarks</key>
-    <string>Закладки Internet Explorer</string>
-    <key>QSPresetIEGroup</key>
-    <string>Internet Explorer</string>
-    <key>QSPresetIEHistory</key>
-    <string>История Internet Explorer</string>
     <key>QSPresetILifeGroup</key>
     <string>iLife</string>
     <key>QSPresetITunesGroup</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/sv.lproj/QSCatalogPreset.name.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/sv.lproj/QSCatalogPreset.name.strings
@@ -114,12 +114,6 @@
     <string>Interna kommandon</string>
     <key>QSPresetInternalObjects</key>
     <string>Interna objekt</string>
-    <key>QSPresetIEBookmarks</key>
-    <string>Internet Explorers bokmärken</string>
-    <key>QSPresetIEGroup</key>
-    <string>Internet Explorer</string>
-    <key>QSPresetIEHistory</key>
-    <string>Internet Explorer-historik</string>
     <key>QSPresetILifeGroup</key>
     <string>iLife</string>
     <key>QSPresetITunesGroup</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/th.lproj/QSCatalogPreset.name.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/th.lproj/QSCatalogPreset.name.strings
@@ -112,12 +112,6 @@
 	<string>Internal Commands</string>
     <key>QSPresetInternalObjects</key>
     <string>Internal Objects</string>
-	<key>QSPresetIEBookmarks</key>
-	<string>Internet Explorer Bookmarks</string>
-	<key>QSPresetIEGroup</key>
-	<string>Internet Explorer</string>
-	<key>QSPresetIEHistory</key>
-	<string>Internet Explorer History</string>
 	<key>QSPresetILifeGroup</key>
 	<string>iLife</string>
 	<key>QSPresetITunesGroup</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/tr.lproj/QSCatalogPreset.name.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/tr.lproj/QSCatalogPreset.name.strings
@@ -114,12 +114,6 @@
     <string>İçsel Komutlar</string>
     <key>QSPresetInternalObjects</key>
     <string>İçsel Nesneler</string>
-    <key>QSPresetIEBookmarks</key>
-    <string>Internet Explorer Yer İmleri</string>
-    <key>QSPresetIEGroup</key>
-    <string>Internet Explorer</string>
-    <key>QSPresetIEHistory</key>
-    <string>Internet Explorer Geçmişi</string>
     <key>QSPresetILifeGroup</key>
     <string>iLife</string>
     <key>QSPresetITunesGroup</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/zh-Hans.lproj/QSCatalogPreset.name.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/zh-Hans.lproj/QSCatalogPreset.name.strings
@@ -114,12 +114,6 @@
     <string>内部命令</string>
     <key>QSPresetInternalObjects</key>
     <string>内部对象</string>
-    <key>QSPresetIEBookmarks</key>
-    <string>IE书签</string>
-    <key>QSPresetIEGroup</key>
-    <string>IE浏览器</string>
-    <key>QSPresetIEHistory</key>
-    <string>IE历史记录</string>
     <key>QSPresetILifeGroup</key>
     <string>iLife</string>
     <key>QSPresetITunesGroup</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/zh-Hant.lproj/QSCatalogPreset.name.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/zh-Hant.lproj/QSCatalogPreset.name.strings
@@ -114,12 +114,6 @@
     <string>內部指令</string>
     <key>QSPresetInternalObjects</key>
     <string>內部物件</string>
-    <key>QSPresetIEBookmarks</key>
-    <string>Internet Explorer 書籤</string>
-    <key>QSPresetIEGroup</key>
-    <string>Internet Explorer</string>
-    <key>QSPresetIEHistory</key>
-    <string>Internet Explorer 瀏覽紀錄</string>
     <key>QSPresetILifeGroup</key>
     <string>iLife</string>
     <key>QSPresetITunesGroup</key>

--- a/Quicksilver/PlugIns-Main/QSHotKeyPlugIn/QSHotKeyTrigger.xib
+++ b/Quicksilver/PlugIns-Main/QSHotKeyPlugIn/QSHotKeyTrigger.xib
@@ -1,1402 +1,208 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<archive type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="8.00">
-	<data>
-		<int key="IBDocument.SystemTarget">1070</int>
-		<string key="IBDocument.SystemVersion">14E46</string>
-		<string key="IBDocument.InterfaceBuilderVersion">7706</string>
-		<string key="IBDocument.AppKitVersion">1348.17</string>
-		<string key="IBDocument.HIToolboxVersion">758.70</string>
-		<object class="NSMutableDictionary" key="IBDocument.PluginVersions">
-			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin</string>
-			<string key="NS.object.0">7706</string>
-		</object>
-		<array key="IBDocument.IntegratedClassDependencies">
-			<string>NSButton</string>
-			<string>NSButtonCell</string>
-			<string>NSCustomObject</string>
-			<string>NSCustomView</string>
-			<string>NSNumberFormatter</string>
-			<string>NSObjectController</string>
-			<string>NSTextField</string>
-			<string>NSTextFieldCell</string>
-		</array>
-		<array key="IBDocument.PluginDependencies">
-			<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-		</array>
-		<object class="NSMutableDictionary" key="IBDocument.Metadata">
-			<string key="NS.key.0">PluginDependencyRecalculationVersion</string>
-			<integer value="1" key="NS.object.0"/>
-		</object>
-		<array class="NSMutableArray" key="IBDocument.RootObjects" id="470402929">
-			<object class="NSCustomObject" id="659170060">
-				<string key="NSClassName">QSHotKeyTriggerManager</string>
-			</object>
-			<object class="NSCustomObject" id="200110089">
-				<string key="NSClassName">FirstResponder</string>
-			</object>
-			<object class="NSCustomObject" id="409163800">
-				<string key="NSClassName">NSApplication</string>
-			</object>
-			<object class="NSCustomView" id="208555038">
-				<reference key="NSNextResponder"/>
-				<int key="NSvFlags">256</int>
-				<array class="NSMutableArray" key="NSSubviews">
-					<object class="NSTextField" id="61054822">
-						<reference key="NSNextResponder" ref="208555038"/>
-						<int key="NSvFlags">264</int>
-						<string key="NSFrame">{{17, 327}, {76, 14}}</string>
-						<reference key="NSSuperview" ref="208555038"/>
-						<reference key="NSWindow"/>
-						<bool key="NSEnabled">YES</bool>
-						<object class="NSTextFieldCell" key="NSCell" id="110623668">
-							<int key="NSCellFlags">67108864</int>
-							<int key="NSCellFlags2">272629760</int>
-							<string key="NSContents">Shortcut:</string>
-							<object class="NSFont" key="NSSupport" id="27">
-								<bool key="IBIsSystemFont">YES</bool>
-								<double key="NSSize">11</double>
-								<int key="NSfFlags">3357</int>
-							</object>
-							<reference key="NSControlView" ref="61054822"/>
-							<object class="NSColor" key="NSBackgroundColor" id="808007310">
-								<int key="NSColorSpace">6</int>
-								<string key="NSCatalogName">System</string>
-								<string key="NSColorName">controlColor</string>
-								<object class="NSColor" key="NSColor">
-									<int key="NSColorSpace">3</int>
-									<bytes key="NSWhite">MC42NjY2NjY2NjY3AA</bytes>
-								</object>
-							</object>
-							<object class="NSColor" key="NSTextColor" id="939436145">
-								<int key="NSColorSpace">6</int>
-								<string key="NSCatalogName">System</string>
-								<string key="NSColorName">controlTextColor</string>
-								<object class="NSColor" key="NSColor" id="378956607">
-									<int key="NSColorSpace">3</int>
-									<bytes key="NSWhite">MAA</bytes>
-								</object>
-							</object>
-						</object>
-						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-						<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-					</object>
-					<object class="NSButton" id="470235144">
-						<reference key="NSNextResponder" ref="208555038"/>
-						<int key="NSvFlags">264</int>
-						<string key="NSFrame">{{102, 207}, {66, 18}}</string>
-						<reference key="NSSuperview" ref="208555038"/>
-						<reference key="NSWindow"/>
-						<bool key="NSEnabled">YES</bool>
-						<object class="NSButtonCell" key="NSCell" id="71229638">
-							<int key="NSCellFlags">67108864</int>
-							<int key="NSCellFlags2">131072</int>
-							<string key="NSContents">Hold for</string>
-							<object class="NSFont" key="NSSupport" id="26">
-								<bool key="IBIsSystemFont">YES</bool>
-								<double key="NSSize">11</double>
-								<int key="NSfFlags">3100</int>
-							</object>
-							<reference key="NSControlView" ref="470235144"/>
-							<int key="NSButtonFlags">1211912448</int>
-							<int key="NSButtonFlags2">2</int>
-							<object class="NSCustomResource" key="NSNormalImage" id="664054870">
-								<string key="NSClassName">NSImage</string>
-								<string key="NSResourceName">NSSwitch</string>
-							</object>
-							<object class="NSButtonImageSource" key="NSAlternateImage" id="938520051">
-								<string key="NSImageName">NSSwitch</string>
-							</object>
-							<string key="NSAlternateContents"/>
-							<string key="NSKeyEquivalent"/>
-							<int key="NSPeriodicDelay">200</int>
-							<int key="NSPeriodicInterval">25</int>
-						</object>
-						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-					</object>
-					<object class="NSTextField" id="594696590">
-						<reference key="NSNextResponder" ref="208555038"/>
-						<int key="NSvFlags">264</int>
-						<string key="NSFrame">{{174, 207}, {45, 19}}</string>
-						<reference key="NSSuperview" ref="208555038"/>
-						<reference key="NSWindow"/>
-						<bool key="NSEnabled">YES</bool>
-						<object class="NSTextFieldCell" key="NSCell" id="61355775">
-							<int key="NSCellFlags">-1804599231</int>
-							<int key="NSCellFlags2">138544128</int>
-							<reference key="NSSupport" ref="26"/>
-							<object class="NSNumberFormatter" key="NSFormatter" id="174257246">
-								<dictionary class="NSMutableDictionary" key="NS.attributes">
-									<boolean value="YES" key="allowsFloats"/>
-									<object class="NSAttributedString" key="attributedStringForNil" id="674570532">
-										<string key="NSString"/>
-									</object>
-									<object class="NSAttributedString" key="attributedStringForNotANumber" id="934987511">
-										<string key="NSString">NaN</string>
-										<dictionary key="NSAttributes" id="744140775"/>
-									</object>
-									<object class="NSAttributedString" key="attributedStringForZero" id="403661526">
-										<string key="NSString">0 s</string>
-										<reference key="NSAttributes" ref="744140775"/>
-									</object>
-									<string key="decimalSeparator">.</string>
-									<integer value="1000" key="formatterBehavior"/>
-									<string key="groupingSeparator">,</string>
-									<object class="NSLocale" key="locale" id="82796808">
-										<string key="NS.identifier"/>
-									</object>
-									<string key="negativeFormat">-#,##0 s</string>
-									<string key="positiveFormat">#,##0.0 s</string>
-									<boolean value="YES" key="usesGroupingSeparator"/>
-								</dictionary>
-								<string key="NS.positiveformat">#,##0.0 s</string>
-								<string key="NS.negativeformat">-#,##0 s</string>
-								<nil key="NS.positiveattrs"/>
-								<nil key="NS.negativeattrs"/>
-								<reference key="NS.zero" ref="403661526"/>
-								<reference key="NS.nil" ref="674570532"/>
-								<reference key="NS.nan" ref="934987511"/>
-								<object class="NSDecimalNumberPlaceholder" key="NS.min" id="516604803">
-									<int key="NS.exponent">0</int>
-									<int key="NS.length">0</int>
-									<bool key="NS.negative">YES</bool>
-									<bool key="NS.compact">NO</bool>
-									<int key="NS.mantissa.bo">1</int>
-									<bytes key="NS.mantissa">AAAAAAAAAAAAAAAAAAAAAA</bytes>
-								</object>
-								<reference key="NS.max" ref="516604803"/>
-								<nil key="NS.rounding"/>
-								<string key="NS.decimal">.</string>
-								<string key="NS.thousand">,</string>
-								<bool key="NS.hasthousands">YES</bool>
-								<bool key="NS.localized">NO</bool>
-								<bool key="NS.allowsfloats">YES</bool>
-							</object>
-							<string key="NSPlaceholderString">1.0 s</string>
-							<reference key="NSControlView" ref="594696590"/>
-							<bool key="NSDrawsBackground">YES</bool>
-							<object class="NSColor" key="NSBackgroundColor" id="859645078">
-								<int key="NSColorSpace">6</int>
-								<string key="NSCatalogName">System</string>
-								<string key="NSColorName">textBackgroundColor</string>
-								<object class="NSColor" key="NSColor">
-									<int key="NSColorSpace">3</int>
-									<bytes key="NSWhite">MQA</bytes>
-								</object>
-							</object>
-							<object class="NSColor" key="NSTextColor" id="701148532">
-								<int key="NSColorSpace">6</int>
-								<string key="NSCatalogName">System</string>
-								<string key="NSColorName">textColor</string>
-								<reference key="NSColor" ref="378956607"/>
-							</object>
-						</object>
-						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-						<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-					</object>
-					<object class="NSButton" id="1044206565">
-						<reference key="NSNextResponder" ref="208555038"/>
-						<int key="NSvFlags">264</int>
-						<string key="NSFrame">{{102, 282}, {69, 18}}</string>
-						<reference key="NSSuperview" ref="208555038"/>
-						<reference key="NSWindow"/>
-						<bool key="NSEnabled">YES</bool>
-						<object class="NSButtonCell" key="NSCell" id="627227471">
-							<int key="NSCellFlags">67108864</int>
-							<int key="NSCellFlags2">131072</int>
-							<string key="NSContents">On Press</string>
-							<reference key="NSSupport" ref="26"/>
-							<reference key="NSControlView" ref="1044206565"/>
-							<int key="NSButtonFlags">1211912448</int>
-							<int key="NSButtonFlags2">2</int>
-							<reference key="NSNormalImage" ref="664054870"/>
-							<reference key="NSAlternateImage" ref="938520051"/>
-							<string key="NSAlternateContents"/>
-							<string key="NSKeyEquivalent"/>
-							<int key="NSPeriodicDelay">200</int>
-							<int key="NSPeriodicInterval">25</int>
-						</object>
-						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-					</object>
-					<object class="NSButton" id="672561679">
-						<reference key="NSNextResponder" ref="208555038"/>
-						<int key="NSvFlags">264</int>
-						<string key="NSFrame">{{102, 242}, {82, 18}}</string>
-						<reference key="NSSuperview" ref="208555038"/>
-						<reference key="NSWindow"/>
-						<bool key="NSEnabled">YES</bool>
-						<object class="NSButtonCell" key="NSCell" id="665925228">
-							<int key="NSCellFlags">67108864</int>
-							<int key="NSCellFlags2">131072</int>
-							<string key="NSContents">On Release</string>
-							<reference key="NSSupport" ref="26"/>
-							<reference key="NSControlView" ref="672561679"/>
-							<int key="NSButtonFlags">1211912448</int>
-							<int key="NSButtonFlags2">2</int>
-							<reference key="NSNormalImage" ref="664054870"/>
-							<reference key="NSAlternateImage" ref="938520051"/>
-							<string key="NSAlternateContents"/>
-							<string key="NSKeyEquivalent"/>
-							<int key="NSPeriodicDelay">200</int>
-							<int key="NSPeriodicInterval">25</int>
-						</object>
-						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-					</object>
-					<object class="NSButton" id="830338487">
-						<reference key="NSNextResponder" ref="208555038"/>
-						<int key="NSvFlags">264</int>
-						<string key="NSFrame">{{117, 262}, {91, 18}}</string>
-						<reference key="NSSuperview" ref="208555038"/>
-						<reference key="NSWindow"/>
-						<bool key="NSEnabled">YES</bool>
-						<object class="NSButtonCell" key="NSCell" id="440311382">
-							<int key="NSCellFlags">67108864</int>
-							<int key="NSCellFlags2">131072</int>
-							<string key="NSContents">Repeat every</string>
-							<reference key="NSSupport" ref="26"/>
-							<reference key="NSControlView" ref="830338487"/>
-							<int key="NSButtonFlags">1211912448</int>
-							<int key="NSButtonFlags2">2</int>
-							<reference key="NSNormalImage" ref="664054870"/>
-							<reference key="NSAlternateImage" ref="938520051"/>
-							<string key="NSAlternateContents"/>
-							<string key="NSKeyEquivalent"/>
-							<int key="NSPeriodicDelay">200</int>
-							<int key="NSPeriodicInterval">25</int>
-						</object>
-						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-					</object>
-					<object class="NSTextField" id="405095846">
-						<reference key="NSNextResponder" ref="208555038"/>
-						<int key="NSvFlags">264</int>
-						<string key="NSFrame">{{214, 262}, {45, 19}}</string>
-						<reference key="NSSuperview" ref="208555038"/>
-						<reference key="NSWindow"/>
-						<bool key="NSEnabled">YES</bool>
-						<object class="NSTextFieldCell" key="NSCell" id="597692211">
-							<int key="NSCellFlags">-1804599231</int>
-							<int key="NSCellFlags2">138544128</int>
-							<reference key="NSSupport" ref="26"/>
-							<object class="NSNumberFormatter" key="NSFormatter" id="943429983">
-								<dictionary class="NSMutableDictionary" key="NS.attributes">
-									<boolean value="YES" key="allowsFloats"/>
-									<object class="NSAttributedString" key="attributedStringForNil" id="161427306">
-										<string key="NSString"/>
-									</object>
-									<object class="NSAttributedString" key="attributedStringForNotANumber" id="555549562">
-										<string key="NSString">NaN</string>
-										<reference key="NSAttributes" ref="744140775"/>
-									</object>
-									<object class="NSAttributedString" key="attributedStringForZero" id="881302709">
-										<string key="NSString">0 s</string>
-										<reference key="NSAttributes" ref="744140775"/>
-									</object>
-									<string key="decimalSeparator">.</string>
-									<integer value="1000" key="formatterBehavior"/>
-									<string key="groupingSeparator">,</string>
-									<reference key="locale" ref="82796808"/>
-									<string key="negativeFormat">-#,##0 s</string>
-									<string key="positiveFormat">#,##0.0 s</string>
-									<boolean value="YES" key="usesGroupingSeparator"/>
-								</dictionary>
-								<string key="NS.positiveformat">#,##0.0 s</string>
-								<string key="NS.negativeformat">-#,##0 s</string>
-								<nil key="NS.positiveattrs"/>
-								<nil key="NS.negativeattrs"/>
-								<reference key="NS.zero" ref="881302709"/>
-								<reference key="NS.nil" ref="161427306"/>
-								<reference key="NS.nan" ref="555549562"/>
-								<reference key="NS.min" ref="516604803"/>
-								<reference key="NS.max" ref="516604803"/>
-								<nil key="NS.rounding"/>
-								<string key="NS.decimal">.</string>
-								<string key="NS.thousand">,</string>
-								<bool key="NS.hasthousands">YES</bool>
-								<bool key="NS.localized">NO</bool>
-								<bool key="NS.allowsfloats">YES</bool>
-							</object>
-							<string key="NSPlaceholderString">1.0 s</string>
-							<reference key="NSControlView" ref="405095846"/>
-							<bool key="NSDrawsBackground">YES</bool>
-							<reference key="NSBackgroundColor" ref="859645078"/>
-							<reference key="NSTextColor" ref="701148532"/>
-						</object>
-						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-						<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-					</object>
-					<object class="NSTextField" id="370867290">
-						<reference key="NSNextResponder" ref="208555038"/>
-						<int key="NSvFlags">264</int>
-						<string key="NSFrame">{{17, 284}, {62, 14}}</string>
-						<reference key="NSSuperview" ref="208555038"/>
-						<reference key="NSWindow"/>
-						<bool key="NSEnabled">YES</bool>
-						<object class="NSTextFieldCell" key="NSCell" id="256236275">
-							<int key="NSCellFlags">67108864</int>
-							<int key="NSCellFlags2">272629760</int>
-							<string key="NSContents">Activate:</string>
-							<reference key="NSSupport" ref="27"/>
-							<reference key="NSControlView" ref="370867290"/>
-							<reference key="NSBackgroundColor" ref="808007310"/>
-							<reference key="NSTextColor" ref="939436145"/>
-						</object>
-						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-						<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-					</object>
-					<object class="NSTextField" id="318892273">
-						<reference key="NSNextResponder" ref="208555038"/>
-						<int key="NSvFlags">264</int>
-						<string key="NSFrame">{{17, 210}, {76, 14}}</string>
-						<reference key="NSSuperview" ref="208555038"/>
-						<reference key="NSWindow"/>
-						<bool key="NSEnabled">YES</bool>
-						<object class="NSTextFieldCell" key="NSCell" id="305087610">
-							<int key="NSCellFlags">67108864</int>
-							<int key="NSCellFlags2">4194304</int>
-							<string key="NSContents">Delay:</string>
-							<reference key="NSSupport" ref="27"/>
-							<reference key="NSControlView" ref="318892273"/>
-							<reference key="NSBackgroundColor" ref="808007310"/>
-							<reference key="NSTextColor" ref="939436145"/>
-						</object>
-						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-						<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-					</object>
-					<object class="NSButton" id="939804473">
-						<reference key="NSNextResponder" ref="208555038"/>
-						<int key="NSvFlags">264</int>
-						<string key="NSFrame">{{102, 172}, {96, 18}}</string>
-						<reference key="NSSuperview" ref="208555038"/>
-						<reference key="NSWindow"/>
-						<bool key="NSEnabled">YES</bool>
-						<object class="NSButtonCell" key="NSCell" id="196510067">
-							<int key="NSCellFlags">67108864</int>
-							<int key="NSCellFlags2">131072</int>
-							<string key="NSContents">Show Window</string>
-							<reference key="NSSupport" ref="26"/>
-							<reference key="NSControlView" ref="939804473"/>
-							<int key="NSButtonFlags">1211912448</int>
-							<int key="NSButtonFlags2">2</int>
-							<reference key="NSNormalImage" ref="664054870"/>
-							<reference key="NSAlternateImage" ref="938520051"/>
-							<string key="NSAlternateContents"/>
-							<string key="NSKeyEquivalent"/>
-							<int key="NSPeriodicDelay">200</int>
-							<int key="NSPeriodicInterval">25</int>
-						</object>
-						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-					</object>
-					<object class="NSTextField" id="726617493">
-						<reference key="NSNextResponder" ref="208555038"/>
-						<int key="NSvFlags">264</int>
-						<string key="NSFrame">{{17, 174}, {76, 14}}</string>
-						<reference key="NSSuperview" ref="208555038"/>
-						<reference key="NSWindow"/>
-						<bool key="NSEnabled">YES</bool>
-						<object class="NSTextFieldCell" key="NSCell" id="12830939">
-							<int key="NSCellFlags">67108864</int>
-							<int key="NSCellFlags2">4194304</int>
-							<string key="NSContents">Display:</string>
-							<reference key="NSSupport" ref="27"/>
-							<reference key="NSControlView" ref="726617493"/>
-							<reference key="NSBackgroundColor" ref="808007310"/>
-							<reference key="NSTextColor" ref="939436145"/>
-						</object>
-						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-						<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-					</object>
-					<object class="NSTextField" id="450616021">
-						<reference key="NSNextResponder" ref="208555038"/>
-						<int key="NSvFlags">264</int>
-						<string key="NSFrame">{{105, 324}, {76, 19}}</string>
-						<reference key="NSSuperview" ref="208555038"/>
-						<reference key="NSWindow"/>
-						<bool key="NSEnabled">YES</bool>
-						<object class="NSTextFieldCell" key="NSCell" id="387881420">
-							<int key="NSCellFlags">-1804599231</int>
-							<int key="NSCellFlags2">138544128</int>
-							<string key="NSContents"/>
-							<reference key="NSSupport" ref="26"/>
-							<string key="NSPlaceholderString">none</string>
-							<reference key="NSControlView" ref="450616021"/>
-							<bool key="NSDrawsBackground">YES</bool>
-							<reference key="NSBackgroundColor" ref="859645078"/>
-							<reference key="NSTextColor" ref="701148532"/>
-						</object>
-						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-						<int key="NSTextFieldAlignmentRectInsetsVersion">1</int>
-					</object>
-					<object class="NSButton" id="719652142">
-						<reference key="NSNextResponder" ref="208555038"/>
-						<int key="NSvFlags">264</int>
-						<string key="NSFrame">{{183, 323}, {29, 21}}</string>
-						<reference key="NSSuperview" ref="208555038"/>
-						<reference key="NSWindow"/>
-						<bool key="NSEnabled">YES</bool>
-						<object class="NSButtonCell" key="NSCell" id="4068953">
-							<int key="NSCellFlags">67108864</int>
-							<int key="NSCellFlags2">134479872</int>
-							<string key="NSContents">Edit</string>
-							<object class="NSFont" key="NSSupport">
-								<bool key="IBIsSystemFont">YES</bool>
-								<double key="NSSize">9.5</double>
-								<int key="NSfFlags">1044</int>
-							</object>
-							<reference key="NSControlView" ref="719652142"/>
-							<int key="NSButtonFlags">914505728</int>
-							<int key="NSButtonFlags2">34</int>
-							<object class="NSFont" key="NSAlternateImage">
-								<string key="NSName">LucidaGrande</string>
-								<double key="NSSize">9.5</double>
-								<int key="NSfFlags">16</int>
-							</object>
-							<string key="NSAlternateContents"/>
-							<object class="NSMutableString" key="NSKeyEquivalent">
-								<characters key="NS.bytes"/>
-							</object>
-							<int key="NSPeriodicDelay">200</int>
-							<int key="NSPeriodicInterval">25</int>
-						</object>
-						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-					</object>
-				</array>
-				<string key="NSFrameSize">{320, 365}</string>
-				<reference key="NSSuperview"/>
-				<reference key="NSWindow"/>
-				<string key="NSClassName">NSView</string>
-				<string key="NSExtension">NSResponder</string>
-			</object>
-			<object class="NSObjectController" id="780705964">
-				<array class="NSMutableArray" key="NSDeclaredKeys">
-					<string>hotKey</string>
-					<string>onPress</string>
-					<string>onRelease</string>
-					<string>onRepeat</string>
-					<string>onRepeatInterval</string>
-					<string>delay</string>
-					<string>delayInterval</string>
-					<string>info.hotKey</string>
-					<string>showWindow</string>
-					<string>triggerOnPress</string>
-					<string>triggerDescription</string>
-				</array>
-				<bool key="NSEditable">YES</bool>
-				<object class="_NSManagedProxy" key="_NSManagedProxy"/>
-			</object>
-		</array>
-		<object class="IBObjectContainer" key="IBDocument.Objects">
-			<array key="connectionRecords">
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">settingsView</string>
-						<reference key="source" ref="659170060"/>
-						<reference key="destination" ref="208555038"/>
-					</object>
-					<int key="connectionID">51</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">hotKeyField</string>
-						<reference key="source" ref="659170060"/>
-						<reference key="destination" ref="450616021"/>
-					</object>
-					<int key="connectionID">193</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: selection.delay</string>
-						<reference key="source" ref="470235144"/>
-						<reference key="destination" ref="780705964"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="470235144"/>
-							<reference key="NSDestination" ref="780705964"/>
-							<string key="NSLabel">value: selection.delay</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">selection.delay</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">138</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">nextKeyView</string>
-						<reference key="source" ref="470235144"/>
-						<reference key="destination" ref="594696590"/>
-					</object>
-					<int key="connectionID">185</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: selection.delayInterval</string>
-						<reference key="source" ref="594696590"/>
-						<reference key="destination" ref="780705964"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="594696590"/>
-							<reference key="NSDestination" ref="780705964"/>
-							<string key="NSLabel">value: selection.delayInterval</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">selection.delayInterval</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">139</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">nextKeyView</string>
-						<reference key="source" ref="594696590"/>
-						<reference key="destination" ref="939804473"/>
-					</object>
-					<int key="connectionID">186</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: selection.onPress</string>
-						<reference key="source" ref="1044206565"/>
-						<reference key="destination" ref="780705964"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="1044206565"/>
-							<reference key="NSDestination" ref="780705964"/>
-							<string key="NSLabel">value: selection.onPress</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">selection.onPress</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">170</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">nextKeyView</string>
-						<reference key="source" ref="1044206565"/>
-						<reference key="destination" ref="830338487"/>
-					</object>
-					<int key="connectionID">172</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: selection.onRelease</string>
-						<reference key="source" ref="672561679"/>
-						<reference key="destination" ref="780705964"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="672561679"/>
-							<reference key="NSDestination" ref="780705964"/>
-							<string key="NSLabel">value: selection.onRelease</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">selection.onRelease</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">135</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">nextKeyView</string>
-						<reference key="source" ref="672561679"/>
-						<reference key="destination" ref="470235144"/>
-					</object>
-					<int key="connectionID">184</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: selection.onRepeat</string>
-						<reference key="source" ref="830338487"/>
-						<reference key="destination" ref="780705964"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="830338487"/>
-							<reference key="NSDestination" ref="780705964"/>
-							<string key="NSLabel">value: selection.onRepeat</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">selection.onRepeat</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">136</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">nextKeyView</string>
-						<reference key="source" ref="830338487"/>
-						<reference key="destination" ref="405095846"/>
-					</object>
-					<int key="connectionID">183</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: selection.onRepeatInterval</string>
-						<reference key="source" ref="405095846"/>
-						<reference key="destination" ref="780705964"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="405095846"/>
-							<reference key="NSDestination" ref="780705964"/>
-							<string key="NSLabel">value: selection.onRepeatInterval</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">selection.onRepeatInterval</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">137</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">nextKeyView</string>
-						<reference key="source" ref="405095846"/>
-						<reference key="destination" ref="672561679"/>
-					</object>
-					<int key="connectionID">171</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">contentObject: currentTrigger.info</string>
-						<reference key="source" ref="780705964"/>
-						<reference key="destination" ref="659170060"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="780705964"/>
-							<reference key="NSDestination" ref="659170060"/>
-							<string key="NSLabel">contentObject: currentTrigger.info</string>
-							<string key="NSBinding">contentObject</string>
-							<string key="NSKeyPath">currentTrigger.info</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">149</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: selection.showWindow</string>
-						<reference key="source" ref="939804473"/>
-						<reference key="destination" ref="780705964"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="939804473"/>
-							<reference key="NSDestination" ref="780705964"/>
-							<string key="NSLabel">value: selection.showWindow</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">selection.showWindow</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">160</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">setButton</string>
-						<reference key="source" ref="450616021"/>
-						<reference key="destination" ref="719652142"/>
-					</object>
-					<int key="connectionID">190</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">set:</string>
-						<reference key="source" ref="450616021"/>
-						<reference key="destination" ref="719652142"/>
-					</object>
-					<int key="connectionID">191</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBBindingConnection" key="connection">
-						<string key="label">value: hotKey</string>
-						<reference key="source" ref="450616021"/>
-						<reference key="destination" ref="659170060"/>
-						<object class="NSNibBindingConnector" key="connector">
-							<reference key="NSSource" ref="450616021"/>
-							<reference key="NSDestination" ref="659170060"/>
-							<string key="NSLabel">value: hotKey</string>
-							<string key="NSBinding">value</string>
-							<string key="NSKeyPath">hotKey</string>
-							<int key="NSNibBindingConnectorVersion">2</int>
-						</object>
-					</object>
-					<int key="connectionID">192</int>
-				</object>
-			</array>
-			<object class="IBMutableOrderedSet" key="objectRecords">
-				<array key="orderedObjects">
-					<object class="IBObjectRecord">
-						<int key="objectID">0</int>
-						<array key="object" id="0"/>
-						<reference key="children" ref="470402929"/>
-						<nil key="parent"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">-2</int>
-						<reference key="object" ref="659170060"/>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">File's Owner</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">-1</int>
-						<reference key="object" ref="200110089"/>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">First Responder</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">5</int>
-						<reference key="object" ref="208555038"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="61054822"/>
-							<reference ref="470235144"/>
-							<reference ref="594696590"/>
-							<reference ref="1044206565"/>
-							<reference ref="672561679"/>
-							<reference ref="830338487"/>
-							<reference ref="405095846"/>
-							<reference ref="370867290"/>
-							<reference ref="318892273"/>
-							<reference ref="939804473"/>
-							<reference ref="726617493"/>
-							<reference ref="450616021"/>
-							<reference ref="719652142"/>
-						</array>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">HotKey Trigger</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">84</int>
-						<reference key="object" ref="61054822"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="110623668"/>
-						</array>
-						<reference key="parent" ref="208555038"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">92</int>
-						<reference key="object" ref="470235144"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="71229638"/>
-						</array>
-						<reference key="parent" ref="208555038"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">93</int>
-						<reference key="object" ref="594696590"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="61355775"/>
-						</array>
-						<reference key="parent" ref="208555038"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">95</int>
-						<reference key="object" ref="1044206565"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="627227471"/>
-						</array>
-						<reference key="parent" ref="208555038"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">96</int>
-						<reference key="object" ref="672561679"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="665925228"/>
-						</array>
-						<reference key="parent" ref="208555038"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">97</int>
-						<reference key="object" ref="830338487"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="440311382"/>
-						</array>
-						<reference key="parent" ref="208555038"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">98</int>
-						<reference key="object" ref="405095846"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="597692211"/>
-						</array>
-						<reference key="parent" ref="208555038"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">116</int>
-						<reference key="object" ref="370867290"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="256236275"/>
-						</array>
-						<reference key="parent" ref="208555038"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">117</int>
-						<reference key="object" ref="318892273"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="305087610"/>
-						</array>
-						<reference key="parent" ref="208555038"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">158</int>
-						<reference key="object" ref="939804473"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="196510067"/>
-						</array>
-						<reference key="parent" ref="208555038"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">179</int>
-						<reference key="object" ref="726617493"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="12830939"/>
-						</array>
-						<reference key="parent" ref="208555038"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">188</int>
-						<reference key="object" ref="450616021"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="387881420"/>
-						</array>
-						<reference key="parent" ref="208555038"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">189</int>
-						<reference key="object" ref="719652142"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="4068953"/>
-						</array>
-						<reference key="parent" ref="208555038"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">126</int>
-						<reference key="object" ref="780705964"/>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">trigger</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">195</int>
-						<reference key="object" ref="110623668"/>
-						<reference key="parent" ref="61054822"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">196</int>
-						<reference key="object" ref="71229638"/>
-						<reference key="parent" ref="470235144"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">197</int>
-						<reference key="object" ref="61355775"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="174257246"/>
-						</array>
-						<reference key="parent" ref="594696590"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">198</int>
-						<reference key="object" ref="627227471"/>
-						<reference key="parent" ref="1044206565"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">199</int>
-						<reference key="object" ref="665925228"/>
-						<reference key="parent" ref="672561679"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">200</int>
-						<reference key="object" ref="440311382"/>
-						<reference key="parent" ref="830338487"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">201</int>
-						<reference key="object" ref="597692211"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="943429983"/>
-						</array>
-						<reference key="parent" ref="405095846"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">202</int>
-						<reference key="object" ref="256236275"/>
-						<reference key="parent" ref="370867290"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">203</int>
-						<reference key="object" ref="305087610"/>
-						<reference key="parent" ref="318892273"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">204</int>
-						<reference key="object" ref="196510067"/>
-						<reference key="parent" ref="939804473"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">205</int>
-						<reference key="object" ref="12830939"/>
-						<reference key="parent" ref="726617493"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">206</int>
-						<reference key="object" ref="387881420"/>
-						<reference key="parent" ref="450616021"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">207</int>
-						<reference key="object" ref="4068953"/>
-						<reference key="parent" ref="719652142"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">94</int>
-						<reference key="object" ref="174257246"/>
-						<reference key="parent" ref="61355775"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">99</int>
-						<reference key="object" ref="943429983"/>
-						<reference key="parent" ref="597692211"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">-3</int>
-						<reference key="object" ref="409163800"/>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">Application</string>
-					</object>
-				</array>
-			</object>
-			<dictionary class="NSMutableDictionary" key="flattenedProperties">
-				<string key="-1.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="-2.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="-3.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="116.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="117.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="126.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<object class="NSMutableDictionary" key="158.IBAttributePlaceholdersKey">
-					<string key="NS.key.0">ToolTip</string>
-					<object class="IBToolTipAttribute" key="NS.object.0">
-						<string key="name">ToolTip</string>
-						<reference key="object" ref="939804473"/>
-						<string key="toolTip">Show window while delaying</string>
-					</object>
-				</object>
-				<string key="158.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="179.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="188.CustomClassName">QSHotKeyField</string>
-				<string key="188.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="189.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="195.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="196.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="197.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="198.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="199.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="200.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="201.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="202.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="203.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="204.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="205.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="206.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="207.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="5.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="84.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<object class="NSMutableDictionary" key="92.IBAttributePlaceholdersKey">
-					<string key="NS.key.0">ToolTip</string>
-					<object class="IBToolTipAttribute" key="NS.object.0">
-						<string key="name">ToolTip</string>
-						<reference key="object" ref="470235144"/>
-						<string key="toolTip">Delays activation of the trigger until key is held for at least this long</string>
-					</object>
-				</object>
-				<string key="92.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<object class="NSMutableDictionary" key="93.IBAttributePlaceholdersKey">
-					<string key="NS.key.0">ToolTip</string>
-					<object class="IBToolTipAttribute" key="NS.object.0">
-						<string key="name">ToolTip</string>
-						<reference key="object" ref="594696590"/>
-						<string key="toolTip">Delays activation of the trigger until key is held for at least this long</string>
-					</object>
-				</object>
-				<string key="93.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="94.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<object class="NSMutableDictionary" key="95.IBAttributePlaceholdersKey">
-					<string key="NS.key.0">ToolTip</string>
-					<object class="IBToolTipAttribute" key="NS.object.0">
-						<string key="name">ToolTip</string>
-						<reference key="object" ref="1044206565"/>
-						<string key="toolTip">Trigger when key is pressed</string>
-					</object>
-				</object>
-				<string key="95.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<object class="NSMutableDictionary" key="96.IBAttributePlaceholdersKey">
-					<string key="NS.key.0">ToolTip</string>
-					<object class="IBToolTipAttribute" key="NS.object.0">
-						<string key="name">ToolTip</string>
-						<reference key="object" ref="672561679"/>
-						<string key="toolTip">Trigger when hotkey is released</string>
-					</object>
-				</object>
-				<string key="96.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<object class="NSMutableDictionary" key="97.IBAttributePlaceholdersKey">
-					<string key="NS.key.0">ToolTip</string>
-					<object class="IBToolTipAttribute" key="NS.object.0">
-						<string key="name">ToolTip</string>
-						<reference key="object" ref="830338487"/>
-						<string key="toolTip">Repeatedly trigger while hotkey is held</string>
-					</object>
-				</object>
-				<string key="97.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<object class="NSMutableDictionary" key="98.IBAttributePlaceholdersKey">
-					<string key="NS.key.0">ToolTip</string>
-					<object class="IBToolTipAttribute" key="NS.object.0">
-						<string key="name">ToolTip</string>
-						<reference key="object" ref="405095846"/>
-						<string key="toolTip">Repeatedly trigger while hotkey is held</string>
-					</object>
-				</object>
-				<string key="98.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="99.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-			</dictionary>
-			<dictionary class="NSMutableDictionary" key="unlocalizedProperties"/>
-			<nil key="activeLocalization"/>
-			<dictionary class="NSMutableDictionary" key="localizations"/>
-			<nil key="sourceID"/>
-			<int key="maxID">207</int>
-		</object>
-		<object class="IBClassDescriber" key="IBDocument.Classes">
-			<array class="NSMutableArray" key="referencedPartialClassDescriptions">
-				<object class="IBPartialClassDescription">
-					<string key="className">FirstResponder</string>
-					<object class="NSMutableDictionary" key="actions">
-						<string key="NS.key.0">:</string>
-						<string key="NS.object.0">id</string>
-					</object>
-					<object class="NSMutableDictionary" key="actionInfosByName">
-						<string key="NS.key.0">:</string>
-						<object class="IBActionInfo" key="NS.object.0">
-							<string key="name">:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-					</object>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBUserSource</string>
-						<string key="minorKey"/>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSApplication</string>
-					<object class="NSMutableDictionary" key="actions">
-						<string key="NS.key.0">relaunch:</string>
-						<string key="NS.object.0">id</string>
-					</object>
-					<object class="NSMutableDictionary" key="actionInfosByName">
-						<string key="NS.key.0">relaunch:</string>
-						<object class="IBActionInfo" key="NS.object.0">
-							<string key="name">relaunch:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-					</object>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">../Code-QuickStepFoundation/NSApplication_BLTRExtensions.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSApplication</string>
-					<object class="NSMutableDictionary" key="actions">
-						<string key="NS.key.0">relaunch:</string>
-						<string key="NS.object.0">id</string>
-					</object>
-					<object class="NSMutableDictionary" key="actionInfosByName">
-						<string key="NS.key.0">relaunch:</string>
-						<object class="IBActionInfo" key="NS.object.0">
-							<string key="name">relaunch:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-					</object>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">../Code-QuickStepFoundation/NSApplication_BLTRExtensions.m</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">QSHotKeyField</string>
-					<string key="superclassName">NSTextField</string>
-					<object class="NSMutableDictionary" key="actions">
-						<string key="NS.key.0">set:</string>
-						<string key="NS.object.0">id</string>
-					</object>
-					<object class="NSMutableDictionary" key="actionInfosByName">
-						<string key="NS.key.0">set:</string>
-						<object class="IBActionInfo" key="NS.object.0">
-							<string key="name">set:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-					</object>
-					<object class="NSMutableDictionary" key="outlets">
-						<string key="NS.key.0">setButton</string>
-						<string key="NS.object.0">NSButton</string>
-					</object>
-					<object class="NSMutableDictionary" key="toOneOutletInfosByName">
-						<string key="NS.key.0">setButton</string>
-						<object class="IBToOneOutletInfo" key="NS.object.0">
-							<string key="name">setButton</string>
-							<string key="candidateClassName">NSButton</string>
-						</object>
-					</object>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">../Code-QuickStepInterface/QSHotKeyEditor.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">QSHotKeyField</string>
-					<object class="NSMutableDictionary" key="actions">
-						<string key="NS.key.0">set:</string>
-						<string key="NS.object.0">id</string>
-					</object>
-					<object class="NSMutableDictionary" key="actionInfosByName">
-						<string key="NS.key.0">set:</string>
-						<object class="IBActionInfo" key="NS.object.0">
-							<string key="name">set:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-					</object>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">../Code-QuickStepInterface/QSHotKeyEditor.m</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">QSHotKeyTriggerManager</string>
-					<string key="superclassName">QSTriggerManager</string>
-					<object class="NSMutableDictionary" key="outlets">
-						<string key="NS.key.0">hotKeyField</string>
-						<string key="NS.object.0">QSHotKeyField</string>
-					</object>
-					<object class="NSMutableDictionary" key="toOneOutletInfosByName">
-						<string key="NS.key.0">hotKeyField</string>
-						<object class="IBToOneOutletInfo" key="NS.object.0">
-							<string key="name">hotKeyField</string>
-							<string key="candidateClassName">QSHotKeyField</string>
-						</object>
-					</object>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">../PlugIns-Main/QSHotKeyPlugIn/QSHotKeyTriggerManager.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">QSTriggerManager</string>
-					<string key="superclassName">NSObject</string>
-					<object class="NSMutableDictionary" key="outlets">
-						<string key="NS.key.0">settingsView</string>
-						<string key="NS.object.0">NSView</string>
-					</object>
-					<object class="NSMutableDictionary" key="toOneOutletInfosByName">
-						<string key="NS.key.0">settingsView</string>
-						<object class="IBToOneOutletInfo" key="NS.object.0">
-							<string key="name">settingsView</string>
-							<string key="candidateClassName">NSView</string>
-						</object>
-					</object>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">../Code-QuickStepCore/QSTriggerManager.h</string>
-					</object>
-				</object>
-			</array>
-			<array class="NSMutableArray" key="referencedPartialClassDescriptionsV3.2+">
-				<object class="IBPartialClassDescription">
-					<string key="className">NSActionCell</string>
-					<string key="superclassName">NSCell</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSActionCell.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSApplication</string>
-					<string key="superclassName">NSResponder</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSApplication.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSApplication</string>
-					<object class="NSMutableDictionary" key="actions">
-						<string key="NS.key.0">relaunch:</string>
-						<string key="NS.object.0">id</string>
-					</object>
-					<object class="NSMutableDictionary" key="actionInfosByName">
-						<string key="NS.key.0">relaunch:</string>
-						<object class="IBActionInfo" key="NS.object.0">
-							<string key="name">relaunch:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-					</object>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">QSFoundation.framework/Headers/NSApplication_BLTRExtensions.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSButton</string>
-					<string key="superclassName">NSControl</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSButton.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSButtonCell</string>
-					<string key="superclassName">NSActionCell</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSButtonCell.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSCell</string>
-					<string key="superclassName">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSCell.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSControl</string>
-					<string key="superclassName">NSView</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSControl.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSController</string>
-					<string key="superclassName">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSController.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSFormatter</string>
-					<string key="superclassName">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">Foundation.framework/Headers/NSFormatter.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSMenu</string>
-					<string key="superclassName">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSMenu.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSNumberFormatter</string>
-					<string key="superclassName">NSFormatter</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">Foundation.framework/Headers/NSNumberFormatter.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObjectController</string>
-					<string key="superclassName">NSController</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSObjectController.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSResponder</string>
-					<string key="superclassName">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSResponder.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSTextField</string>
-					<string key="superclassName">NSControl</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSTextField.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSTextFieldCell</string>
-					<string key="superclassName">NSActionCell</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSTextFieldCell.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSView</string>
-					<string key="superclassName">NSResponder</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">AppKit.framework/Headers/NSView.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">QSHotKeyField</string>
-					<string key="superclassName">NSTextField</string>
-					<object class="NSMutableDictionary" key="actions">
-						<string key="NS.key.0">set:</string>
-						<string key="NS.object.0">id</string>
-					</object>
-					<object class="NSMutableDictionary" key="actionInfosByName">
-						<string key="NS.key.0">set:</string>
-						<object class="IBActionInfo" key="NS.object.0">
-							<string key="name">set:</string>
-							<string key="candidateClassName">id</string>
-						</object>
-					</object>
-					<object class="NSMutableDictionary" key="outlets">
-						<string key="NS.key.0">setButton</string>
-						<string key="NS.object.0">NSButton</string>
-					</object>
-					<object class="NSMutableDictionary" key="toOneOutletInfosByName">
-						<string key="NS.key.0">setButton</string>
-						<object class="IBToOneOutletInfo" key="NS.object.0">
-							<string key="name">setButton</string>
-							<string key="candidateClassName">NSButton</string>
-						</object>
-					</object>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">QSInterface.framework/Headers/QSHotKeyEditor.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">QSTriggerManager</string>
-					<string key="superclassName">NSObject</string>
-					<object class="NSMutableDictionary" key="outlets">
-						<string key="NS.key.0">settingsView</string>
-						<string key="NS.object.0">NSView</string>
-					</object>
-					<object class="NSMutableDictionary" key="toOneOutletInfosByName">
-						<string key="NS.key.0">settingsView</string>
-						<object class="IBToOneOutletInfo" key="NS.object.0">
-							<string key="name">settingsView</string>
-							<string key="candidateClassName">NSView</string>
-						</object>
-					</object>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">QSCore.framework/Headers/QSTriggerManager.h</string>
-					</object>
-				</object>
-			</array>
-		</object>
-		<int key="IBDocument.localizationMode">0</int>
-		<string key="IBDocument.TargetRuntimeIdentifier">IBCocoaFramework</string>
-		<bool key="IBDocument.previouslyAttemptedUpgradeToXcode5">NO</bool>
-		<object class="NSMutableDictionary" key="IBDocument.PluginDeclaredDependencies">
-			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin.macosx</string>
-			<real value="1070" key="NS.object.0"/>
-		</object>
-		<object class="NSMutableDictionary" key="IBDocument.PluginDeclaredDevelopmentDependencies">
-			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin.InterfaceBuilder3</string>
-			<integer value="4600" key="NS.object.0"/>
-		</object>
-		<bool key="IBDocument.PluginDeclaredDependenciesTrackSystemTargetVersion">YES</bool>
-		<int key="IBDocument.defaultPropertyAccessControl">3</int>
-		<object class="NSMutableDictionary" key="IBDocument.LastKnownImageSizes">
-			<string key="NS.key.0">NSSwitch</string>
-			<string key="NS.object.0">{15, 15}</string>
-		</object>
-	</data>
-</archive>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="11762" systemVersion="16D32" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11762"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <customObject id="-2" userLabel="File's Owner" customClass="QSHotKeyTriggerManager">
+            <connections>
+                <outlet property="hotKeyField" destination="188" id="193"/>
+                <outlet property="settingsView" destination="5" id="51"/>
+            </connections>
+        </customObject>
+        <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
+        <customObject id="-3" userLabel="Application"/>
+        <customView id="5" userLabel="HotKey Trigger">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="365"/>
+            <autoresizingMask key="autoresizingMask"/>
+            <subviews>
+                <button verticalHuggingPriority="750" id="189">
+                    <rect key="frame" x="183" y="323" width="29" height="21"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                    <buttonCell key="cell" type="smallSquare" title="Edit" bezelStyle="smallSquare" alignment="center" controlSize="mini" borderStyle="border" inset="2" id="207">
+                        <behavior key="behavior" lightByBackground="YES" lightByGray="YES" changeBackground="YES" changeGray="YES"/>
+                        <font key="font" metaFont="system" size="9.5"/>
+                    </buttonCell>
+                    <connections>
+                        <action selector="set:" target="188" id="191"/>
+                    </connections>
+                </button>
+                <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="NO" id="188" customClass="QSHotKeyField">
+                    <rect key="frame" x="105" y="324" width="76" height="19"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                    <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="center" placeholderString="none" drawsBackground="YES" id="206">
+                        <font key="font" metaFont="smallSystem"/>
+                        <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                    <connections>
+                        <binding destination="-2" name="value" keyPath="hotKey" id="192"/>
+                        <outlet property="setButton" destination="189" id="190"/>
+                    </connections>
+                </textField>
+                <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="NO" id="179">
+                    <rect key="frame" x="17" y="174" width="76" height="14"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                    <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="left" title="Display:" id="205">
+                        <font key="font" metaFont="smallSystemBold"/>
+                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+                <button toolTip="Show window while delaying" id="158">
+                    <rect key="frame" x="102" y="172" width="96" height="18"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                    <buttonCell key="cell" type="check" title="Show Window" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="204">
+                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                        <font key="font" metaFont="smallSystem"/>
+                    </buttonCell>
+                    <connections>
+                        <binding destination="126" name="value" keyPath="selection.showWindow" id="160"/>
+                    </connections>
+                </button>
+                <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="NO" id="117">
+                    <rect key="frame" x="17" y="210" width="76" height="14"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                    <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="left" title="Delay:" id="203">
+                        <font key="font" metaFont="smallSystemBold"/>
+                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+                <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="NO" id="116">
+                    <rect key="frame" x="17" y="284" width="62" height="14"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                    <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Activate:" id="202">
+                        <font key="font" metaFont="smallSystemBold"/>
+                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+                <textField toolTip="Repeatedly trigger while hotkey is held" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="NO" id="98">
+                    <rect key="frame" x="214" y="262" width="45" height="19"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                    <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="center" placeholderString="1.0 s" drawsBackground="YES" id="201">
+                        <numberFormatter key="formatter" formatterBehavior="10_0" positiveFormat="#,##0.0 s" negativeFormat="-#,##0 s" localizesFormat="NO" thousandSeparator="," id="99">
+                            <attributedString key="attributedStringForNil"/>
+                            <attributedString key="attributedStringForNotANumber">
+                                <fragment content="NaN"/>
+                            </attributedString>
+                            <attributedString key="attributedStringForZero">
+                                <fragment content="0 s"/>
+                            </attributedString>
+                            <decimal key="minimum" value="NaN"/>
+                            <decimal key="maximum" value="NaN"/>
+                        </numberFormatter>
+                        <font key="font" metaFont="smallSystem"/>
+                        <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                    <connections>
+                        <binding destination="126" name="value" keyPath="selection.onRepeatInterval" id="137"/>
+                        <outlet property="nextKeyView" destination="96" id="171"/>
+                    </connections>
+                </textField>
+                <button toolTip="Repeatedly trigger while hotkey is held" id="97">
+                    <rect key="frame" x="117" y="262" width="91" height="18"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                    <buttonCell key="cell" type="check" title="Repeat every" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="200">
+                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                        <font key="font" metaFont="smallSystem"/>
+                    </buttonCell>
+                    <connections>
+                        <binding destination="126" name="value" keyPath="selection.onRepeat" id="136"/>
+                        <outlet property="nextKeyView" destination="98" id="183"/>
+                    </connections>
+                </button>
+                <button toolTip="Trigger when hotkey is released" id="96">
+                    <rect key="frame" x="102" y="242" width="82" height="18"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                    <buttonCell key="cell" type="check" title="On Release" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="199">
+                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                        <font key="font" metaFont="smallSystem"/>
+                    </buttonCell>
+                    <connections>
+                        <binding destination="126" name="value" keyPath="selection.onRelease" id="135"/>
+                        <outlet property="nextKeyView" destination="92" id="184"/>
+                    </connections>
+                </button>
+                <button toolTip="Trigger when key is pressed" id="95">
+                    <rect key="frame" x="102" y="282" width="69" height="18"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                    <buttonCell key="cell" type="check" title="On Press" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="198">
+                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                        <font key="font" metaFont="smallSystem"/>
+                    </buttonCell>
+                    <connections>
+                        <binding destination="126" name="value" keyPath="selection.onPress" id="170"/>
+                        <outlet property="nextKeyView" destination="97" id="172"/>
+                    </connections>
+                </button>
+                <textField toolTip="Delays activation of the trigger until key is held for at least this long" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="NO" id="93">
+                    <rect key="frame" x="174" y="207" width="45" height="19"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                    <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="center" placeholderString="1.0 s" drawsBackground="YES" id="197">
+                        <numberFormatter key="formatter" formatterBehavior="10_0" positiveFormat="#,##0.0 s" negativeFormat="-#,##0 s" localizesFormat="NO" thousandSeparator="," id="94">
+                            <attributedString key="attributedStringForNil"/>
+                            <attributedString key="attributedStringForNotANumber">
+                                <fragment content="NaN"/>
+                            </attributedString>
+                            <attributedString key="attributedStringForZero">
+                                <fragment content="0 s"/>
+                            </attributedString>
+                            <decimal key="minimum" value="NaN"/>
+                            <decimal key="maximum" value="NaN"/>
+                        </numberFormatter>
+                        <font key="font" metaFont="smallSystem"/>
+                        <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                    <connections>
+                        <binding destination="126" name="value" keyPath="selection.delayInterval" id="139"/>
+                        <outlet property="nextKeyView" destination="158" id="186"/>
+                    </connections>
+                </textField>
+                <button toolTip="Delays activation of the trigger until key is held for at least this long" id="92">
+                    <rect key="frame" x="102" y="207" width="66" height="18"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                    <buttonCell key="cell" type="check" title="Hold for" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="196">
+                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                        <font key="font" metaFont="smallSystem"/>
+                    </buttonCell>
+                    <connections>
+                        <binding destination="126" name="value" keyPath="selection.delay" id="138"/>
+                        <outlet property="nextKeyView" destination="93" id="185"/>
+                    </connections>
+                </button>
+                <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="NO" id="84">
+                    <rect key="frame" x="17" y="327" width="76" height="14"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                    <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Shortcut:" id="195">
+                        <font key="font" metaFont="smallSystemBold"/>
+                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+            </subviews>
+        </customView>
+        <objectController id="126" userLabel="trigger">
+            <declaredKeys>
+                <string>hotKey</string>
+                <string>onPress</string>
+                <string>onRelease</string>
+                <string>onRepeat</string>
+                <string>onRepeatInterval</string>
+                <string>delay</string>
+                <string>delayInterval</string>
+                <string>info.hotKey</string>
+                <string>showWindow</string>
+                <string>triggerOnPress</string>
+                <string>triggerDescription</string>
+            </declaredKeys>
+            <connections>
+                <binding destination="-2" name="contentObject" keyPath="currentTrigger.info" id="149"/>
+            </connections>
+        </objectController>
+    </objects>
+</document>

--- a/Quicksilver/QSDroplet/QSDroplet.xib
+++ b/Quicksilver/QSDroplet/QSDroplet.xib
@@ -1,91 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<archive type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="8.00">
-	<data>
-		<int key="IBDocument.SystemTarget">1070</int>
-		<string key="IBDocument.SystemVersion">12C3012</string>
-		<string key="IBDocument.InterfaceBuilderVersion">3084</string>
-		<string key="IBDocument.AppKitVersion">1187.34</string>
-		<string key="IBDocument.HIToolboxVersion">625.00</string>
-		<object class="NSMutableDictionary" key="IBDocument.PluginVersions">
-			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin</string>
-			<string key="NS.object.0">3084</string>
-		</object>
-		<array key="IBDocument.IntegratedClassDependencies">
-			<string>NSCustomObject</string>
-		</array>
-		<array key="IBDocument.PluginDependencies">
-			<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-		</array>
-		<object class="NSMutableDictionary" key="IBDocument.Metadata">
-			<string key="NS.key.0">PluginDependencyRecalculationVersion</string>
-			<integer value="1" key="NS.object.0"/>
-		</object>
-		<array class="NSMutableArray" key="IBDocument.RootObjects" id="566001967">
-			<object class="NSCustomObject" id="676320279">
-				<object class="NSMutableString" key="NSClassName">
-					<characters key="NS.bytes">NSApplication</characters>
-				</object>
-			</object>
-			<object class="NSCustomObject" id="338157600">
-				<string key="NSClassName">FirstResponder</string>
-			</object>
-			<object class="NSCustomObject" id="298126581">
-				<string key="NSClassName">NSApplication</string>
-			</object>
-		</array>
-		<object class="IBObjectContainer" key="IBDocument.Objects">
-			<array class="NSMutableArray" key="connectionRecords"/>
-			<object class="IBMutableOrderedSet" key="objectRecords">
-				<array key="orderedObjects">
-					<object class="IBObjectRecord">
-						<int key="objectID">0</int>
-						<array key="object" id="0"/>
-						<reference key="children" ref="566001967"/>
-						<nil key="parent"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">-2</int>
-						<reference key="object" ref="676320279"/>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">File's Owner</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">-1</int>
-						<reference key="object" ref="338157600"/>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">First Responder</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">-3</int>
-						<reference key="object" ref="298126581"/>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">Application</string>
-					</object>
-				</array>
-			</object>
-			<dictionary class="NSMutableDictionary" key="flattenedProperties">
-				<string key="-1.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="-2.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-				<string key="-3.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
-			</dictionary>
-			<dictionary class="NSMutableDictionary" key="unlocalizedProperties"/>
-			<nil key="activeLocalization"/>
-			<dictionary class="NSMutableDictionary" key="localizations"/>
-			<nil key="sourceID"/>
-			<int key="maxID">248</int>
-		</object>
-		<object class="IBClassDescriber" key="IBDocument.Classes"/>
-		<int key="IBDocument.localizationMode">0</int>
-		<string key="IBDocument.TargetRuntimeIdentifier">IBCocoaFramework</string>
-		<object class="NSMutableDictionary" key="IBDocument.PluginDeclaredDependencies">
-			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin.macosx</string>
-			<real value="1070" key="NS.object.0"/>
-		</object>
-		<object class="NSMutableDictionary" key="IBDocument.PluginDeclaredDevelopmentDependencies">
-			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin.InterfaceBuilder3</string>
-			<real value="4500" key="NS.object.0"/>
-		</object>
-		<bool key="IBDocument.PluginDeclaredDependenciesTrackSystemTargetVersion">YES</bool>
-		<int key="IBDocument.defaultPropertyAccessControl">3</int>
-	</data>
-</archive>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="11762" systemVersion="16D32" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11762"/>
+    </dependencies>
+    <objects>
+        <customObject id="-2" userLabel="File's Owner" customClass="NSApplication"/>
+        <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
+        <customObject id="-3" userLabel="Application"/>
+    </objects>
+</document>

--- a/Quicksilver/Resources/DefaultMnemonics.plist
+++ b/Quicksilver/Resources/DefaultMnemonics.plist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>abbreviation</key>
@@ -12,11 +12,6 @@
 	</dict>
 	<key>implied</key>
 	<dict>
-		<key>/Applications/Internet Explorer.app</key>
-		<dict>
-			<key>ie</key>
-			<integer>2</integer>
-		</dict>
 		<key>/Applications/Mail.app</key>
 		<dict>
 			<key>m</key>


### PR DESCRIPTION
I noticed a warning about the droplet NIB. It got overlooked when I updated the deployment target. That’s all that’s changed.

And Internet Explorer… Probably safe to drop that, right?