### PR TITLE
better proxy caching

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSDefines.h
+++ b/Quicksilver/Code-QuickStepCore/QSDefines.h
@@ -162,4 +162,8 @@
  *  E.g. if 10.7 is specified, 10.6.8, 10.6.9... would all be supported
  */
 #define kPluginRequirementsOSUnsupportedVersion @"osUnsupported"
-
+/**
+ *  Type: string
+ *  Key to the reason the interface was hidden/deactivated
+ */
+#define kQSInterfaceDeactivatedReason @"deactivate reason"

--- a/Quicksilver/Code-QuickStepCore/QSNotifications.h
+++ b/Quicksilver/Code-QuickStepCore/QSNotifications.h
@@ -2,6 +2,8 @@
 #define QSReleaseAllCachesNotification @"QSReleaseAllCachesNotification"
 #define QSReleaseAllNotification @"QSReleaseAllNotification"
 #define QSInterfaceChangedNotification @"QSInterfaceChangedNotification"
+#define QSInterfaceActivatedNotification @"InterfaceActivated"
+#define QSInterfaceDeactivatedNotification @"InterfaceDeactivated"
 
 #define QSActionsChanged @"QSActionsChanged"
 #define QSReleaseCaches @"QSReleaseCaches"

--- a/Quicksilver/Code-QuickStepCore/QSProxyObject.h
+++ b/Quicksilver/Code-QuickStepCore/QSProxyObject.h
@@ -35,7 +35,7 @@
 - (NSObject <QSProxyObjectProvider> *)proxyProvider;
 - (QSObject*)proxyObject;
 
-- (void)releaseProxy;
+- (void)releaseProxy:(NSNotification *)notif;
 
 - (BOOL)bypassValidation;
 - (NSArray *)proxyTypes;

--- a/Quicksilver/Code-QuickStepCore/QSTriggerCenter.m
+++ b/Quicksilver/Code-QuickStepCore/QSTriggerCenter.m
@@ -46,12 +46,12 @@
 		/* tiennou: Those look unused. If they aren't, change them to extern NSStrings */
 		[nc addObserver:self
 			   selector:@selector(interfaceActivated)
-				   name:@"InterfaceActivated"
+				   name:QSInterfaceActivatedNotification
 				 object:nil];
 
 		[nc addObserver:self
 			   selector:@selector(interfaceDeactivated)
-				   name:@"InterfaceDeactivated"
+				   name:QSInterfaceDeactivatedNotification
 				 object:nil];
 	}
 	return self;
@@ -60,8 +60,8 @@
 - (void)dealloc {
 	NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
 	[nc removeObserver:self name:QSActiveApplicationChanged object:nil];
-	[nc removeObserver:self name:@"InterfaceActivated" object:nil];
-	[nc removeObserver:self name:@"InterfaceDeactivated" object:nil];
+	[nc removeObserver:self name:QSInterfaceActivatedNotification object:nil];
+	[nc removeObserver:self name:QSInterfaceDeactivatedNotification object:nil];
 	triggers = nil;
 	triggersDict = nil;
 }

--- a/Quicksilver/Code-QuickStepInterface/QSInterfaceController.m
+++ b/Quicksilver/Code-QuickStepInterface/QSInterfaceController.m
@@ -197,7 +197,6 @@
 		CGSSetGlobalHotKeyOperatingMode(conn, CGSGlobalHotKeyEnable);
 	}
 	if ([[self window] isVisible] && ![[self window] attachedSheet]) {
-		[[NSNotificationCenter defaultCenter] postNotificationName:QSInterfaceDeactivatedNotification object:self];
 		[[self window] makeFirstResponder:nil];
 	}
     // Close the Quicklook panel if the QS window closes
@@ -232,20 +231,24 @@
 }
 
 - (void)hideMainWindow:(id)sender {
+	[[NSNotificationCenter defaultCenter] postNotificationName:QSInterfaceDeactivatedNotification object:self];
 	[self hideMainWindowWithEffect:nil];
 }
 
 - (void)hideMainWindowFromExecution:(id)sender {
+	[[NSNotificationCenter defaultCenter] postNotificationName:QSInterfaceDeactivatedNotification object:self userInfo:@{kQSInterfaceDeactivatedReason: @"execution"}];
 	[self hideMainWindowWithEffect:
      [[self window] windowPropertyForKey:kQSWindowExecEffect]];
 }
 
 - (void)hideMainWindowFromCancel:(id)sender {
+	[[NSNotificationCenter defaultCenter] postNotificationName:QSInterfaceDeactivatedNotification object:self userInfo:@{kQSInterfaceDeactivatedReason: @"cancel"}];
 	[self hideMainWindowWithEffect:
      [[self window] windowPropertyForKey:kQSWindowCancelEffect]];
 }
 
 - (void)hideMainWindowFromFade:(id)sender {
+	[[NSNotificationCenter defaultCenter] postNotificationName:QSInterfaceDeactivatedNotification object:self userInfo:@{kQSInterfaceDeactivatedReason: @"fade"}];
 	if ([[self window] respondsToSelector:@selector(windowPropertyForKey:)])
 		[self hideMainWindowWithEffect:
          [[self window] windowPropertyForKey:kQSWindowFadeEffect]];

--- a/Quicksilver/Code-QuickStepInterface/QSInterfaceController.m
+++ b/Quicksilver/Code-QuickStepInterface/QSInterfaceController.m
@@ -197,7 +197,7 @@
 		CGSSetGlobalHotKeyOperatingMode(conn, CGSGlobalHotKeyEnable);
 	}
 	if ([[self window] isVisible] && ![[self window] attachedSheet]) {
-		[[NSNotificationCenter defaultCenter] postNotificationName:@"InterfaceDeactivated" object:self];
+		[[NSNotificationCenter defaultCenter] postNotificationName:QSInterfaceDeactivatedNotification object:self];
 		[[self window] makeFirstResponder:nil];
 	}
     // Close the Quicklook panel if the QS window closes
@@ -681,7 +681,7 @@
 #pragma mark IBActions
 - (IBAction)showInterface:(id)sender {
 	 
-	[[NSNotificationCenter defaultCenter] postNotificationName:@"InterfaceActivated" object:self];
+	[[NSNotificationCenter defaultCenter] postNotificationName:QSInterfaceActivatedNotification object:self];
 	[self showMainWindow:self];
 }
 


### PR DESCRIPTION
I think I’ve finally figured out how to get rid of the timer.

There are generally two places we want to resolve a proxy object: to show it in the interface, and to use it in a command. Once resolved, we want to hold onto that value until one of two things happens: The command is finished using the object, or the interface was dismissed.

Common scenarios (and their effect on the proxy):

Select and do nothing.

1. Select a proxy in the interface (resolve)
2. Dismiss the interface without doing anything (release)

Run a trigger.

1. Run a command that uses a proxy object (resolve)
2. The trigger’s command finishes (release)

Those are fine on their own, but an even more common scenario combines them in a weird order.

1. Select a proxy in the interface (resolve)
2. Hit Return to run the command, which dismisses the interface (release)
3. Run the command (resolve)
4. The command finishes (release)

The problem with that was, between 1 and 3, the object could change so you could run the action on something you didn’t want.

The previous solution was to just hold onto the resolved object for 2 more seconds, but that broke workflows that used the same proxy in rapid succession.

Now, when the interface is dismissed, instead of blindly clearing the proxy cache, it will check to see *why* the interface was dismissed. If it’s because a command was run, it leaves the cache in place knowing that it will get cleared anyway when the command finishes. Otherwise, the cache is cleared immediately.

The only thing I’m not 100% comfortable with is the change to when the notifications are posted. It used to be [more limited](https://github.com/quicksilver/Quicksilver/pull/2322/commits/db95bcf46035210f798d2c302972bc1ccc50922f#diff-67e3a94a52a5e4a92915f1f10797045bL199) it seems, but I don’t know if that made a difference in practice.