### PR TITLE
don’t add identifiers to string objects

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSLibrarian.m
+++ b/Quicksilver/Code-QuickStepCore/QSLibrarian.m
@@ -321,6 +321,11 @@ static CGFloat searchSpeed = 0.0;
             if ([obj identifier]) {
                 [self setIdentifier:[obj identifier] forObject:obj];
             } else {
+				if ([[obj primaryType] isEqualToString:QSTextType]) {
+					// don't add identifiers to string objects
+					// it ends up replacing the string value
+					continue;
+				}
                 NSString *ident = [NSString stringWithFormat:@"QSID:%@:%@", [entry identifier], [obj displayName]];
                 [obj setIdentifier:ident];
             }


### PR DESCRIPTION
Of course `git blame` said “look in the mirror” on this one.