### PR TITLE
QSSense fixup

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSCore.h
+++ b/Quicksilver/Code-QuickStepCore/QSCore.h
@@ -19,7 +19,6 @@
 #import "QSComputerSource.h"
 #import "QSDebug.h"
 #import "QSDefines.h"
-#import "QSense.h"
 #import "QSExecutor.h"
 #import "QSGlobalSelectionProvider.h"
 #import "QSHandledObjectHandler.h"

--- a/Quicksilver/Code-QuickStepCore/QSStringRanker.m
+++ b/Quicksilver/Code-QuickStepCore/QSStringRanker.m
@@ -7,7 +7,7 @@
 //
 
 #import "QSStringRanker.h"
-#import "QSense.h"
+#import "QSSense.h"
 #import "NSString_Purification.h"
 
 @implementation QSDefaultStringRanker

--- a/Quicksilver/Code-QuickStepFoundation/NSString_BLTRExtensions.h
+++ b/Quicksilver/Code-QuickStepFoundation/NSString_BLTRExtensions.h
@@ -13,16 +13,9 @@ NSAttributedString * highlightString(NSString *string, NSString *keyString);
 NSComparisonResult prefixCompare(NSString *aString, NSString *bString);
 
 @interface NSString (Abbreviation)
-- (CGFloat) scoreForString:(NSString *)string;
-
-- (NSArray *)hitsForString:(NSString *)testString;
-
 - (CGFloat) scoreForAbbreviation:(NSString *)abbreviation;
-//- (float) oldScoreForAbbreviation:(NSString *)abbreviation;
 - (CGFloat) scoreForAbbreviation:(NSString *)abbreviation hitMask:(NSMutableIndexSet *)mask;
-//- (float) oldScoreForAbbreviation:(NSString *)abbreviation hitMask:(NSMutableIndexSet *)mask;
 - (CGFloat) scoreForAbbreviation:(NSString *)abbreviation inRange:(NSRange)searchRange fromRange:(NSRange)abbreviationRange hitMask:(NSMutableIndexSet *)mask;
-
 @end
 
 @interface NSAttributedString (Sizing)

--- a/Quicksilver/Code-QuickStepFoundation/NSString_BLTRExtensions.m
+++ b/Quicksilver/Code-QuickStepFoundation/NSString_BLTRExtensions.m
@@ -43,49 +43,10 @@ NSComparisonResult prefixCompare(NSString *aString, NSString *bString) {
 }
 
 - (CGFloat) scoreForAbbreviation:(NSString *)abbreviation inRange:(NSRange)searchRange fromRange:(NSRange)abbreviationRange hitMask:(NSMutableIndexSet *)mask {
-	CGFloat score, remainingScore;
-	NSInteger i, j;
-	NSRange matchedRange, remainingSearchRange;
-	if (!abbreviationRange.length) return 0.9; //deduct some points for all remaining letters
-	if (abbreviationRange.length>searchRange.length) return 0.0;
-	for (i = abbreviationRange.length; i>0; i--) { //Search for steadily smaller portions of the abbreviation
-		matchedRange = [self rangeOfString:[abbreviation substringWithRange:NSMakeRange(abbreviationRange.location, i)] options:NSCaseInsensitiveSearch range:searchRange];
+	CFRange strRange = CFRangeMake(searchRange.location, searchRange.length);
+	CFRange abbrRange = CFRangeMake(abbreviationRange.location, abbreviationRange.length);
 
-		if (matchedRange.location == NSNotFound || matchedRange.location+abbreviationRange.length>NSMaxRange(searchRange)) continue;
-
-		if (mask) [mask addIndexesInRange:matchedRange];
-
-		remainingSearchRange.location = NSMaxRange(matchedRange);
-		remainingSearchRange.length = NSMaxRange(searchRange) -remainingSearchRange.location;
-
-		// Search what is left of the string with the rest of the abbreviation
-		remainingScore = [self scoreForAbbreviation:abbreviation inRange:remainingSearchRange fromRange:NSMakeRange(abbreviationRange.location+i, abbreviationRange.length-i) hitMask:mask];
-		if (remainingScore) {
-			score = remainingSearchRange.location-searchRange.location;
-			// ignore skipped characters if is first letter of a word
-			if (matchedRange.location>searchRange.location) {//if some letters were skipped
-				if ([[NSCharacterSet whitespaceCharacterSet] characterIsMember:[self characterAtIndex:matchedRange.location-1]]) {
-					for (j = matchedRange.location-2; j >= (NSInteger) searchRange.location; j--) {
-						if ([[NSCharacterSet whitespaceCharacterSet] characterIsMember:[self characterAtIndex:j]]) score--;
-						else score -= 0.15;
-					}
-				} else if ([[NSCharacterSet uppercaseLetterCharacterSet] characterIsMember:[self characterAtIndex:matchedRange.location]]) {
-					for (j = matchedRange.location-1; j >= (NSInteger) searchRange.location; j--) {
-						if ([[NSCharacterSet uppercaseLetterCharacterSet] characterIsMember:[self characterAtIndex:j]])
-							score--;
-						else
-							score -= 0.15;
-					}
-				} else {
-					score -= (matchedRange.location-searchRange.location)/2;
-				}
-			}
-			score += remainingScore*remainingSearchRange.length;
-			score /= searchRange.length;
-			return score;
-		}
-	}
-	return 0;
+	return QSScoreForAbbreviationWithRanges((__bridge CFStringRef)self, (__bridge CFStringRef)abbreviation, mask, strRange, abbrRange);
 }
 
 /* FIXME: This can be removed sometimes */

--- a/Quicksilver/Code-QuickStepFoundation/NSString_BLTRExtensions.m
+++ b/Quicksilver/Code-QuickStepFoundation/NSString_BLTRExtensions.m
@@ -16,6 +16,7 @@ NSComparisonResult prefixCompare(NSString *aString, NSString *bString) {
 }
 
 @implementation NSString (Abbreviation)
+/* FIXME: This can be removed sometimes */
 - (CGFloat) scoreForString:(NSString *)testString {
 	CGFloat score = 1;
 	NSInteger i;
@@ -33,15 +34,6 @@ NSComparisonResult prefixCompare(NSString *aString, NSString *bString) {
 	score -= currentRange.length/[testString length];
 	return score;
 }
-
-#if 0
-- (CGFloat) oldScoreForAbbreviation:(NSString *)abbreviation hitMask:(NSMutableIndexSet *)mask {
-	return [self scoreForAbbreviation:abbreviation inRange:NSMakeRange(0, [self length]) fromRange:NSMakeRange(0, [abbreviation length]) hitMask:mask];
-}
-- (CGFloat) oldScoreForAbbreviation:(NSString *)abbreviation {
-	return [self oldScoreForAbbreviation:abbreviation hitMask:nil];
-}
-#endif
 
 - (CGFloat) scoreForAbbreviation:(NSString *)abbreviation {
 	return [self scoreForAbbreviation:abbreviation hitMask:nil];
@@ -96,6 +88,7 @@ NSComparisonResult prefixCompare(NSString *aString, NSString *bString) {
 	return 0;
 }
 
+/* FIXME: This can be removed sometimes */
 - (NSArray *)hitsForString:(NSString *)testString {
 	NSMutableArray *hitsArray = [NSMutableArray arrayWithCapacity:[self length]];
 	NSUInteger i;

--- a/Quicksilver/Code-QuickStepFoundation/NSString_BLTRExtensions.m
+++ b/Quicksilver/Code-QuickStepFoundation/NSString_BLTRExtensions.m
@@ -77,7 +77,7 @@ NSComparisonResult prefixCompare(NSString *aString, NSString *bString) {
 							score -= 0.15;
 					}
 				} else {
-					score -= matchedRange.location-searchRange.location;
+					score -= (matchedRange.location-searchRange.location)/2;
 				}
 			}
 			score += remainingScore*remainingSearchRange.length;

--- a/Quicksilver/Code-QuickStepFoundation/QSFoundation.h
+++ b/Quicksilver/Code-QuickStepFoundation/QSFoundation.h
@@ -32,6 +32,7 @@
 #import "QSLSTools.h"
 #import "QSLog.h"
 #import "QSHotKeyEvent.h"
+#import "QSSense.h"
 #import "NSWorkspace_BLTRExtensions.h"
 #import "NSWindow_BLTRExtensions.h"
 #import "NSView_BLTRExtensions.h"

--- a/Quicksilver/Code-QuickStepFoundation/QSSense.h
+++ b/Quicksilver/Code-QuickStepFoundation/QSSense.h
@@ -10,3 +10,4 @@
 
 
 CGFloat QSScoreForAbbreviation(CFStringRef string, CFStringRef abbr, id hitMask);
+CGFloat QSScoreForAbbreviationWithRanges(CFStringRef str, CFStringRef abbr, id mask, CFRange strRange, CFRange abbrRange);

--- a/Quicksilver/Code-QuickStepFoundation/QSSense.m
+++ b/Quicksilver/Code-QuickStepFoundation/QSSense.m
@@ -17,74 +17,80 @@
 CGFloat QSScoreForAbbreviationWithRanges(CFStringRef str, CFStringRef abbr, id mask, CFRange strRange, CFRange abbrRange);
 
 CGFloat QSScoreForAbbreviation(CFStringRef str, CFStringRef abbr, id mask) {
-	return QSScoreForAbbreviationWithRanges(str, abbr, mask, CFRangeMake(0, CFStringGetLength(str) ), CFRangeMake(0, CFStringGetLength(abbr)));
+	return QSScoreForAbbreviationWithRanges(str, abbr, mask, CFRangeMake(0, CFStringGetLength(str)), CFRangeMake(0, CFStringGetLength(abbr)));
 }
 
 CGFloat QSScoreForAbbreviationWithRanges(CFStringRef str, CFStringRef abbr, id mask, CFRange strRange, CFRange abbrRange) {
-    
 	if (!abbrRange.length)
-        return IGNORED_SCORE; //deduct some points for all remaining letters
-    
+		return IGNORED_SCORE; //deduct some points for all remaining letters
+
 	if (abbrRange.length > strRange.length)
-        return 0.0;
-	
+		return 0.0;
+
+	static CFCharacterSetRef wordSeparator = NULL;
+	static CFCharacterSetRef uppercase = NULL;
+	static dispatch_once_t onceToken;
+	dispatch_once(&onceToken, ^{
+		wordSeparator = CFCharacterSetCreateMutableCopy(NULL, CFCharacterSetGetPredefined(kCFCharacterSetWhitespace));
+		CFCharacterSetAddCharactersInString((CFMutableCharacterSetRef)wordSeparator, (CFStringRef)@".");
+
+		uppercase = CFCharacterSetGetPredefined(kCFCharacterSetUppercaseLetter);
+	});
+
 	// Create an inline buffer version of str.  Will be used in loop below
 	// for faster lookups.
 	CFStringInlineBuffer inlineBuffer;
 	CFStringInitInlineBuffer(str, &inlineBuffer, strRange);
 	CFLocaleRef userLoc = CFLocaleCopyCurrent();
 
-    CGFloat score = 0.0, remainingScore = 0.0;
-	NSInteger i, j;
+	CGFloat score = 0.0, remainingScore = 0.0;
+	CFIndex i, j;
 	CFRange matchedRange, remainingStrRange, adjustedStrRange = strRange;
-    
-	for (i = abbrRange.length; i > 0; i--) { //Search for steadily smaller portions of the abbreviation
+
+	// Search for steadily smaller portions of the abbreviation
+	for (i = abbrRange.length; i > 0; i--) {
 		CFStringRef curAbbr = CFStringCreateWithSubstring (NULL, abbr, CFRangeMake(abbrRange.location, i) );
-		//terminality
-		//axeen
+		// terminality
+		// axeen
+
 		BOOL found = CFStringFindWithOptionsAndLocale(str, curAbbr,
-                                                      CFRangeMake(adjustedStrRange.location, adjustedStrRange.length - abbrRange.length + i),
-                                                      kCFCompareCaseInsensitive | kCFCompareDiacriticInsensitive | kCFCompareLocalized,
-                                                      userLoc, &matchedRange);
+													  CFRangeMake(adjustedStrRange.location, adjustedStrRange.length - abbrRange.length + i),
+													  kCFCompareCaseInsensitive | kCFCompareDiacriticInsensitive | kCFCompareLocalized,
+													  userLoc, &matchedRange);
 		CFRelease(curAbbr);
-		
+
 		if (!found) {
 			continue;
 		}
-		if (matchedRange.location + abbrRange.length > strRange.location + strRange.length) {
-			continue;
-		}
-		
+
 		if (mask) {
 			[mask addIndexesInRange:NSMakeRange(matchedRange.location, matchedRange.length)];
 		}
-		
+
 		remainingStrRange.location = matchedRange.location + matchedRange.length;
 		remainingStrRange.length = strRange.location + strRange.length - remainingStrRange.location;
-		
+
 		// Search what is left of the string with the rest of the abbreviation
-		remainingScore = QSScoreForAbbreviationWithRanges(str, abbr, mask, remainingStrRange, CFRangeMake(abbrRange.location + i, abbrRange.length - i) );
-		
+		remainingScore = QSScoreForAbbreviationWithRanges(str, abbr, mask, remainingStrRange, CFRangeMake(abbrRange.location + i, abbrRange.length - i));
+
 		if (remainingScore) {
 			score = remainingStrRange.location-strRange.location;
 			// ignore skipped characters if is first letter of a word
-			if (matchedRange.location>strRange.location) {//if some letters were skipped
-				static CFCharacterSetRef wordSeparator = NULL;
-				if (!wordSeparator)
-				{
-				  wordSeparator = CFCharacterSetCreateMutableCopy(NULL, CFCharacterSetGetPredefined(kCFCharacterSetWhitespace));
-				  CFCharacterSetAddCharactersInString((CFMutableCharacterSetRef)wordSeparator, (CFStringRef)@".");
-				}
-				static CFCharacterSetRef uppercase = NULL;
-				if (!uppercase) uppercase = CFCharacterSetGetPredefined(kCFCharacterSetUppercaseLetter);
-				if (CFCharacterSetIsCharacterMember(wordSeparator, CFStringGetCharacterFromInlineBuffer(&inlineBuffer, matchedRange.location-1) )) {
-					for (j = matchedRange.location-2; j >= (NSInteger) strRange.location; j--) {
-						if (CFCharacterSetIsCharacterMember(wordSeparator, CFStringGetCharacterFromInlineBuffer(&inlineBuffer, j) )) score--;
-						else score -= SKIPPED_SCORE;
+			if (matchedRange.location > strRange.location) {
+				// if some letters were skipped
+				UniChar previousChar = CFStringGetCharacterFromInlineBuffer(&inlineBuffer, matchedRange.location - 1);
+				UniChar character = CFStringGetCharacterFromInlineBuffer(&inlineBuffer, matchedRange.location);
+				if (CFCharacterSetIsCharacterMember(wordSeparator, previousChar)) {
+					// We're on the first letter of a word
+					for (j = matchedRange.location - 2; j >= strRange.location; j--) {
+						if (CFCharacterSetIsCharacterMember(wordSeparator, CFStringGetCharacterFromInlineBuffer(&inlineBuffer, j)))
+							score--;
+						else
+							score -= SKIPPED_SCORE;
 					}
-				} else if (CFCharacterSetIsCharacterMember(uppercase, CFStringGetCharacterFromInlineBuffer(&inlineBuffer, matchedRange.location) )) {
-					for (j = matchedRange.location-1; j >= (NSInteger) strRange.location; j--) {
-						if (CFCharacterSetIsCharacterMember(uppercase, CFStringGetCharacterFromInlineBuffer(&inlineBuffer, j) ))
+				} else if (CFCharacterSetIsCharacterMember(uppercase, character)) {
+					for (j = matchedRange.location - 1; j >= strRange.location; j--) {
+						if (CFCharacterSetIsCharacterMember(uppercase, CFStringGetCharacterFromInlineBuffer(&inlineBuffer, j)))
 							score--;
 						else
 							score -= SKIPPED_SCORE;
@@ -93,12 +99,12 @@ CGFloat QSScoreForAbbreviationWithRanges(CFStringRef str, CFStringRef abbr, id m
 					score -= (matchedRange.location-strRange.location)/2;
 				}
 			}
-			score += remainingScore*remainingStrRange.length;
+			score += remainingScore * remainingStrRange.length;
 			score /= strRange.length;
-            CFRelease(userLoc);
+			CFRelease(userLoc);
 			return score;
 		}
 	}
-    CFRelease(userLoc);
+	CFRelease(userLoc);
 	return 0;
 }

--- a/Quicksilver/Code-QuickStepFoundation/QSSense.m
+++ b/Quicksilver/Code-QuickStepFoundation/QSSense.m
@@ -1,0 +1,104 @@
+//
+// QSense.m
+// QSqSense
+//
+// Created by Alcor on 11/22/04.
+// Copyright 2004 Blacktree. All rights reserved.
+//
+
+#import "QSSense.h"
+
+#define MIN_ABBR_OPTIMIZE 0
+#define IGNORED_SCORE 0.9
+#define SKIPPED_SCORE 0.15
+
+
+
+CGFloat QSScoreForAbbreviationWithRanges(CFStringRef str, CFStringRef abbr, id mask, CFRange strRange, CFRange abbrRange);
+
+CGFloat QSScoreForAbbreviation(CFStringRef str, CFStringRef abbr, id mask) {
+	return QSScoreForAbbreviationWithRanges(str, abbr, mask, CFRangeMake(0, CFStringGetLength(str) ), CFRangeMake(0, CFStringGetLength(abbr)));
+}
+
+CGFloat QSScoreForAbbreviationWithRanges(CFStringRef str, CFStringRef abbr, id mask, CFRange strRange, CFRange abbrRange) {
+    
+	if (!abbrRange.length)
+        return IGNORED_SCORE; //deduct some points for all remaining letters
+    
+	if (abbrRange.length > strRange.length)
+        return 0.0;
+	
+	// Create an inline buffer version of str.  Will be used in loop below
+	// for faster lookups.
+	CFStringInlineBuffer inlineBuffer;
+	CFStringInitInlineBuffer(str, &inlineBuffer, strRange);
+	CFLocaleRef userLoc = CFLocaleCopyCurrent();
+
+    CGFloat score = 0.0, remainingScore = 0.0;
+	NSInteger i, j;
+	CFRange matchedRange, remainingStrRange, adjustedStrRange = strRange;
+    
+	for (i = abbrRange.length; i > 0; i--) { //Search for steadily smaller portions of the abbreviation
+		CFStringRef curAbbr = CFStringCreateWithSubstring (NULL, abbr, CFRangeMake(abbrRange.location, i) );
+		//terminality
+		//axeen
+		BOOL found = CFStringFindWithOptionsAndLocale(str, curAbbr,
+                                                      CFRangeMake(adjustedStrRange.location, adjustedStrRange.length - abbrRange.length + i),
+                                                      kCFCompareCaseInsensitive | kCFCompareDiacriticInsensitive | kCFCompareLocalized,
+                                                      userLoc, &matchedRange);
+		CFRelease(curAbbr);
+		
+		if (!found) {
+			continue;
+		}
+		if (matchedRange.location + abbrRange.length > strRange.location + strRange.length) {
+			continue;
+		}
+		
+		if (mask) {
+			[mask addIndexesInRange:NSMakeRange(matchedRange.location, matchedRange.length)];
+		}
+		
+		remainingStrRange.location = matchedRange.location + matchedRange.length;
+		remainingStrRange.length = strRange.location + strRange.length - remainingStrRange.location;
+		
+		// Search what is left of the string with the rest of the abbreviation
+		remainingScore = QSScoreForAbbreviationWithRanges(str, abbr, mask, remainingStrRange, CFRangeMake(abbrRange.location + i, abbrRange.length - i) );
+		
+		if (remainingScore) {
+			score = remainingStrRange.location-strRange.location;
+			// ignore skipped characters if is first letter of a word
+			if (matchedRange.location>strRange.location) {//if some letters were skipped
+				static CFCharacterSetRef wordSeparator = NULL;
+				if (!wordSeparator)
+				{
+				  wordSeparator = CFCharacterSetCreateMutableCopy(NULL, CFCharacterSetGetPredefined(kCFCharacterSetWhitespace));
+				  CFCharacterSetAddCharactersInString((CFMutableCharacterSetRef)wordSeparator, (CFStringRef)@".");
+				}
+				static CFCharacterSetRef uppercase = NULL;
+				if (!uppercase) uppercase = CFCharacterSetGetPredefined(kCFCharacterSetUppercaseLetter);
+				if (CFCharacterSetIsCharacterMember(wordSeparator, CFStringGetCharacterFromInlineBuffer(&inlineBuffer, matchedRange.location-1) )) {
+					for (j = matchedRange.location-2; j >= (NSInteger) strRange.location; j--) {
+						if (CFCharacterSetIsCharacterMember(wordSeparator, CFStringGetCharacterFromInlineBuffer(&inlineBuffer, j) )) score--;
+						else score -= SKIPPED_SCORE;
+					}
+				} else if (CFCharacterSetIsCharacterMember(uppercase, CFStringGetCharacterFromInlineBuffer(&inlineBuffer, matchedRange.location) )) {
+					for (j = matchedRange.location-1; j >= (NSInteger) strRange.location; j--) {
+						if (CFCharacterSetIsCharacterMember(uppercase, CFStringGetCharacterFromInlineBuffer(&inlineBuffer, j) ))
+							score--;
+						else
+							score -= SKIPPED_SCORE;
+					}
+				} else {
+					score -= (matchedRange.location-strRange.location)/2;
+				}
+			}
+			score += remainingScore*remainingStrRange.length;
+			score /= strRange.length;
+            CFRelease(userLoc);
+			return score;
+		}
+	}
+    CFRelease(userLoc);
+	return 0;
+}

--- a/Quicksilver/Quicksilver.xcodeproj/project.pbxproj
+++ b/Quicksilver/Quicksilver.xcodeproj/project.pbxproj
@@ -158,6 +158,9 @@
 		4DD89F290EBDDBA9005A15AE /* QSNotifications.h in Headers */ = {isa = PBXBuildFile; fileRef = 4DD89F200EBDDBA9005A15AE /* QSNotifications.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4DD89F2A0EBDDBA9005A15AE /* QSPreferenceKeys.h in Headers */ = {isa = PBXBuildFile; fileRef = 4DD89F210EBDDBA9005A15AE /* QSPreferenceKeys.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4DD89F2B0EBDDBA9005A15AE /* QSTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 4DD89F220EBDDBA9005A15AE /* QSTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4DF329D61EA2C1C9003CD3CE /* QSSense.h in Headers */ = {isa = PBXBuildFile; fileRef = E1E5FB7907B20DD10044D6EF /* QSSense.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4DF329D71EA2C1D5003CD3CE /* QSSense.m in Sources */ = {isa = PBXBuildFile; fileRef = E1E5FB7A07B20DD10044D6EF /* QSSense.m */; };
+		4DF329D91EA2C5F0003CD3CE /* TestQSSense.m in Sources */ = {isa = PBXBuildFile; fileRef = 4DF329D81EA2C5F0003CD3CE /* TestQSSense.m */; };
 		4DF441B50ED9C66700656AD1 /* QSHandledObjectHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 7FB8AD4D08E6328D000A65C4 /* QSHandledObjectHandler.m */; };
 		4DFE7DA20E081A3B000B9AA3 /* NSImage+QuickLook.m in Sources */ = {isa = PBXBuildFile; fileRef = 4DFE7DA00E081A30000B9AA3 /* NSImage+QuickLook.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		4DFE7DA30E081A3C000B9AA3 /* NSImage+QuickLook.h in Headers */ = {isa = PBXBuildFile; fileRef = 4DFE7D9F0E081A30000B9AA3 /* NSImage+QuickLook.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -633,8 +636,6 @@
 		E1E5FBE207B20DD20044D6EF /* QSComputerSource.h in Headers */ = {isa = PBXBuildFile; fileRef = E1E5FB7507B20DD10044D6EF /* QSComputerSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E1E5FBE307B20DD20044D6EF /* QSComputerSource.m in Sources */ = {isa = PBXBuildFile; fileRef = E1E5FB7607B20DD10044D6EF /* QSComputerSource.m */; };
 		E1E5FBE407B20DD20044D6EF /* QSCore.h in Headers */ = {isa = PBXBuildFile; fileRef = E1E5FB7707B20DD10044D6EF /* QSCore.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E1E5FBE607B20DD20044D6EF /* QSense.h in Headers */ = {isa = PBXBuildFile; fileRef = E1E5FB7907B20DD10044D6EF /* QSense.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E1E5FBE707B20DD20044D6EF /* QSense.m in Sources */ = {isa = PBXBuildFile; fileRef = E1E5FB7A07B20DD10044D6EF /* QSense.m */; };
 		E1E5FBE807B20DD20044D6EF /* QSExecutor.h in Headers */ = {isa = PBXBuildFile; fileRef = E1E5FB7B07B20DD10044D6EF /* QSExecutor.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E1E5FBE907B20DD20044D6EF /* QSExecutor.m in Sources */ = {isa = PBXBuildFile; fileRef = E1E5FB7C07B20DD10044D6EF /* QSExecutor.m */; };
 		E1E5FBEA07B20DD20044D6EF /* QSGlobalSelectionProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = E1E5FB7D07B20DD10044D6EF /* QSGlobalSelectionProvider.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1177,6 +1178,7 @@
 		4DD89F200EBDDBA9005A15AE /* QSNotifications.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = QSNotifications.h; sourceTree = "<group>"; usesTabs = 1; };
 		4DD89F210EBDDBA9005A15AE /* QSPreferenceKeys.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = QSPreferenceKeys.h; sourceTree = "<group>"; usesTabs = 1; };
 		4DD89F220EBDDBA9005A15AE /* QSTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = QSTypes.h; sourceTree = "<group>"; usesTabs = 1; };
+		4DF329D81EA2C5F0003CD3CE /* TestQSSense.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TestQSSense.m; path = "Tests/Tests-QSFoundation/TestQSSense.m"; sourceTree = "<group>"; };
 		4DFE7D9F0E081A30000B9AA3 /* NSImage+QuickLook.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSImage+QuickLook.h"; sourceTree = "<group>"; };
 		4DFE7DA00E081A30000B9AA3 /* NSImage+QuickLook.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSImage+QuickLook.m"; sourceTree = "<group>"; };
 		4DFE7DA10E081A30000B9AA3 /* README.rtf */ = {isa = PBXFileReference; lastKnownFileType = text.rtf; path = README.rtf; sourceTree = "<group>"; };
@@ -2185,8 +2187,8 @@
 		E1E5FB7507B20DD10044D6EF /* QSComputerSource.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; path = QSComputerSource.h; sourceTree = "<group>"; usesTabs = 1; };
 		E1E5FB7607B20DD10044D6EF /* QSComputerSource.m */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.objc; path = QSComputerSource.m; sourceTree = "<group>"; usesTabs = 1; };
 		E1E5FB7707B20DD10044D6EF /* QSCore.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; path = QSCore.h; sourceTree = "<group>"; usesTabs = 1; };
-		E1E5FB7907B20DD10044D6EF /* QSense.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; path = QSense.h; sourceTree = "<group>"; usesTabs = 1; };
-		E1E5FB7A07B20DD10044D6EF /* QSense.m */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.objc; path = QSense.m; sourceTree = "<group>"; usesTabs = 1; };
+		E1E5FB7907B20DD10044D6EF /* QSSense.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; path = QSSense.h; sourceTree = "<group>"; usesTabs = 1; };
+		E1E5FB7A07B20DD10044D6EF /* QSSense.m */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.objc; path = QSSense.m; sourceTree = "<group>"; usesTabs = 1; };
 		E1E5FB7B07B20DD10044D6EF /* QSExecutor.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; path = QSExecutor.h; sourceTree = "<group>"; usesTabs = 1; };
 		E1E5FB7C07B20DD10044D6EF /* QSExecutor.m */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.objc; path = QSExecutor.m; sourceTree = "<group>"; usesTabs = 1; wrapsLines = 1; };
 		E1E5FB7D07B20DD10044D6EF /* QSGlobalSelectionProvider.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; path = QSGlobalSelectionProvider.h; sourceTree = "<group>"; usesTabs = 1; };
@@ -2642,6 +2644,7 @@
 			children = (
 				CD661C5319DBD2F3000F3695 /* TestNSApplicationMethods.m */,
 				66448E1214F42A4E000FA2E2 /* TestPathWildcards.m */,
+				4DF329D81EA2C5F0003CD3CE /* TestQSSense.m */,
 			);
 			name = QSFoundationTests;
 			sourceTree = "<group>";
@@ -3194,6 +3197,8 @@
 				CDCC200E10A4C14B009C4EED /* QSMDPredicate.h */,
 				CDCC200F10A4C14B009C4EED /* QSMDPredicate.m */,
 				4DD89F1F0EBDDBA9005A15AE /* QSMacros.h */,
+				E1E5FB7907B20DD10044D6EF /* QSSense.h */,
+				E1E5FB7A07B20DD10044D6EF /* QSSense.m */,
 				E1E5FA6E07B204BE0044D6EF /* NDAlias+QSMods.h */,
 				E1E5FA6F07B204BE0044D6EF /* NDAlias+QSMods.m */,
 				E1E5FA7007B204BE0044D6EF /* NDProcess+QSMods.h */,
@@ -3306,8 +3311,6 @@
 				4DD89F1C0EBDDBA9005A15AE /* QSDefines.h */,
 				D49399091350078E00B908C6 /* QSDownloads.h */,
 				D493990A1350078E00B908C6 /* QSDownloads.m */,
-				E1E5FB7907B20DD10044D6EF /* QSense.h */,
-				E1E5FB7A07B20DD10044D6EF /* QSense.m */,
 				E1E5FB7B07B20DD10044D6EF /* QSExecutor.h */,
 				E1E5FB7C07B20DD10044D6EF /* QSExecutor.m */,
 				E1E5FB7D07B20DD10044D6EF /* QSGlobalSelectionProvider.h */,
@@ -3600,7 +3603,6 @@
 				E1E5FBE407B20DD20044D6EF /* QSCore.h in Headers */,
 				4DD89F240EBDDBA9005A15AE /* QSDebug.h in Headers */,
 				4DD89F250EBDDBA9005A15AE /* QSDefines.h in Headers */,
-				E1E5FBE607B20DD20044D6EF /* QSense.h in Headers */,
 				E1E5FBE807B20DD20044D6EF /* QSExecutor.h in Headers */,
 				E1E5FBEA07B20DD20044D6EF /* QSGlobalSelectionProvider.h in Headers */,
 				7FB8AD4E08E6328D000A65C4 /* QSHandledObjectHandler.h in Headers */,
@@ -3772,6 +3774,7 @@
 				CD803A381C5C3D2D00CF90F3 /* SFLListItem.h in Headers */,
 				4D66BC25148701EA00351C42 /* NSPathControl+NDAlias.h in Headers */,
 				4D66BC27148701EA00351C42 /* NSSavePanel+NDAlias.h in Headers */,
+				4DF329D61EA2C1C9003CD3CE /* QSSense.h in Headers */,
 				4D66BC29148701EA00351C42 /* NSString+NDCarbonUtilities.h in Headers */,
 				D4BDCC1F19E7F8F50080710C /* SUExport.h in Headers */,
 				D4BDCC1C19E7F78F0080710C /* SUStandardVersionComparator.h in Headers */,
@@ -4603,6 +4606,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4DF329D91EA2C5F0003CD3CE /* TestQSSense.m in Sources */,
 				CD661C5419DBD2F3000F3695 /* TestNSApplicationMethods.m in Sources */,
 				66448E1314F42A4E000FA2E2 /* TestPathWildcards.m in Sources */,
 			);
@@ -4691,7 +4695,6 @@
 				E1E5FBDD07B20DD20044D6EF /* QSCollection.m in Sources */,
 				E1E5FBDF07B20DD20044D6EF /* QSCommand.m in Sources */,
 				E1E5FBE307B20DD20044D6EF /* QSComputerSource.m in Sources */,
-				E1E5FBE707B20DD20044D6EF /* QSense.m in Sources */,
 				E1E5FBE907B20DD20044D6EF /* QSExecutor.m in Sources */,
 				E1E5FBEB07B20DD20044D6EF /* QSGlobalSelectionProvider.m in Sources */,
 				4DF441B50ED9C66700656AD1 /* QSHandledObjectHandler.m in Sources */,
@@ -4809,6 +4812,7 @@
 				7FDF341907F7D59E00594789 /* NSDictionary+BLTRExtensions.m in Sources */,
 				7F3DB4BB0926D1620062EDFD /* NSEvent+BLTRExtensions.m in Sources */,
 				E1E5FABC07B204BF0044D6EF /* NSException_TraceExtensions.m in Sources */,
+				4DF329D71EA2C1D5003CD3CE /* QSSense.m in Sources */,
 				E1E5FABE07B204BF0044D6EF /* NSFileManager_BLTRExtensions.m in Sources */,
 				E1E5FAC007B204BF0044D6EF /* NSGeometry_BLTRExtensions.m in Sources */,
 				4DFE7DA20E081A3B000B9AA3 /* NSImage+QuickLook.m in Sources */,

--- a/Quicksilver/Tests/Tests-QSFoundation/TestQSSense.m
+++ b/Quicksilver/Tests/Tests-QSFoundation/TestQSSense.m
@@ -50,13 +50,13 @@ const float ACC = 0.00001;
 	XCTAssertEqualWithAccuracy(score, 0.90909, ACC);
 
 	score = [str scoreForAbbreviation:@"ts"];
-	XCTAssertEqualWithAccuracy(score, 0.83636, ACC);
+	XCTAssertEqualWithAccuracy(score, 0.92727, ACC);
 
 	score = [str scoreForAbbreviation:@"te"];
 	XCTAssertEqualWithAccuracy(score, 0.91818, ACC);
 
 	score = [str scoreForAbbreviation:@"tet"];
-	XCTAssertEqualWithAccuracy(score, 0.84545, ACC);
+	XCTAssertEqualWithAccuracy(score, 0.93636, ACC);
 
 	score = [str scoreForAbbreviation:@"str"];
 	XCTAssertEqualWithAccuracy(score, 0.91818, ACC);
@@ -65,7 +65,7 @@ const float ACC = 0.00001;
 	XCTAssertEqualWithAccuracy(score, 0.93181, ACC);
 
 	score = [str scoreForAbbreviation:@"ng"];
-	XCTAssertEqualWithAccuracy(score, 0.18181, ACC);
+	XCTAssertEqualWithAccuracy(score, 0.63636, ACC);
 }
 
 - (void)testScoreLongString {
@@ -108,13 +108,13 @@ const float ACC = 0.00001;
 	XCTAssertEqualWithAccuracy(score, 0.90222, ACC);
 
 	score = [str scoreForAbbreviation:@"ts"];
-	XCTAssertEqualWithAccuracy(score, 0.86444, ACC);
+	XCTAssertEqualWithAccuracy(score, 0.88666, ACC);
 
 	score = [str scoreForAbbreviation:@"te"];
 	XCTAssertEqualWithAccuracy(score, 0.80777, ACC);
 
 	score = [str scoreForAbbreviation:@"tet"];
-	XCTAssertEqualWithAccuracy(score, 0.79000, ACC);
+	XCTAssertEqualWithAccuracy(score, 0.81222, ACC);
 
 	score = [str scoreForAbbreviation:@"str"];
 	XCTAssertEqualWithAccuracy(score, 0.78555, ACC);
@@ -129,7 +129,7 @@ const float ACC = 0.00001;
 	XCTAssertEqualWithAccuracy(score, 0.75888, ACC);
 
 	score = [str scoreForAbbreviation:@"ng"];
-	XCTAssertEqualWithAccuracy(score, 0.52444, ACC);
+	XCTAssertEqualWithAccuracy(score, 0.74666, ACC);
 }
 
 - (void)testLongString {
@@ -213,25 +213,25 @@ const float ACC = 0.00001;
 
 	strRange.length += STEP;
 	score = [str scoreForAbbreviation:abbr inRange:strRange fromRange:abbrRange hitMask:indexes];
-	XCTAssertEqualWithAccuracy(score, 0.58846, ACC);
+	XCTAssertEqualWithAccuracy(score, 0.74230, ACC);
 	results = [NSIndexSet indexSetFromArray:@[@(0), @(5), @(15), @(16), @(22), @(23), @(26), @(36)]];
 	XCTAssertEqualObjects(indexes, results);
 
 	strRange.length += STEP;
 	score = [str scoreForAbbreviation:abbr inRange:strRange fromRange:abbrRange hitMask:indexes];
-	XCTAssertEqualWithAccuracy(score, 0.51279, ACC);
+	XCTAssertEqualWithAccuracy(score, 0.69883, ACC);
 	results = [NSIndexSet indexSetFromArray:@[@(0), @(5), @(15), @(16), @(22), @(23), @(26), @(36), @(40), @(41)]];
 	XCTAssertEqualObjects(indexes, results);
 
 	strRange.length += STEP;
 	score = [str scoreForAbbreviation:abbr inRange:strRange fromRange:abbrRange hitMask:indexes];
-	XCTAssertEqualWithAccuracy(score, 0.54574, ACC);
+	XCTAssertEqualWithAccuracy(score, 0.71595, ACC);
 	results = [NSIndexSet indexSetFromArray:@[@(0), @(5), @(15), @(16), @(22), @(23), @(26), @(36), @(40), @(41)]];
 	XCTAssertEqualObjects(indexes, results);
 
 	strRange.length += STEP;
 	score = [str scoreForAbbreviation:abbr inRange:strRange fromRange:abbrRange hitMask:indexes];
-	XCTAssertEqualWithAccuracy(score, 0.57352, ACC);
+	XCTAssertEqualWithAccuracy(score, 0.73039, ACC);
 	results = [NSIndexSet indexSetFromArray:@[@(0), @(5), @(15), @(16), @(22), @(23), @(26), @(36), @(40), @(41)]];
 	XCTAssertEqualObjects(indexes, results);
 }

--- a/Quicksilver/Tests/Tests-QSFoundation/TestQSSense.m
+++ b/Quicksilver/Tests/Tests-QSFoundation/TestQSSense.m
@@ -1,0 +1,268 @@
+//
+//  TestQSSense.m
+//  Quicksilver
+//
+//  Created by Etienne on 15/04/2017.
+//
+//
+
+#import <XCTest/XCTest.h>
+
+@interface TestQSSense : XCTestCase
+
+@end
+
+@implementation TestQSSense
+
+const float ACC = 0.00001;
+
+- (void)testScoreSimple {
+	CFStringRef str  = CFSTR("Test string");
+	CGFloat score = 0;
+
+	score = QSScoreForAbbreviation(str, CFSTR("t"), nil);
+	XCTAssertEqualWithAccuracy(score, 0.90909, ACC);
+
+	score = QSScoreForAbbreviation(str, CFSTR("ts"), nil);
+	XCTAssertEqualWithAccuracy(score, 0.92727, ACC);
+
+	score = QSScoreForAbbreviation(str, CFSTR("te"), nil);
+	XCTAssertEqualWithAccuracy(score, 0.91818, ACC);
+
+	score = QSScoreForAbbreviation(str, CFSTR("tet"), nil);
+	XCTAssertEqualWithAccuracy(score, 0.93636, ACC);
+
+	score = QSScoreForAbbreviation(str, CFSTR("str"), nil);
+	XCTAssertEqualWithAccuracy(score, 0.91818, ACC);
+
+	score = QSScoreForAbbreviation(str, CFSTR("tstr"), nil);
+	XCTAssertEqualWithAccuracy(score, 0.79090, ACC);
+
+	score = QSScoreForAbbreviation(str, CFSTR("ng"), nil);
+	XCTAssertEqualWithAccuracy(score, 0.63636, ACC);
+}
+
+- (void)testScoreSimpleNS {
+	NSString *str = @"Test string";
+	CGFloat score = 0;
+
+	score =	[str scoreForAbbreviation:@"t"];
+	XCTAssertEqualWithAccuracy(score, 0.90909, ACC);
+
+	score = [str scoreForAbbreviation:@"ts"];
+	XCTAssertEqualWithAccuracy(score, 0.83636, ACC);
+
+	score = [str scoreForAbbreviation:@"te"];
+	XCTAssertEqualWithAccuracy(score, 0.91818, ACC);
+
+	score = [str scoreForAbbreviation:@"tet"];
+	XCTAssertEqualWithAccuracy(score, 0.84545, ACC);
+
+	score = [str scoreForAbbreviation:@"str"];
+	XCTAssertEqualWithAccuracy(score, 0.91818, ACC);
+
+	score = [str scoreForAbbreviation:@"tstr"];
+	XCTAssertEqualWithAccuracy(score, 0.93181, ACC);
+
+	score = [str scoreForAbbreviation:@"ng"];
+	XCTAssertEqualWithAccuracy(score, 0.18181, ACC);
+}
+
+- (void)testScoreLongString {
+	CFStringRef str = CFSTR("This is a really long test string for testing");
+	CGFloat score = 0;
+
+	score = QSScoreForAbbreviation(str, CFSTR("t"), nil);
+	XCTAssertEqualWithAccuracy(score, 0.90222, ACC);
+
+	score = QSScoreForAbbreviation(str, CFSTR("ts"), nil);
+	XCTAssertEqualWithAccuracy(score, 0.88666, ACC);
+
+	score = QSScoreForAbbreviation(str, CFSTR("te"), nil);
+	XCTAssertEqualWithAccuracy(score, 0.80777, ACC);
+
+	score = QSScoreForAbbreviation(str, CFSTR("tet"), nil);
+	XCTAssertEqualWithAccuracy(score, 0.81222, ACC);
+
+	score = QSScoreForAbbreviation(str, CFSTR("str"), nil);
+	XCTAssertEqualWithAccuracy(score, 0.78555, ACC);
+
+	score = QSScoreForAbbreviation(str, CFSTR("tstr"), nil);
+	XCTAssertEqualWithAccuracy(score, 0.67777, ACC);
+
+	score = QSScoreForAbbreviation(str, CFSTR("testi"), nil);
+	XCTAssertEqualWithAccuracy(score, 0.74000, ACC);
+
+	score = QSScoreForAbbreviation(str, CFSTR("for"), nil);
+	XCTAssertEqualWithAccuracy(score, 0.75888, ACC);
+
+	score = QSScoreForAbbreviation(str, CFSTR("ng"), nil);
+	XCTAssertEqualWithAccuracy(score, 0.74666, ACC);
+}
+
+- (void)testScoreLongStringNS {
+	NSString *str = @"This is a really long test string for testing";
+	CGFloat score = 0;
+
+	score = [str scoreForAbbreviation:@"t"];
+	XCTAssertEqualWithAccuracy(score, 0.90222, ACC);
+
+	score = [str scoreForAbbreviation:@"ts"];
+	XCTAssertEqualWithAccuracy(score, 0.86444, ACC);
+
+	score = [str scoreForAbbreviation:@"te"];
+	XCTAssertEqualWithAccuracy(score, 0.80777, ACC);
+
+	score = [str scoreForAbbreviation:@"tet"];
+	XCTAssertEqualWithAccuracy(score, 0.79000, ACC);
+
+	score = [str scoreForAbbreviation:@"str"];
+	XCTAssertEqualWithAccuracy(score, 0.78555, ACC);
+
+	score = [str scoreForAbbreviation:@"tstr"];
+	XCTAssertEqualWithAccuracy(score, 0.78888, ACC);
+
+	score = [str scoreForAbbreviation:@"testi"];
+	XCTAssertEqualWithAccuracy(score, 0.74000, ACC);
+
+	score = [str scoreForAbbreviation:@"for"];
+	XCTAssertEqualWithAccuracy(score, 0.75888, ACC);
+
+	score = [str scoreForAbbreviation:@"ng"];
+	XCTAssertEqualWithAccuracy(score, 0.52444, ACC);
+}
+
+- (void)testLongString {
+	CFStringRef str = CFSTR("This excellent string tells us an interesting story");
+	CFRange strRange = CFRangeMake(0, 27); // tells^
+	CFStringRef abbr = CFSTR("test");
+	CFRange abbrRange = CFRangeMake(0, CFStringGetLength(abbr));
+	CGFloat score = 0;
+	const int STEP = 4;
+	NSMutableIndexSet *indexes = [[NSMutableIndexSet alloc] init];
+	NSIndexSet *results = nil;
+
+	score = QSScoreForAbbreviationWithRanges(str, CFSTR("test"), indexes, strRange, abbrRange);
+	XCTAssertEqualWithAccuracy(score, 0.74074, ACC);
+	results = [NSIndexSet indexSetFromArray:@[@(0), @(5), @(15), @(16), @(22), @(23)]];
+	XCTAssertEqualObjects(indexes, results);
+
+	strRange.length += STEP;
+	score = QSScoreForAbbreviationWithRanges(str, CFSTR("test"), indexes, strRange, abbrRange);
+	XCTAssertEqualWithAccuracy(score, 0.76129, ACC);
+	results = [NSIndexSet indexSetFromArray:@[@(0), @(5), @(15), @(16), @(22), @(23), @(26)]];
+	XCTAssertEqualObjects(indexes, results);
+
+	strRange.length += STEP;
+	score = QSScoreForAbbreviationWithRanges(str, CFSTR("test"), indexes, strRange, abbrRange);
+	XCTAssertEqualWithAccuracy(score, 0.77714, ACC);
+	results = [NSIndexSet indexSetFromArray:@[@(0), @(5), @(15), @(16), @(22), @(23), @(26)]];
+	XCTAssertEqualObjects(indexes, results);
+
+	strRange.length += STEP;
+	score = QSScoreForAbbreviationWithRanges(str, CFSTR("test"), indexes, strRange, abbrRange);
+	XCTAssertEqualWithAccuracy(score, 0.74230, ACC);
+	results = [NSIndexSet indexSetFromArray:@[@(0), @(5), @(15), @(16), @(22), @(23), @(26), @(36)]];
+	XCTAssertEqualObjects(indexes, results);
+
+	strRange.length += STEP;
+	score = QSScoreForAbbreviationWithRanges(str, CFSTR("test"), indexes, strRange, abbrRange);
+	XCTAssertEqualWithAccuracy(score, 0.69883, ACC);
+	results = [NSIndexSet indexSetFromArray:@[@(0), @(5), @(15), @(16), @(22), @(23), @(26), @(36), @(40), @(41)]];
+	XCTAssertEqualObjects(indexes, results);
+
+	strRange.length += STEP;
+	score = QSScoreForAbbreviationWithRanges(str, CFSTR("test"), indexes, strRange, abbrRange);
+	XCTAssertEqualWithAccuracy(score, 0.71595, ACC);
+	results = [NSIndexSet indexSetFromArray:@[@(0), @(5), @(15), @(16), @(22), @(23), @(26), @(36), @(40), @(41)]];
+	XCTAssertEqualObjects(indexes, results);
+
+	strRange.length += STEP;
+	score = QSScoreForAbbreviationWithRanges(str, CFSTR("test"), indexes, strRange, abbrRange);
+	XCTAssertEqualWithAccuracy(score, 0.73039, ACC);
+	results = [NSIndexSet indexSetFromArray:@[@(0), @(5), @(15), @(16), @(22), @(23), @(26), @(36), @(40), @(41)]];
+	XCTAssertEqualObjects(indexes, results);
+}
+
+- (void)testLongStringNS {
+	NSString *str = @"This excellent string tells us an interesting story";
+	NSRange strRange = NSMakeRange(0, 27); // tells^
+	NSString *abbr = @"test";
+	NSRange abbrRange = NSMakeRange(0, [abbr length]);
+	CGFloat score = 0;
+	const int STEP = 4;
+	NSMutableIndexSet *indexes = [[NSMutableIndexSet alloc] init];
+	NSIndexSet *results = nil;
+
+	score = [str scoreForAbbreviation:abbr inRange:strRange fromRange:abbrRange hitMask:indexes];
+	XCTAssertEqualWithAccuracy(score, 0.90185, ACC);
+	results = [NSIndexSet indexSetFromArray:@[@(0), @(5), @(15), @(16), @(22), @(23)]];
+	XCTAssertEqualObjects(indexes, results);
+
+	strRange.length += STEP;
+	score = [str scoreForAbbreviation:abbr inRange:strRange fromRange:abbrRange hitMask:indexes];
+	XCTAssertEqualWithAccuracy(score, 0.90161, ACC);
+	results = [NSIndexSet indexSetFromArray:@[@(0), @(5), @(15), @(16), @(22), @(23), @(26)]];
+	XCTAssertEqualObjects(indexes, results);
+
+	strRange.length += STEP;
+	score = [str scoreForAbbreviation:abbr inRange:strRange fromRange:abbrRange hitMask:indexes];
+	XCTAssertEqualWithAccuracy(score, 0.90142, ACC);
+	results = [NSIndexSet indexSetFromArray:@[@(0), @(5), @(15), @(16), @(22), @(23), @(26)]];
+	XCTAssertEqualObjects(indexes, results);
+
+	strRange.length += STEP;
+	score = [str scoreForAbbreviation:abbr inRange:strRange fromRange:abbrRange hitMask:indexes];
+	XCTAssertEqualWithAccuracy(score, 0.58846, ACC);
+	results = [NSIndexSet indexSetFromArray:@[@(0), @(5), @(15), @(16), @(22), @(23), @(26), @(36)]];
+	XCTAssertEqualObjects(indexes, results);
+
+	strRange.length += STEP;
+	score = [str scoreForAbbreviation:abbr inRange:strRange fromRange:abbrRange hitMask:indexes];
+	XCTAssertEqualWithAccuracy(score, 0.51279, ACC);
+	results = [NSIndexSet indexSetFromArray:@[@(0), @(5), @(15), @(16), @(22), @(23), @(26), @(36), @(40), @(41)]];
+	XCTAssertEqualObjects(indexes, results);
+
+	strRange.length += STEP;
+	score = [str scoreForAbbreviation:abbr inRange:strRange fromRange:abbrRange hitMask:indexes];
+	XCTAssertEqualWithAccuracy(score, 0.54574, ACC);
+	results = [NSIndexSet indexSetFromArray:@[@(0), @(5), @(15), @(16), @(22), @(23), @(26), @(36), @(40), @(41)]];
+	XCTAssertEqualObjects(indexes, results);
+
+	strRange.length += STEP;
+	score = [str scoreForAbbreviation:abbr inRange:strRange fromRange:abbrRange hitMask:indexes];
+	XCTAssertEqualWithAccuracy(score, 0.57352, ACC);
+	results = [NSIndexSet indexSetFromArray:@[@(0), @(5), @(15), @(16), @(22), @(23), @(26), @(36), @(40), @(41)]];
+	XCTAssertEqualObjects(indexes, results);
+}
+
+- (void)testPerformanceNS {
+	[self measureBlock:^{
+		[@"Test string" scoreForAbbreviation:@"tsg"];
+	}];
+}
+- (void)testPerformanceCF {
+    [self measureBlock:^{
+		CFStringRef str  = CFSTR("Test string");
+		CFStringRef abbr = CFSTR("tsg");
+
+		QSScoreForAbbreviationWithRanges(str, abbr, nil,
+										 CFRangeMake(0, CFStringGetLength(str)),
+										 CFRangeMake(0, CFStringGetLength(abbr)));
+	}];
+}
+
+- (void)testPerformanceCFMicro {
+	[self measureBlock:^{
+		CFStringRef str  = CFSTR("This is a really long test string for testing");
+		CFStringRef abbr = CFSTR("tsg");
+
+		for (int i = 0; i <= 100000; i++) {
+			QSScoreForAbbreviationWithRanges(str, abbr, nil,
+											 CFRangeMake(0, CFStringGetLength(str)),
+											 CFRangeMake(0, CFStringGetLength(abbr)));
+		}
+	}];
+}
+
+@end

--- a/Quicksilver/Tests/Tests-QSFoundation/TestQSSense.m
+++ b/Quicksilver/Tests/Tests-QSFoundation/TestQSSense.m
@@ -42,32 +42,6 @@ const float ACC = 0.00001;
 	XCTAssertEqualWithAccuracy(score, 0.63636, ACC);
 }
 
-- (void)testScoreSimpleNS {
-	NSString *str = @"Test string";
-	CGFloat score = 0;
-
-	score =	[str scoreForAbbreviation:@"t"];
-	XCTAssertEqualWithAccuracy(score, 0.90909, ACC);
-
-	score = [str scoreForAbbreviation:@"ts"];
-	XCTAssertEqualWithAccuracy(score, 0.92727, ACC);
-
-	score = [str scoreForAbbreviation:@"te"];
-	XCTAssertEqualWithAccuracy(score, 0.91818, ACC);
-
-	score = [str scoreForAbbreviation:@"tet"];
-	XCTAssertEqualWithAccuracy(score, 0.93636, ACC);
-
-	score = [str scoreForAbbreviation:@"str"];
-	XCTAssertEqualWithAccuracy(score, 0.91818, ACC);
-
-	score = [str scoreForAbbreviation:@"tstr"];
-	XCTAssertEqualWithAccuracy(score, 0.93181, ACC);
-
-	score = [str scoreForAbbreviation:@"ng"];
-	XCTAssertEqualWithAccuracy(score, 0.63636, ACC);
-}
-
 - (void)testScoreLongString {
 	CFStringRef str = CFSTR("This is a really long test string for testing");
 	CGFloat score = 0;
@@ -97,38 +71,6 @@ const float ACC = 0.00001;
 	XCTAssertEqualWithAccuracy(score, 0.75888, ACC);
 
 	score = QSScoreForAbbreviation(str, CFSTR("ng"), nil);
-	XCTAssertEqualWithAccuracy(score, 0.74666, ACC);
-}
-
-- (void)testScoreLongStringNS {
-	NSString *str = @"This is a really long test string for testing";
-	CGFloat score = 0;
-
-	score = [str scoreForAbbreviation:@"t"];
-	XCTAssertEqualWithAccuracy(score, 0.90222, ACC);
-
-	score = [str scoreForAbbreviation:@"ts"];
-	XCTAssertEqualWithAccuracy(score, 0.88666, ACC);
-
-	score = [str scoreForAbbreviation:@"te"];
-	XCTAssertEqualWithAccuracy(score, 0.80777, ACC);
-
-	score = [str scoreForAbbreviation:@"tet"];
-	XCTAssertEqualWithAccuracy(score, 0.81222, ACC);
-
-	score = [str scoreForAbbreviation:@"str"];
-	XCTAssertEqualWithAccuracy(score, 0.78555, ACC);
-
-	score = [str scoreForAbbreviation:@"tstr"];
-	XCTAssertEqualWithAccuracy(score, 0.78888, ACC);
-
-	score = [str scoreForAbbreviation:@"testi"];
-	XCTAssertEqualWithAccuracy(score, 0.74000, ACC);
-
-	score = [str scoreForAbbreviation:@"for"];
-	XCTAssertEqualWithAccuracy(score, 0.75888, ACC);
-
-	score = [str scoreForAbbreviation:@"ng"];
 	XCTAssertEqualWithAccuracy(score, 0.74666, ACC);
 }
 
@@ -184,64 +126,7 @@ const float ACC = 0.00001;
 	XCTAssertEqualObjects(indexes, results);
 }
 
-- (void)testLongStringNS {
-	NSString *str = @"This excellent string tells us an interesting story";
-	NSRange strRange = NSMakeRange(0, 27); // tells^
-	NSString *abbr = @"test";
-	NSRange abbrRange = NSMakeRange(0, [abbr length]);
-	CGFloat score = 0;
-	const int STEP = 4;
-	NSMutableIndexSet *indexes = [[NSMutableIndexSet alloc] init];
-	NSIndexSet *results = nil;
-
-	score = [str scoreForAbbreviation:abbr inRange:strRange fromRange:abbrRange hitMask:indexes];
-	XCTAssertEqualWithAccuracy(score, 0.90185, ACC);
-	results = [NSIndexSet indexSetFromArray:@[@(0), @(5), @(15), @(16), @(22), @(23)]];
-	XCTAssertEqualObjects(indexes, results);
-
-	strRange.length += STEP;
-	score = [str scoreForAbbreviation:abbr inRange:strRange fromRange:abbrRange hitMask:indexes];
-	XCTAssertEqualWithAccuracy(score, 0.90161, ACC);
-	results = [NSIndexSet indexSetFromArray:@[@(0), @(5), @(15), @(16), @(22), @(23), @(26)]];
-	XCTAssertEqualObjects(indexes, results);
-
-	strRange.length += STEP;
-	score = [str scoreForAbbreviation:abbr inRange:strRange fromRange:abbrRange hitMask:indexes];
-	XCTAssertEqualWithAccuracy(score, 0.90142, ACC);
-	results = [NSIndexSet indexSetFromArray:@[@(0), @(5), @(15), @(16), @(22), @(23), @(26)]];
-	XCTAssertEqualObjects(indexes, results);
-
-	strRange.length += STEP;
-	score = [str scoreForAbbreviation:abbr inRange:strRange fromRange:abbrRange hitMask:indexes];
-	XCTAssertEqualWithAccuracy(score, 0.74230, ACC);
-	results = [NSIndexSet indexSetFromArray:@[@(0), @(5), @(15), @(16), @(22), @(23), @(26), @(36)]];
-	XCTAssertEqualObjects(indexes, results);
-
-	strRange.length += STEP;
-	score = [str scoreForAbbreviation:abbr inRange:strRange fromRange:abbrRange hitMask:indexes];
-	XCTAssertEqualWithAccuracy(score, 0.69883, ACC);
-	results = [NSIndexSet indexSetFromArray:@[@(0), @(5), @(15), @(16), @(22), @(23), @(26), @(36), @(40), @(41)]];
-	XCTAssertEqualObjects(indexes, results);
-
-	strRange.length += STEP;
-	score = [str scoreForAbbreviation:abbr inRange:strRange fromRange:abbrRange hitMask:indexes];
-	XCTAssertEqualWithAccuracy(score, 0.71595, ACC);
-	results = [NSIndexSet indexSetFromArray:@[@(0), @(5), @(15), @(16), @(22), @(23), @(26), @(36), @(40), @(41)]];
-	XCTAssertEqualObjects(indexes, results);
-
-	strRange.length += STEP;
-	score = [str scoreForAbbreviation:abbr inRange:strRange fromRange:abbrRange hitMask:indexes];
-	XCTAssertEqualWithAccuracy(score, 0.73039, ACC);
-	results = [NSIndexSet indexSetFromArray:@[@(0), @(5), @(15), @(16), @(22), @(23), @(26), @(36), @(40), @(41)]];
-	XCTAssertEqualObjects(indexes, results);
-}
-
-- (void)testPerformanceNS {
-	[self measureBlock:^{
-		[@"Test string" scoreForAbbreviation:@"tsg"];
-	}];
-}
-- (void)testPerformanceCF {
+- (void)testPerformance {
     [self measureBlock:^{
 		CFStringRef str  = CFSTR("Test string");
 		CFStringRef abbr = CFSTR("tsg");
@@ -252,7 +137,7 @@ const float ACC = 0.00001;
 	}];
 }
 
-- (void)testPerformanceCFMicro {
+- (void)testPerformanceMicro {
 	[self measureBlock:^{
 		CFStringRef str  = CFSTR("This is a really long test string for testing");
 		CFStringRef abbr = CFSTR("tsg");


### PR DESCRIPTION
This is also a really old branch (2012 was a good year !).

So, we have 2 different versions of the ranking algorithm in-tree, both dating back from the Dawn of Time. The main ranking loop would use QSSense (through `QSStringRanker`). I haven't seen any use of the `NSString` category, but since it's hidden behind forwarding, it might be used sometimes.

~~They *had* a differing behavior (but I never found the time to thoroughly check).~~

The differing behavior was introduced in 87d328a actually. The comparison options are also a give-away (QSSense is case and diacritic insensitive and respect localization, the other is just case-insensitive.

So THE DIFFERENCE is what it is.

I've added a test case for it, because I wanted to 1) see it work 2) see what was different.