### PR TITLE
QSObject cleanup

### DIFF
--- a/Quicksilver/Code-App/QSController.m
+++ b/Quicksilver/Code-App/QSController.m
@@ -1029,7 +1029,7 @@ static QSController *defaultController = nil;
 #endif
     [NSApp disableRelaunchOnLogin];
 	[[NSNotificationCenter defaultCenter] postNotificationName:@"QSApplicationDidFinishLaunchingNotification" object:self];
-    [QSObject interfaceChanged];
+	[[NSNotificationCenter defaultCenter] postNotificationName:QSReleaseAllCachesNotification object:self];
     
     // Setup Activation Hotkey
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];

--- a/Quicksilver/Code-QuickStepCore/QSObject.h
+++ b/Quicksilver/Code-QuickStepCore/QSObject.h
@@ -38,17 +38,6 @@ extern NSSize QSMaxIconSize;
 #define kQSContents               @"QSObjectContents"
 #define kQSObjectComponents       @"QSObjectComponents"
 
-typedef struct _QSObjectFlags {
-	unsigned int		multiTyped:1;
-	unsigned int		iconLoaded:1;
-	unsigned int		childrenLoaded:1;
-	unsigned int		contentsLoaded:1;
-	unsigned int		noIdentifier:1;
-	unsigned int		isProxy:1;
-	unsigned int		retainsIcon:1;
-	//  NSCellType		  type:2;
-} QSObjectFlags;
-
 @interface QSObject : QSBasicObject <NSCopying, NSCoding> {
 	NSMutableDictionary *data QS_DEPRECATED; /* Temporary */
 }

--- a/Quicksilver/Code-QuickStepCore/QSObject.h
+++ b/Quicksilver/Code-QuickStepCore/QSObject.h
@@ -85,8 +85,6 @@ extern NSSize QSMaxIconSize;
 - (BOOL)loadIcon;
 - (BOOL)unloadIcon;
 
-- (void)updateIcon:(NSImage *)newIcon QS_DEPRECATED_MSG("Use -setIcon:");
-
 /** Type-handling */
 
 - (NSArray *)types;

--- a/Quicksilver/Code-QuickStepCore/QSObject.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject.m
@@ -109,9 +109,9 @@ NSSize QSMaxIconSize;
 }
 
 - (void)dealloc {
+	[[NSNotificationCenter defaultCenter] removeObserver:self];
 	if ([self iconLoaded])
 		[self unloadIcon];
-	[[NSNotificationCenter defaultCenter] removeObserver:self];
 	[self unloadChildren];
 }
 

--- a/Quicksilver/Code-QuickStepCore/QSObject.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject.m
@@ -634,8 +634,6 @@ typedef struct _QSObjectFlags {
 	}
 }
 
-- (void)updateIcon:(NSImage *)newIcon { self.icon = newIcon; }
-
 - (BOOL)iconLoaded {
 	@synchronized (self) {
 		return _flags.iconLoaded;

--- a/Quicksilver/Code-QuickStepCore/QSObject.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject.m
@@ -391,15 +391,12 @@ typedef struct _QSObjectFlags {
 }
 
 - (void)setPrimaryType:(NSString *)newPrimaryType {
-	if (_primaryType != newPrimaryType) {
-		_primaryType = newPrimaryType;
+	if (_primaryType == newPrimaryType) {
+		return;
 	}
 
-	/* FIXME: This can cause primaryType to have a different value between ivar
-	 * and _meta. At first, it's doesn't seems so bad, but a deserialized object
-	 * after a restart would get the UTI instead of the original primaryType
-	 */
 	newPrimaryType = QSUTIForAnyTypeString(newPrimaryType);
+	_primaryType = newPrimaryType;
 	[self setObject:newPrimaryType forMeta:kQSObjectPrimaryType];
 }
 

--- a/Quicksilver/Code-QuickStepCore/QSObject.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject.m
@@ -11,7 +11,30 @@ BOOL QSObjectInitialized = NO;
 
 NSSize QSMaxIconSize;
 
+@interface QSObject () {
+	/* Access mush be protected by @synchronized */
+	NSString *_identifier;
+	NSString *_name;
+	NSString *_label;
+	NSString *_details;
+	NSString *_primaryType;
+	id _primaryObject;
+
+	NSImage *_icon;
+
+	NSTimeInterval _lastAccess;
+	QSObjectFlags _flags;
+
+	/* Acts as a placeholder while the ivar is still accessible externally */
+	NSMutableDictionary *_data;
+}
+
+@end
+
 @implementation QSObject
+
+@synthesize data=data;
+
 + (void)initialize {
 	if (!QSObjectInitialized) {
 		QSMaxIconSize = QSSizeMax;
@@ -19,8 +42,6 @@ NSSize QSMaxIconSize;
 		[nc addObserver:self selector:@selector(interfaceChanged) name:QSInterfaceChangedNotification object:nil];
 		[nc addObserver:self selector:@selector(purgeOldImagesAndChildren) name:QSReleaseOldCachesNotification object:nil];
 		[nc addObserver:self selector:@selector(purgeAllImagesAndChildren) name:QSReleaseAllCachesNotification object:nil];
-
-	//	controller = [NSApp delegate];
 
 		iconLoadedSet = [[NSMutableSet alloc] init];
 		childLoadedSet = [[NSMutableSet alloc] init];
@@ -32,55 +53,88 @@ NSSize QSMaxIconSize;
 + (void)purgeAllImagesAndChildren {[self purgeImagesAndChildrenOlderThan:0.0];}
 
 + (void)purgeImagesAndChildrenOlderThan:(NSTimeInterval)interval {
-    NSTimeInterval tempLastAccess = 0;
-    NSSet *tempIconSet = nil;
-    NSSet *tempChildSet = nil;
+	NSTimeInterval tempLastAccess = 0;
+	NSSet *tempIconSet = nil;
+	NSSet *tempChildSet = nil;
 
-    // Make copies of the sets so we can purge them without bothering about threading
-    // We're synchronizing on the class instance, since those are class-ivars
-    @synchronized ([QSObject class]) {
-        tempLastAccess = globalLastAccess;
-        tempIconSet = [iconLoadedSet copy];
-        tempChildSet = [childLoadedSet copy];
-    }
+	// Make copies of the sets so we can purge them without bothering about threading
+	// We're synchronizing on the class instance, since those are class-ivars
+	@synchronized ([QSObject class]) {
+		tempLastAccess = globalLastAccess;
+		tempIconSet = [iconLoadedSet copy];
+		tempChildSet = [childLoadedSet copy];
+	}
 
 	for (QSObject *obj in tempIconSet) {
-		if (obj->lastAccess && obj->lastAccess < (tempLastAccess - interval)) {
+		if (obj->_lastAccess && obj->_lastAccess < (tempLastAccess - interval)) {
 			[obj unloadIcon];
 		}
 	}
 	for (QSObject *obj in tempChildSet) {
-		if (obj->lastAccess && obj->lastAccess < (tempLastAccess - interval)) {
+		if (obj->_lastAccess && obj->_lastAccess < (tempLastAccess - interval)) {
 			[obj unloadChildren];
 		}
 	}
 }
 
 + (void)interfaceChanged {
-	//QSMaxIconSize = [(QSInterfaceController *)[[NSApp delegate] interfaceController] maxIconSize];
 	[self purgeAllImagesAndChildren];
-	// if (VERBOSE) NSLog(@"newsize %f", QSMaxIconSize.width);
 }
 
-- (id)init {
-	if (self = [super init]) {
++ (instancetype)objectWithName:(NSString *)aName {
+	QSObject *newObject = [[self alloc] init];
+	newObject.name = aName;
+	return newObject;
+}
 
-		data = [NSMutableDictionary dictionaryWithCapacity:0];
-		meta = [NSMutableDictionary dictionaryWithCapacity:0];
-		cache = [QSThreadSafeMutableDictionary dictionaryWithCapacity:0];
-		name = nil;
-		label = nil;
-		icon = nil;
-		identifier = nil;
-		primaryType = nil;
-		lastAccess = 0;
-	}
++ (instancetype)objectWithIdentifier:(NSString *)anIdentifier {
+	return [QSLib objectWithIdentifier:anIdentifier];
+}
+
++ (instancetype)makeObjectWithIdentifier:(NSString *)anIdentifier {
+	QSObject *object = [[QSObject alloc] init];
+	object.identifier = anIdentifier;
+	return object;
+}
+
+- (instancetype)init {
+	self = [super init];
+	if (!self) return nil;
+
+	_data = data = [NSMutableDictionary dictionaryWithCapacity:0];
+	_meta = [NSMutableDictionary dictionaryWithCapacity:0];
+	_cache = [NSMutableDictionary dictionaryWithCapacity:0];
+
 	return self;
+}
+
+- (void)dealloc {
+	if ([self iconLoaded])
+		[self unloadIcon];
+	[[NSNotificationCenter defaultCenter] removeObserver:self];
+	[self unloadChildren];
 }
 
 - (NSUInteger)hash
 {
-	return identifier.hash ^ data.hash;
+	return _identifier.hash ^ _data.hash;
+}
+
+- (instancetype)initWithCoder:(NSCoder *)coder {
+	self = [self init];
+	if (!self) return nil;
+
+	[_meta setDictionary:[coder decodeObjectForKey:@"meta"]];
+	[_data setDictionary:[coder decodeObjectForKey:@"data"]];
+	[self extractMetadata];
+	id dup = [QSLib objectWithIdentifier:self.identifier];
+	if (dup) return dup;
+	return self;
+}
+
+- (void)encodeWithCoder:(NSCoder *)coder {
+	[coder encodeObject:self.meta forKey:@"meta"];
+	[coder encodeObject:self.data forKey:@"data"];
 }
 
 - (BOOL)isEqual:(QSObject *)anObject {
@@ -89,12 +143,14 @@ NSSize QSMaxIconSize;
 		anObject = [(QSRankedObject *)anObject object];
 	}
 	if (self == anObject) return YES;
-	NSString *otherIdentifier = anObject->identifier;
-	if ((identifier || otherIdentifier) && [identifier isEqualToString:otherIdentifier]) {
+	NSString *otherIdentifier = anObject->_identifier;
+	if ((_identifier || otherIdentifier) && [_identifier isEqualToString:otherIdentifier]) {
 		return YES;
 	}
-	if ([self count] > 1) {
-		if ([self count] != [anObject count]) {
+
+	/* FIXME: This must go live in QSCollection */
+	if (self.count > 1) {
+		if (self.count != anObject.count) {
 			return NO;
 		}
 		NSSet *myObjects = [NSSet setWithArray:[self splitObjects]];
@@ -103,28 +159,683 @@ NSSize QSMaxIconSize;
 			return NO;
 		}
 	} else {
-		if (![data isEqualToDictionary:anObject->data]) {
+		if (![_data isEqualToDictionary:anObject->_data]) {
 			return NO;
 		}
 	}
 	return YES;
 }
 
-+ (id)objectWithName:(NSString *)aName {
-	QSObject *newObject = [[self alloc] init];
-	[newObject setName:aName];
-	return newObject;
+- (NSString *)descriptionWithLocale:(NSDictionary *)locale indent:(NSUInteger)level {
+	return [_data descriptionWithLocale:locale indent:level];
 }
 
-+ (id)makeObjectWithIdentifier:(NSString *)anIdentifier {
-    QSObject *object = [[QSObject alloc] init];
-    [object setIdentifier:anIdentifier];
-    return object;
+/* TODO: rename -debugDescription */
+- (const char *) gdbDataFormatter {
+	return [[NSString stringWithFormat:@"name: %@, label: %@, identifier: %@, primaryType: %@, primaryObject: %@, meta: %@, data: %@, cache: %@, icon: %@, lastAccess: %f",
+			 (_name ? _name : @"nil"),
+			 (_label ? _label : @"nil"),
+			 (_identifier ? _identifier : @"nil"),
+			 (_primaryType ? _primaryType : @"nil"),
+			 (_primaryObject ? _primaryObject : @"nil"),
+			 (_meta ? [_meta descriptionInStringsFileFormat] : @"nil"),
+			 (_data ? [_data descriptionInStringsFileFormat] : @"nil"),
+			 (_cache ? [_cache descriptionInStringsFileFormat] : @"nil"),
+			 (_icon ? [_icon description] : @"nil"),
+			 (_lastAccess ? _lastAccess : 0.0f)] UTF8String];
 }
 
-+ (id)objectWithIdentifier:(NSString *)anIdentifier {
-	return [QSLib objectWithIdentifier:anIdentifier];
+- (id)copyWithZone:(NSZone *)zone {
+	QSObject *copy = [[[self class] allocWithZone:zone] init];
+
+	copy.name = [_name copy];
+	copy.label = [_label copy];
+	copy.identifier = [_identifier copy];
+	copy.icon = [_icon copy];
+	copy.primaryType = [_primaryType copy];
+	copy.primaryObject = [_primaryObject copy];
+
+	copy.meta = [_meta mutableCopy];
+	copy.data = [_data mutableCopy];
+	copy.cache = [_cache mutableCopy];
+
+	copy->_flags = _flags;
+	copy->_lastAccess = _lastAccess;
+
+	return copy;
 }
+
+/* FIXME: What is the meaning of this ?? */
+- (void)forwardInvocation:(NSInvocation *)invocation {
+	if ([_data respondsToSelector:[invocation selector]])
+		[invocation invokeWithTarget:_data];
+	else
+		[self doesNotRecognizeSelector:[invocation selector]];
+}
+
+- (NSString *)guessPrimaryType {
+	NSArray *allKeys = self.types;
+	if ([allKeys containsObject:QSFilePathType]) return QSFilePathType;
+	else if ([allKeys containsObject:QSURLType]) return QSURLType;
+	else if ([allKeys containsObject:QSTextType]) return QSTextType;
+	else if ([allKeys containsObject:NSColorPboardType]) return NSColorPboardType;
+
+	if ([allKeys count] == 1) return [allKeys lastObject];
+
+	return nil;
+}
+
+#pragma mark -
+#pragma mark Properties
+
+- (NSString *)identifier {
+	@synchronized (self) {
+		if (_flags.noIdentifier)
+			return nil;
+
+		if (!_identifier) {
+			NSString *ident = nil;
+			id handler = nil;
+			if (handler = [self handlerForSelector:@selector(identifierForObject:)]) {
+				ident = [handler identifierForObject:self];
+			}
+			if (!ident) {
+				ident = _meta[kQSObjectObjectID];
+			}
+			self.identifier = ident;
+		}
+
+		return _identifier;
+	}
+}
+
+- (void)setIdentifier:(NSString *)newIdentifier {
+	@synchronized(self) {
+		if (_identifier != nil && newIdentifier != nil) {
+			if(![_identifier isEqualToString:newIdentifier]) {
+				[QSLib removeObjectWithIdentifier:_identifier];
+				[QSLib setIdentifier:newIdentifier forObject:self];
+				_meta[newIdentifier] = kQSObjectObjectID;
+				_flags.noIdentifier = NO;
+				_identifier = newIdentifier;
+			}
+		}
+		else if (newIdentifier == nil) {
+			_flags.noIdentifier = YES;
+			[_meta removeObjectForKey:kQSObjectObjectID];
+			[QSLib removeObjectWithIdentifier:_identifier];
+			_identifier = nil;
+		} else if (_identifier == nil) {
+			_flags.noIdentifier = NO;
+			[QSLib setIdentifier:newIdentifier forObject:self];
+			_meta[newIdentifier] = kQSObjectObjectID;
+			_identifier = newIdentifier;
+		}
+	}
+}
+
+- (NSString *)name {
+	if (!_name) {
+		_name = _meta[kQSObjectPrimaryName];
+	}
+	return _name;
+}
+
+- (void)setName:(NSString *)newName {
+	if (![_name isEqualToString:newName]) {
+		if ([newName length] > 255) newName = [newName substringToIndex:255];
+		// ***warning  ** this should take first line only?
+		_name = newName;
+		if (newName) {
+			if ([newName isEqualToString:[self label]]) {
+				// label is only necessary if it differs
+				self.label = nil;
+			}
+			_meta[newName] = kQSObjectPrimaryName;
+		} else {
+			[_meta removeObjectForKey:kQSObjectPrimaryName];
+		}
+	}
+}
+
+- (NSString *)label {
+	if (!_label) {
+		self.label = _meta[kQSObjectAlternateName];
+	}
+	return _label;
+}
+
+- (void)setLabel:(NSString *)newLabel {
+	if (![newLabel isEqualToString:_label]) {
+		if (![newLabel length] || [newLabel isEqualToString:[self name]]) {
+			newLabel = nil;
+		}
+		_label = newLabel;
+	}
+	[self setObject:_label forMeta:kQSObjectAlternateName];
+}
+
+- (NSString *)details {
+	NSString *details = nil;
+
+	// check the object handler for this type
+	id handler = nil;
+	if (handler = [self handlerForSelector:@selector(detailsOfObject:)]) {
+		details = [handler detailsOfObject:self];
+	}
+
+	// check the cache
+	if (!details) {
+		details = _meta[kQSObjectDetails];
+	}
+
+	if (details) return details;
+
+	// no details from the handler or cache, so find them some other way and cache the result
+
+	NSBundle *mybundle = [self bundle];
+	// this is almost always (null) so test it first
+	if (mybundle) {
+		if (details) {
+			details = [mybundle safeLocalizedStringForKey:details value:details table:@"QSObject.details"];
+		} else {
+			details = [mybundle safeLocalizedStringForKey:[self identifier] value:details table:@"QSObject.details"];
+		}
+	}
+	if (details != nil) {
+		[self setObject:details forMeta:kQSObjectDetails];
+	} else if ([self stringValue]) {
+		details = [self stringValue];
+	} else if ([[self objectForType:self.primaryType] isKindOfClass:[NSString class]]) {
+		details = [self objectForType:self.primaryType];
+	}
+
+	return details;
+}
+
+- (void)setDetails:(NSString *)newDetails {
+	[self setObject:newDetails forMeta:kQSObjectDetails];
+}
+
+- (NSString *)primaryType {
+	if (_primaryType) {
+		return _primaryType;
+	}
+	if (!_primaryType)
+		_primaryType = _meta[kQSObjectPrimaryType];
+	if (!_primaryType)
+		_primaryType = [self guessPrimaryType];
+	if (_primaryType)
+		self.primaryType = _primaryType;
+	return _primaryType;
+}
+
+- (void)setPrimaryType:(NSString *)newPrimaryType {
+	if (_primaryType != newPrimaryType) {
+		_primaryType = newPrimaryType;
+	}
+
+	/* FIXME: This can cause primaryType to have a different value between ivar
+	 * and _meta. At first, it's doesn't seems so bad, but a deserialized object
+	 * after a restart would get the UTI instead of the original primaryType
+	 */
+	newPrimaryType = QSUTIForAnyTypeString(newPrimaryType);
+	[self setObject:newPrimaryType forMeta:kQSObjectPrimaryType];
+}
+
+- (NSString *)kind {
+	NSString *kind = _meta[kQSObjectKind];
+	if (kind) return kind;
+
+	id handler = nil;
+	if (handler = [self handlerForSelector:@selector(kindOfObject:)]) {
+		kind = [handler kindOfObject:self];
+		if (kind) {
+			_meta[kind] = kQSObjectKind;
+			return kind;
+		}
+	}
+
+	return self.primaryType;
+}
+
+- (void)setPrimaryObject:(id)obj {
+	_primaryObject = obj;
+}
+
+- (NSString *)displayName {
+	return self.label ? self.label : self.name;
+}
+
+- (NSString *)toolTip {
+#ifdef DEBUG
+	return [NSString stringWithFormat:@"%@ (%p) \r%@\rTypes:\r\t%@", self.name , self, self.details , [self.decodedTypes componentsJoinedByString:@"\r\t"]];
+#endif
+	return nil; //[self displayName];
+}
+
+- (id)primaryObject {return _data[self.primaryType]; }
+
+#pragma mark -
+#pragma mark Hierarchy
+
+- (QSObject *)parent {
+	QSObject * parent = nil;
+
+	id handler = nil;
+	if (handler = [self handlerForSelector:@selector(parentOfObject:)])
+		parent = [handler parentOfObject:self];
+
+	if (!parent)
+		parent = [QSLib objectWithIdentifier:_meta[kQSObjectParentID]];
+	return parent;
+}
+
+- (NSArray *)children {
+	if (!_flags.childrenLoaded || !self.childrenValid)
+		[self loadChildren];
+
+	return _cache[kQSObjectChildren];
+}
+
+- (void)setChildren:(NSArray *)newChildren {
+	if (newChildren) {
+		if (self.cache[kQSObjectChildren] != newChildren) {
+			self.cache[kQSObjectChildren] = newChildren;
+			NSString *parentID = self.identifier;
+			for (QSObject *child in newChildren) {
+				child.parentID = parentID;
+			}
+		}
+	} else {
+		[self.cache removeObjectForKey:kQSObjectChildren];
+	}
+}
+
+- (NSArray *)altChildren {
+	if (!_flags.childrenLoaded || !self.childrenValid)
+		[self loadChildren];
+	return self.cache[kQSObjectAltChildren];
+}
+
+- (void)setAltChildren:(NSArray *)newAltChildren {
+	if (newAltChildren) {
+		/* FIXME: Looks like a bug */
+		if (self.cache[kQSObjectChildren] != newAltChildren) {
+			self.cache[kQSObjectAltChildren] = newAltChildren;
+			NSString *parentID = self.identifier;
+			for (QSObject *child in newAltChildren) {
+				child.parentID = parentID;
+			}
+		}
+	} else {
+		[self.cache removeObjectForKey:kQSObjectAltChildren];
+	}
+}
+
+- (void)setParentID:(NSString *)parentID {
+	[self setObject:parentID forMeta:kQSObjectParentID];
+}
+
+- (BOOL)hasChildren {
+	id handler = nil;
+	if (handler = [self handlerForSelector:@selector(objectHasChildren:)])
+		return [handler objectHasChildren:self];
+	return NO;
+}
+
+- (void)loadChildren {
+	id handler = [self handlerForSelector:@selector(loadChildrenForObject:)];
+	if (handler && [handler loadChildrenForObject:self]) {
+		_flags.childrenLoaded = YES;
+		NSTimeInterval now = [NSDate timeIntervalSinceReferenceDate];
+		self.childrenLoadedDate = now;
+		_lastAccess = now;
+
+		@synchronized ([QSObject class]) {
+			globalLastAccess = now;
+			[childLoadedSet addObject:self];
+		}
+	}
+
+	NSArray *components = [self objectForCache:kQSObjectComponents];
+	if (components)
+		self.children = components;
+}
+
+- (BOOL)unloadChildren {
+	if (!self.childrenLoaded) return NO;
+
+	self.children = nil;
+	self.altChildren = nil;
+	_flags.childrenLoaded = NO;
+	self.childrenLoadedDate = 0;
+	@synchronized ([QSObject class]) {
+		[childLoadedSet removeObject:self];
+	}
+	return YES;
+}
+
+- (BOOL)childrenLoaded { return _flags.childrenLoaded;  }
+- (void)setChildrenLoaded:(BOOL)flag {
+	_flags.childrenLoaded = flag;
+}
+
+- (BOOL)childrenValid {
+	id handler = nil;
+	if (handler = [self handlerForSelector:@selector(objectHasValidChildren:)])
+		return [handler objectHasValidChildren:self];
+
+	return NO;
+}
+
+- (NSTimeInterval)childrenLoadedDate { return [self.meta[kQSObjectChildrenLoadDate] doubleValue];  }
+- (void)setChildrenLoadedDate:(NSTimeInterval)newChildrenLoadedDate {
+	self.meta[kQSObjectChildrenLoadDate] = @(newChildrenLoadedDate);
+}
+
+- (BOOL)contentsLoaded { return _flags.contentsLoaded;  }
+- (void)setContentsLoaded:(BOOL)flag {
+	_flags.contentsLoaded = flag;
+}
+
+#pragma mark -
+#pragma mark Icons
+
+- (NSImage *)icon {
+	NSTimeInterval now = [NSDate timeIntervalSinceReferenceDate];
+	_lastAccess = now;
+	@synchronized ([QSObject class]) {
+		globalLastAccess = now;
+	}
+
+	if (_icon) return _icon;
+
+	id handler = nil;
+	if (handler = [self handlerForSelector:@selector(setQuickIconForObject:)])
+		[handler setQuickIconForObject:self];
+
+	else if ([[self primaryType] isEqualToString:QSContactPhoneType])
+		self.icon = [QSResourceManager imageNamed:@"ContactPhone"];
+	else if ([[self primaryType] isEqualToString:QSContactAddressType])
+		self.icon = [QSResourceManager imageNamed:@"ContactAddress"];
+	else if ([[self primaryType] isEqualToString:QSEmailAddressType])
+		self.icon = [QSResourceManager imageNamed:@"ContactEmail"];
+
+	else if ([[self types] containsObject:@"BookmarkDictionaryListPboardType"]) {
+		self.icon = [QSResourceManager imageNamed:@"FadedDefaultBookmarkIcon"];
+	}
+
+	if (!_icon) {
+		// try and get an image from the QSTypeDefinitions dict
+		NSString *namedIcon = [[[QSReg tableNamed:@"QSTypeDefinitions"] objectForKey:[self primaryType]] objectForKey:@"icon"];
+		if (namedIcon) {
+			self.icon = [QSResourceManager imageNamed:namedIcon];
+		}
+	}
+	if (!_icon) {
+		self.icon = [QSResourceManager imageNamed:@"GenericQuestionMarkIcon"];
+	}
+
+	if (_icon) return _icon;
+	return nil;
+}
+
+- (void)setIcon:(NSImage *)newIcon {
+	if (newIcon != _icon) {
+		BOOL iconChange = (_icon != nil && newIcon != nil);
+		_icon = newIcon;
+		[_icon setCacheMode:NSImageCacheNever];
+		if (iconChange) {
+			// icon is being replaced, not set - notify UI
+			[[NSNotificationCenter defaultCenter] postNotificationName:QSObjectIconModified object:self];
+		}
+	}
+}
+
+- (void)updateIcon:(NSImage *)newIcon { self.icon = newIcon; }
+
+- (BOOL)iconLoaded { return _flags.iconLoaded;  }
+- (void)setIconLoaded:(BOOL)flag {
+	_flags.iconLoaded = flag;
+	@synchronized([QSObject class]) {
+		if (flag) {
+			[iconLoadedSet addObject:self];
+		} else {
+			[iconLoadedSet removeObject:self];
+		}
+	}
+}
+
+- (BOOL)retainsIcon { return _flags.retainsIcon;  }
+- (void)setRetainsIcon:(BOOL)flag {
+	_flags.retainsIcon = (flag>0);
+}
+
+- (BOOL)loadIcon {
+	NSString *namedIcon = [self objectForMeta:kQSObjectIconName];
+	if (self.iconLoaded && !namedIcon) {
+		return NO;
+	}
+
+	/* FIXME: Why isn't this done in -setIcon: ? */
+	self.iconLoaded = YES;
+	NSTimeInterval now = [NSDate timeIntervalSinceReferenceDate];
+	_lastAccess = now;
+	@synchronized ([QSObject class]) {
+		globalLastAccess = now;
+	}
+
+	if (namedIcon) {
+		NSImage *image = [QSResourceManager imageNamed:namedIcon];
+		if (image) {
+			self.icon = image;
+			return YES;
+		}
+	}
+
+	id handler = nil;
+	if (handler = [self handlerForSelector:@selector(loadIconForObject:)]) {
+		QSObject __weak *weakSelf = self;
+		dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0), ^{
+			// loadIconForObject returns a BOOL, but we can't return it from here
+			// nothing ever checks the return from loadIcon anyway
+			[handler loadIconForObject:weakSelf];
+		});
+		return YES;
+	}
+
+	if ([IMAGETYPES intersectsSet:[NSSet setWithArray:self.types]]) {
+		self.icon = [[NSImage alloc] initWithPasteboard:(NSPasteboard *)self];
+	}
+
+	if (!self.icon) {
+		self.icon = [QSResourceManager imageNamed:@"GenericQuestionMarkIcon"];
+		return NO;
+	}
+
+	return NO;
+}
+
+- (BOOL)unloadIcon {
+	if (!self.iconLoaded) return NO;
+	if (self.retainsIcon) return NO;
+
+	self.icon = nil;
+	self.iconLoaded = NO;
+	return YES;
+}
+
+- (BOOL)drawIconInRect:(NSRect)rect flipped:(BOOL)flipped {
+	id handler = nil;
+	if (handler = [self handlerForSelector:@selector(drawIconForObject:inRect:flipped:)]) {
+		return [handler drawIconForObject:self inRect:rect flipped:flipped];
+	}
+	return NO;
+}
+
+#pragma mark -
+#pragma mark Type-handling
+
+- (NSArray *)types {
+	/* FIXME: make not mutable */
+	NSMutableArray *array = [[self.data allKeys] mutableCopy];
+	return array;
+}
+
+- (NSArray *)decodedTypes {
+	NSMutableArray *decodedTypes = [NSMutableArray array];
+	for (NSString *thisType in self.data) {
+		[decodedTypes addObject:[thisType decodedPasteboardType]];
+	}
+	return decodedTypes;
+}
+
+- (id <QSObjectHandler>)handlerForType:(NSString *)type selector:(SEL)selector {
+	id __block handler = [[QSReg objectHandlers] objectForKey:type];
+	if (!handler) {
+		[[QSReg objectHandlers] enumerateKeysAndObjectsUsingBlock:^(NSString *handlerType, id anyHandler, BOOL *stop) {
+			if (UTTypeConformsTo((__bridge CFStringRef)type, (__bridge CFStringRef)handlerType) ||
+				(UTTypeConformsTo((__bridge CFStringRef)handlerType, kUTTypeText) && UTTypeConformsTo((__bridge CFStringRef)type, kUTTypeText))) {
+				handler = anyHandler;
+				*stop = YES;
+			}
+		}];
+	}
+	return (selector == NULL ? handler : ([handler respondsToSelector:selector] ? handler : nil ));
+}
+
+- (id <QSObjectHandler>)handlerForSelector:(SEL)selector {
+	return [self handlerForType:[self primaryType] selector:selector];
+}
+
+- (id <QSObjectHandler>)handler {
+	return [self handlerForType:[self primaryType] selector:nil];
+}
+
+#pragma mark -
+#pragma mark Low-level access
+
+- (id)objectForMeta:(id)aKey {
+	return self.meta[aKey];
+}
+
+- (void)setObject:(id)object forMeta:(id)aKey {
+	if (!aKey) return;
+
+	if (object) {
+		if (object != self.meta[aKey]) {
+			self.meta[aKey] = object;
+		}
+	} else {
+		[self.meta removeObjectForKey:aKey];
+	}
+}
+
+- (id)objectForType:(id)aKey {
+	id object = [self _safeObjectForType:aKey];
+	if ([object isKindOfClass:[NSArray class]]) {
+		if ([(NSArray *) object count] == 1) return [object lastObject];
+	} else {
+		aKey = QSUTIForAnyTypeString(aKey);
+		if ([aKey isEqualToString:QSTextType] && [object isKindOfClass:[NSData class]]) {
+			object = [[NSString alloc] initWithData:object encoding:NSUTF8StringEncoding];
+		}
+		return object;
+	}
+	// if the object for type: aKey is an array, we return 'nil' (not the actual array)
+	// For those cases we use arrayForType
+	return nil;
+}
+
+- (void)setObject:(id)object forType:(id)aKey {
+	if (!aKey) return;
+
+	aKey = QSUTIForAnyTypeString(aKey);
+	@synchronized (_data) {
+		if (object) {
+			if (object != _data[aKey]) {
+				_data[aKey] = object;
+			}
+		} else {
+			[_data removeObjectForKey:aKey];
+		}
+	}
+}
+
+- (id)objectForCache:(id)aKey {
+	return self.cache[aKey];
+}
+
+- (void)setObject:(id)object forCache:(id)aKey {
+	if (!aKey) return;
+
+	@synchronized(_cache) {
+		if (object) {
+			if (object != self.cache[aKey]) {
+				self.cache[aKey] = object;
+			}
+		} else {
+			[self.cache removeObjectForKey:aKey];
+		}
+	}
+}
+
+- (NSArray *)arrayForType:(id)aKey {
+	id object = [self _safeObjectForType:aKey];
+	if (!object) return nil;
+	if ([object isKindOfClass:[NSArray class]]) return object;
+	else return [NSArray arrayWithObject:object];
+}
+
+#pragma mark -
+#pragma mark Archiving
+
++ (instancetype)objectFromFile:(NSString *)path {
+	return [[self alloc] initFromFile:path];
+}
+
+- (instancetype)initFromFile:(NSString *)path {
+	self = [self init];
+	if (!self) return nil;
+
+	[_data setDictionary:[NSDictionary dictionaryWithContentsOfFile:path]];
+	[self extractMetadata];
+
+	return self;
+}
+
+- (void)writeToFile:(NSString *)path {
+	[self.data writeToFile:path atomically:YES];
+}
+
+- (void)extractMetadata {
+	if (_meta[kQSObjectIcon]) {
+		id iconRef = _meta[kQSObjectIcon];
+		if ([iconRef isKindOfClass:[NSData class]])
+			self.icon = [[NSImage alloc] initWithData:iconRef];
+		else if ([iconRef isKindOfClass:[NSString class]])
+			self.icon = [QSResourceManager imageNamed:iconRef];
+		/* FIXME: Again with the iconLoaded stuff */
+		if (self.icon != nil) {
+			self.IconLoaded = YES;
+		}
+	}
+	if (_meta[kQSObjectAlternateName])
+		self.label = _meta[kQSObjectAlternateName];
+	if (_meta[kQSObjectPrimaryName])
+		self.name = _meta[kQSObjectPrimaryName];
+	if (_meta[kQSObjectObjectID])
+		self.identifier = _meta[kQSObjectObjectID];
+	if (_meta[kQSObjectPrimaryType])
+		self.primaryType = _meta[kQSObjectPrimaryType];
+
+	[_data removeObjectForKey:QSProcessType]; // Don't carry over process info
+}
+
+@end
+
+@implementation QSObject (QSCollection)
 
 + (id)objectByMergingObjects:(NSArray *)objects withObject:(QSObject *)object {
 	if ([objects containsObject:object] || !object)
@@ -135,28 +846,14 @@ NSSize QSMaxIconSize;
 	return [self objectByMergingObjects:array];
 }
 
-- (NSArray *)splitObjects {
-    QSObject *object = [self resolvedObject];
-	if ([object count] == 1) {
-		return [NSArray arrayWithObject:object];
-	}
-	
-	NSArray *splitObjects = [object objectForCache:kQSObjectComponents];
-    
-    if (!splitObjects) {
-        splitObjects = [object children];
-    }
-    return splitObjects;
-}
-
 // Method to merge objects into a single 'combined' object
 + (id)objectByMergingObjects:(NSArray *)objects {
 	// if there's only 1 object, just return it
-	if ([objects count] == 1) {
-		return [objects objectAtIndex:0];
+	if (objects.count == 1) {
+		return objects[0];
 	}
 	NSMutableSet *typesSet = nil;
-	
+
 	// Dict to store each object's data
 	NSMutableDictionary *combinedData = [NSMutableDictionary dictionary];
 	NSString *type;
@@ -176,845 +873,124 @@ NSSize QSMaxIconSize;
 			[typesSet intersectSet:[NSSet setWithArray:[thisObject types]]];
 		}
 		for(type in typesSet) {
-			array = [combinedData objectForKey:type];
+			array = combinedData[type];
 			if (!array) {
-                [combinedData setObject:(array = [NSMutableArray array]) forKey:type];
-            }
-			
+				[combinedData setObject:(array = [NSMutableArray array]) forKey:type];
+			}
+
 			[array addObjectsFromArray:[thisObject arrayForType:type]];
 			// add the object to the setOfObjects to keep track of which objects we've added to combinedData
 			[setOfObjects addObject:thisObject];
 		}
 	}
-	
+
 	// If there's still only 1 object (case: if the comma trick is used on the same object multiple times)
 	if ([setOfObjects count] == 1) {
 		return [objects objectAtIndex:0];
 	}
-	
-    NSMutableArray *typesToRemove = [NSMutableArray array];
+
+	NSMutableArray *typesToRemove = [NSMutableArray array];
 	for(type in combinedData) {
 		if (![typesSet containsObject:type])
-            [typesToRemove addObject:type];
+			[typesToRemove addObject:type];
 	}
-	
-    [combinedData removeObjectsForKeys:typesToRemove];
-	
+
+	[combinedData removeObjectsForKeys:typesToRemove];
+
 	// Create the 'combined' object
 	QSObject *object = [[QSObject alloc] init];
-	[object setDataDictionary:combinedData];
-    [object setObject:objects forCache:kQSObjectComponents];
-	if ([combinedData objectForKey:QSFilePathType])
+	object.data = combinedData;
+	[object setObject:objects forCache:kQSObjectComponents];
+	if (combinedData[QSFilePathType])
 		// try to guess a name based on the file types
 		[object guessName];
 	else
 		// fall back on setting a simple name
-		[object setName:NSLocalizedString(@"Combined Objects", nil)];
+		object.name = NSLocalizedString(@"Combined Objects", nil);
 	return object;
 }
 
-- (void)dealloc {
-	//NSLog(@"dealloc %x %@", self, [self name]);
-    if ([self iconLoaded])
-        [self unloadIcon];
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
-	[self unloadChildren];
-	 data = nil;
-	 meta = nil;
-	 cache = nil;
-
-	 name = nil;
-	 label = nil;
-	 identifier = nil;
-	 icon = nil;
-	 primaryType = nil;
-	 primaryObject = nil;
-
-}
-
-// !!! Andre Berg 20091008: adding a gdbDataFormatter method which can be easily used 
-// as GDB data formatter, e.g. "<QSObject> {[$VAR gdbDataFormatter]}:s" will call it 
-// and display the result. The advantage is that this formatter will go less out of scope
-
-- (const char *) gdbDataFormatter {
-	return [[NSString stringWithFormat:@"name: %@, label: %@, identifier: %@, primaryType: %@, primaryObject: %@, meta: %@, data: %@, cache: %@, icon: %@, lastAccess: %f",
-             (name ? name : @"nil"),
-             (label ? label : @"nil"),
-             (identifier ? identifier : @"nil"),
-			 (primaryType ? primaryType : @"nil"),
-			 (primaryObject ? primaryObject : @"nil"),
-             (meta ? [meta descriptionInStringsFileFormat] : @"nil"),
-             (data ? [data descriptionInStringsFileFormat] : @"nil"),
-             (cache ? [cache descriptionInStringsFileFormat] : @"nil"),
-             (icon ? [icon description] : @"nil"),
-			 (lastAccess ? lastAccess : 0.0f)] UTF8String];
-}
-
-- (id)copyWithZone:(NSZone *)zone {
-    QSObject *copy = [[[self class] allocWithZone:zone] init];
-    
-    copy.name = [name copy];
-    copy.label = [label copy];
-    copy.identifier = [identifier copy];
-    copy.icon = [icon copy];
-    copy.primaryType = [primaryType copy];
-    copy.primaryObject = [primaryObject copy];
-    
-    copy.meta = [meta mutableCopy];
-    copy.data = [data mutableCopy];
-    copy.cache = [cache mutableCopy];
-    
-    copy.flags = flags;
-    copy.lastAccess = lastAccess;
-    
-    return copy;
-}
-
-- (void)setPrimaryObject:(id)obj {
-    primaryObject = obj;
-}
-
-- (void)setMeta:(NSMutableDictionary *)obj {
-    meta = obj;
-}
-
-- (void)setData:(NSMutableDictionary *)obj {
-    data = obj;
-}
-
-- (void)setFlags:(QSObjectFlags)fl {
-    flags = fl;
-}
-
-- (void)setLastAccess:(NSTimeInterval)lastAcc {
-    lastAccess = lastAcc;
-}
-
-- (NSString *)displayName {
-	return [self label] ? [self label] : [self name];
-}
-
-- (NSString *)toolTip {
-#ifdef DEBUG
-	return [NSString stringWithFormat:@"%@ (%p) \r%@\rTypes:\r\t%@", [self name] , self, [self details] , [[self decodedTypes] componentsJoinedByString:@"\r\t"]];
-#endif
-	return nil; //[self displayName];
-}
-
-- (NSString *)descriptionWithLocale:(NSDictionary *)locale indent:(NSUInteger)level {
-	return [data descriptionWithLocale:locale indent:level];
-}
-
-- (id <QSObjectHandler>)handlerForType:(NSString *)type selector:(SEL)selector {
-	id __block handler = [[QSReg objectHandlers] objectForKey:type];
-    if (!handler) {
-        [[QSReg objectHandlers] enumerateKeysAndObjectsUsingBlock:^(NSString *handlerType, id anyHandler, BOOL *stop) {
-            if (UTTypeConformsTo((__bridge CFStringRef)type, (__bridge CFStringRef)handlerType) ||
-                (UTTypeConformsTo((__bridge CFStringRef)handlerType, kUTTypeText) && UTTypeConformsTo((__bridge CFStringRef)type, kUTTypeText))) {
-                handler = anyHandler;
-                *stop = YES;
-            }
-        }];
-    }
-//    if(DEBUG && VERBOSE && handler == nil)
-//        NSLog(@"No handler for type %@", type);
-    
-    return (selector == NULL ? handler : ([handler respondsToSelector:selector] ? handler : nil ));
-}
-
-- (id <QSObjectHandler>)handlerForSelector:(SEL)selector {
-    return [self handlerForType:[self primaryType] selector:selector];
-}
-
-- (id <QSObjectHandler>)handler {
-	return [self handlerForType:[self primaryType] selector:nil];
-}
-
-- (BOOL)drawIconInRect:(NSRect)rect flipped:(BOOL)flipped {
-	id handler = nil;
-	 if (handler = [self handlerForSelector:@selector(drawIconForObject:inRect:flipped:)]) {
-		return [handler drawIconForObject:self inRect:rect flipped:flipped];
+- (NSArray *)splitObjects {
+	QSObject *object = [self resolvedObject];
+	if (object.count == 1) {
+		return @[object];
 	}
-	return NO;
-}
 
-- (void)setDetails:(NSString *)newDetails {
-    [self setObject:newDetails forMeta:kQSObjectDetails];
-}
+	NSArray *splitObjects = [object objectForCache:kQSObjectComponents];
 
-- (NSString *)details {
-	NSString *details = nil;
-
-	// check the object handler for this type
-    id handler = nil;
-	if (handler = [self handlerForSelector:@selector(detailsOfObject:)]) {
-		details = [handler detailsOfObject:self];
+	if (!splitObjects) {
+		splitObjects = [object children];
 	}
-    
-    // check the cache
-    if (!details) {
-        details = [meta objectForKey:kQSObjectDetails];
-    }
-    
-	if (details) return details;
-    
-    // no details from the handler or cache, so find them some other way and cache the result
-
-	NSBundle *mybundle = [self bundle];
-	// this is almost always (null) so test it first
-	if (mybundle) {
-		if (details) {
-			details = [mybundle safeLocalizedStringForKey:details value:details table:@"QSObject.details"];
-		} else {
-			details = [mybundle safeLocalizedStringForKey:[self identifier] value:details table:@"QSObject.details"];
-		}
-	}
-    if (details != nil) {
-        [self setObject:details forMeta:kQSObjectDetails];
-    } else if ([self stringValue]) {
-        details = [self stringValue];
-    } else if ([itemForKey([self primaryType]) isKindOfClass:[NSString class]]) {
-        details = itemForKey([self primaryType]);
-    }
-    
-	return details;
+	return splitObjects;
 }
 
-- (id)primaryObject {return itemForKey([self primaryType]);}
-	//- (id)objectForKey:(id)aKey {return [data objectForKey:aKey];}
-	//- (void)setObject:(id)object forKey:(id)aKey {[data setObject:object forKey:aKey];}
-
-- (id)_safeObjectForType:(id)aKey {
-    aKey = QSUTIForAnyTypeString(aKey);
-    return [data objectForKey:aKey];
-#if 0
-	if (flags.multiTyped)
-		return[data objectForKey:aKey];
-	else if ([[self primaryType] isEqualToString:aKey])
-		return data;
-	return nil;
-#endif
-}
-
-- (id)objectForType:(id)aKey {
-	id object = [self _safeObjectForType:aKey];
-	if ([object isKindOfClass:[NSArray class]]) {
-		if ([(NSArray *) object count] == 1) return [object lastObject];
-	} else {
-		aKey = QSUTIForAnyTypeString(aKey);
-        if ([aKey isEqualToString:QSTextType] && [object isKindOfClass:[NSData class]]) {
-            object = [[NSString alloc] initWithData:object encoding:NSUTF8StringEncoding];
-        }
-        return object;
-    }
-    // if the object for type: aKey is an array, we return 'nil' (not the actual array)
-    // For those cases we use arrayForType
-    return nil;
-}
-- (NSArray *)arrayForType:(id)aKey {
-	id object = [self _safeObjectForType:aKey];
-	if (!object) return nil;
-	if ([object isKindOfClass:[NSArray class]]) return object;
-	else return [NSArray arrayWithObject:object];
-}
-
-- (void)setObject:(id)object forType:(id)aKey {
-    if (!aKey) {
-        return;
-    }
-    aKey = QSUTIForAnyTypeString(aKey);
-    @synchronized(data) {
-        if (object) {
-            if (object != [data objectForKey:aKey]) {
-                [data setObject:object forKey:aKey];
-            }
-        } else {
-            [data removeObjectForKey:aKey];
-        }
-    }
-}
-
-- (id)objectForCache:(id)aKey {
-    return [cache objectForKey:aKey];
-}
-
-- (void)setObject:(id)object forCache:(id)aKey {
-    if (!aKey) {
-        return;
-    }
-	if (object) {
-		if (object != [[self cache] objectForKey:aKey]) {
-			[[self cache] setObject:object forKey:aKey];
-		}
-	} else {
-		[[self cache] removeObjectForKey:aKey];
-	}
-}
-
-- (id)objectForMeta:(id)aKey {
-    return [meta objectForKey:aKey];
-}
-
-- (void)setObject:(id)object forMeta:(id)aKey {
-    if (!aKey) {
-        return;
-    }
-    if (object) {
-        if (object != [meta objectForKey:aKey]) {
-            [meta setObject:object forKey:aKey];
-        }
-    } else {
-        [meta removeObjectForKey:aKey];
-    }
-}
-
-- (NSMutableDictionary *)cache {
-	return cache;
-}
-- (void)setCache:(NSMutableDictionary *)aCache {
-	if (cache != aCache) {
-		cache = [QSThreadSafeMutableDictionary dictionaryWithDictionary:aCache];
-	}
-}
-
-- (void)forwardInvocation:(NSInvocation *)invocation {
-	if ([data respondsToSelector:[invocation selector]])
-		[invocation invokeWithTarget:data];
-	else
-		[self doesNotRecognizeSelector:[invocation selector]];
-}
-
-- (NSString *)guessPrimaryType {
-	NSArray *allKeys = [data allKeys];
-	if ([allKeys containsObject:QSFilePathType]) return QSFilePathType;
-	else if ([allKeys containsObject:QSURLType]) return QSURLType;
-	else if ([allKeys containsObject:QSTextType]) return QSTextType;
-	else if ([allKeys containsObject:NSColorPboardType]) return NSColorPboardType;
-
-	if ([allKeys count] == 1) return [allKeys lastObject];
-
-	return nil;
-}
-
-- (NSArray *)types {
-	NSMutableArray *array = [[data allKeys] mutableCopy];
-
-	return array;
-}
-
-- (NSArray *)decodedTypes {
-	NSMutableArray *decodedTypes = [NSMutableArray arrayWithCapacity:[data count]];
-	for(NSString *thisType in data) {
-		[decodedTypes addObject:[thisType decodedPasteboardType]];
-	}
-	return decodedTypes;
-}
-
-- (NSUInteger) count {
-	if (![self primaryType]) {
+- (NSUInteger)count {
+	if (!self.primaryType) {
 		NSUInteger count = 1;
-		for(id value in [[self dataDictionary] allValues]) {
-			if ([value isKindOfClass:[NSArray class]]) count = MAX([(NSArray *)value count] , count);
+		for (id value in [self.data allValues]) {
+			if ([value isKindOfClass:[NSArray class]])
+				count = MAX([(NSArray *)value count], count);
 		}
 		return count;
 	}
-	id priObj = [self primaryObject];
+
+	id priObj = self.primaryObject;
 	if ([priObj isKindOfClass:[NSArray class]])
 		return [(NSArray *)priObj count];
+
 	return 1;
 }
 
 - (NSUInteger) primaryCount {
-	return [self count];
-}
-
-- (BOOL)isProxyObject
-{
-    return NO;
-}
-
-- (QSObject *)resolvedObject
-{
-    return self;
-}
-@end
-
-@implementation QSObject (Hierarchy)
-
-- (QSObject *)parent {
-    QSObject * parent = nil;
-
-	id handler = nil;
-	if (handler = [self handlerForSelector:@selector(parentOfObject:)])
-		parent = [handler parentOfObject:self];
-
-	if (!parent)
-		parent = [QSLib objectWithIdentifier:[meta objectForKey:kQSObjectParentID]];
-	return parent;
-}
-
-- (void)setParentID:(NSString *)parentID {
-    [self setObject:parentID forMeta:kQSObjectParentID];
-}
-
-- (BOOL)childrenValid {
-	id handler = nil;
-	if (handler = [self handlerForSelector:@selector(objectHasValidChildren:)])
-		return [handler objectHasValidChildren:self];
-
-	return NO;
-}
-
-- (BOOL)unloadChildren {
-	//NSLog(@"unload children of %@", self);
-
-	if (![self childrenLoaded]) return NO;
-	//NSLog(@"unloaded %@ %x", self, self);
-	[self setChildren:nil];
-	[self setAltChildren:nil];
-	flags.childrenLoaded = NO;
-	[self setChildrenLoadedDate:0];
-    @synchronized ([QSObject class]) {
-        [childLoadedSet removeObject:self];
-    }
-	return YES;
-}
-
-- (void)loadChildren {
-	id handler = [self handlerForSelector:@selector(loadChildrenForObject:)];
-	if (handler && [handler loadChildrenForObject:self]) {
-        flags.childrenLoaded = YES;
-        NSTimeInterval now = [NSDate timeIntervalSinceReferenceDate];
-        self.childrenLoadedDate = now;
-        self.lastAccess = now;
-
-        @synchronized ([QSObject class]) {
-            globalLastAccess = now;
-            [childLoadedSet addObject:self];
-        }
-    }
-
-    NSArray *components = [self objectForCache:kQSObjectComponents];
-    if (components)
-        [self setChildren:components];
-}
-
-- (BOOL)hasChildren {
-
-	id handler = nil;
-	if (handler = [self handlerForSelector:@selector(objectHasChildren:)])
-		return [handler objectHasChildren:self];
-	return NO;
-}
-@end
-
-//Standard Accessors
-
-@implementation QSObject (Accessors)
-
-- (NSString *)identifier {
-    @synchronized(self) {
-        if (flags.noIdentifier)
-            return nil;
-        
-        if (!identifier) {
-            NSString *ident = nil;
-            id handler = nil;
-            if (handler = [self handlerForSelector:@selector(identifierForObject:)]) {
-                ident = [handler identifierForObject:self];
-            }
-            if (!ident) {
-                ident = [meta objectForKey:kQSObjectObjectID];
-            }
-            [self setIdentifier:ident];
-        }
-        
-        return identifier;
-    }
-}
-
-- (void)setIdentifier:(NSString *)newIdentifier
-{
-    @synchronized(self) {
-        if (identifier != nil && newIdentifier != nil) {
-            if(![identifier isEqualToString:newIdentifier]) {
-                [QSLib removeObjectWithIdentifier:identifier];
-                [QSLib setIdentifier:newIdentifier forObject:self];
-                [meta setObject:newIdentifier forKey:kQSObjectObjectID];
-                flags.noIdentifier = NO;
-                identifier = newIdentifier;
-            }
-        }
-        else if (newIdentifier == nil) {
-            flags.noIdentifier = YES;
-            [meta removeObjectForKey:kQSObjectObjectID];
-            [QSLib removeObjectWithIdentifier:identifier];
-            identifier = nil;
-        } else if (identifier == nil) {
-            flags.noIdentifier = NO;
-			[QSLib setIdentifier:newIdentifier forObject:self];
-            [meta setObject:newIdentifier forKey:kQSObjectObjectID];
-            identifier = newIdentifier;
-        }
-    }
-}
-
-- (NSString *)name {
-	if (!name) {
-        name = [meta objectForKey:kQSObjectPrimaryName];
-    }
-	return name;
-}
-
-- (void)setName:(NSString *)newName {
-    if (![name isEqualToString:newName]) {
-        if ([newName length] > 255) newName = [newName substringToIndex:255];
-        // ***warning  ** this should take first line only?
-        name = newName;
-        if (newName) {
-            if ([newName isEqualToString:[self label]]) {
-                // label is only necessary if it differs
-                [self setLabel:nil];
-            }
-            [meta setObject:newName forKey:kQSObjectPrimaryName];
-        } else {
-            [meta removeObjectForKey:kQSObjectPrimaryName];
-        }
-    }
-}
-
-- (NSArray *)children {
-	if (!flags.childrenLoaded || ![self childrenValid])
-		[self loadChildren];
-
-	return [cache objectForKey:kQSObjectChildren];
-}
-
-- (void)setChildren:(NSArray *)newChildren {
-	if (newChildren) {
-        if ([[self cache] objectForKey:kQSObjectChildren] != newChildren) {
-            [[self cache] setObject:newChildren forKey:kQSObjectChildren];
-			NSString *parentID = [self identifier];
-			for (QSObject *child in newChildren) {
-				[child setParentID:parentID];
-			}
-        }
-    } else {
-        [[self cache] removeObjectForKey:kQSObjectChildren];
-    }
-}
-
-- (NSArray *)altChildren {
-	if (!flags.childrenLoaded || ![self childrenValid])
-		[self loadChildren];
-	return [cache objectForKey:kQSObjectAltChildren];
-}
-
-- (void)setAltChildren:(NSArray *)newAltChildren {
-	if (newAltChildren) {
-        if ([[self cache] objectForKey:kQSObjectChildren] != newAltChildren) {
-            [[self cache] setObject:newAltChildren forKey:kQSObjectAltChildren];
-			NSString *parentID = [self identifier];
-			for (QSObject *child in newAltChildren) {
-				[child setParentID:parentID];
-			}
-        }
-    } else {
-        [[self cache] removeObjectForKey:kQSObjectAltChildren];
-    }
-}
-
-- (NSString *)label {
-    if (!label) {
-        [self setLabel:[meta objectForKey:kQSObjectAlternateName]];
-    }
-    return label;
-}
-
-- (void)setLabel:(NSString *)newLabel {
-	if (![newLabel isEqualToString:label]) {
-        if (![newLabel length] || [newLabel isEqualToString:[self name]]) {
-            newLabel = nil;
-        }
-		label = newLabel;
-    }
-    [self setObject:label forMeta:kQSObjectAlternateName];
-}
-
-- (NSString *)kind {
-	NSString *kind = [meta objectForKey:kQSObjectKind];
-	if (kind) return kind;
-
-	id handler = nil;
-	if (handler = [self handlerForSelector:@selector(kindOfObject:)]) {
-		kind = [handler kindOfObject:self];
-		if (kind) {
-			[meta setObject:kind forKey:kQSObjectKind];
-			return kind;
-		}
-	}
-
-	return [self primaryType];
-}
-
-- (NSString *)primaryType {
-	if (primaryType) {
-		return primaryType;
-	}
-    if (!primaryType)
-        primaryType = [meta objectForKey:kQSObjectPrimaryType];
-	if (!primaryType)
-		primaryType = [self guessPrimaryType];
-	if (primaryType)
-		[self setPrimaryType:primaryType];
-	return primaryType;
-}
-- (void)setPrimaryType:(NSString *)newPrimaryType {
-    if (primaryType != newPrimaryType) {
-        primaryType = newPrimaryType;
-    }
-	newPrimaryType = QSUTIForAnyTypeString(newPrimaryType);
-    [self setObject:newPrimaryType forMeta:kQSObjectPrimaryType];
-}
-
-- (NSMutableDictionary *)dataDictionary {
-	return data;
-}
-
-- (void)setDataDictionary:(NSMutableDictionary *)newDataDictionary {
-    if (newDataDictionary != data) {
-        data = newDataDictionary;
-    }
-}
-
-- (BOOL)iconLoaded { return flags.iconLoaded;  }
-- (void)setIconLoaded:(BOOL)flag {
-	flags.iconLoaded = flag;
-    @synchronized([QSObject class]) {
-        if (flag) {
-            [iconLoadedSet addObject:self];
-        } else {
-            [iconLoadedSet removeObject:self];
-        }
-    }
-}
-
-- (BOOL)retainsIcon { return flags.retainsIcon;  }
-- (void)setRetainsIcon:(BOOL)flag {
-	flags.retainsIcon = (flag>0);
-}
-
-- (BOOL)childrenLoaded { return flags.childrenLoaded;  }
-- (void)setChildrenLoaded:(BOOL)flag {
-	flags.childrenLoaded = flag;
-}
-
-- (BOOL)contentsLoaded { return flags.contentsLoaded;  }
-- (void)setContentsLoaded:(BOOL)flag {
-	flags.contentsLoaded = flag;
-}
-- (NSTimeInterval) childrenLoadedDate { return [[meta objectForKey:kQSObjectChildrenLoadDate] doubleValue];  }
-- (void)setChildrenLoadedDate:(NSTimeInterval)newChildrenLoadedDate {
-	[meta setObject:[NSNumber numberWithDouble:newChildrenLoadedDate] forKey:kQSObjectChildrenLoadDate];
-}
-
-- (NSTimeInterval) lastAccess { return lastAccess;  }
-- (void)setlastAccess:(NSTimeInterval)newlastAccess {
-	lastAccess = newlastAccess;
+	return self.count;
 }
 
 @end
 
-@implementation QSObject (Archiving)
-+ (id)objectFromFile:(NSString *)path {
-	return [[self alloc] initFromFile:path];
-}
-- (id)initFromFile:(NSString *)path {
-	if (self = [self init]) {
-		[data setDictionary:[NSDictionary dictionaryWithContentsOfFile:path]];
-			[self extractMetadata];
-	}
-	return self;
-}
-- (void)writeToFile:(NSString *)path {
-	[data writeToFile:path atomically:YES];
-}
-- (id)initWithCoder:(NSCoder *)coder {
-	self = [self init];
+@implementation QSObject (QSProxySupport)
 
-	[meta setDictionary:[coder decodeObjectForKey:@"meta"]];
-	[data setDictionary:[coder decodeObjectForKey:@"data"]];
-	[self extractMetadata];
-	id dup = [QSLib objectWithIdentifier:[self identifier]];
-	if (dup) return dup;
-	return self;
+- (BOOL)isProxyObject { return NO; }
+
+- (QSObject *)resolvedObject { return self; }
+
+- (id)_safeObjectForType:(id)aKey {
+	aKey = QSUTIForAnyTypeString(aKey);
+	return self.data[aKey];
 }
 
-- (void)extractMetadata {
-	if ([meta objectForKey:kQSObjectIcon]) {
-		id iconRef = [meta objectForKey:kQSObjectIcon];
-		if ([iconRef isKindOfClass:[NSData class]])
-			[self setIcon:[[NSImage alloc] initWithData:iconRef]];
-		else if ([iconRef isKindOfClass:[NSString class]])
-			[self setIcon:[QSResourceManager imageNamed:iconRef]];
-        if (icon != nil) {
-            [self setIconLoaded:YES];
-        }
-	}
-    if ([meta objectForKey:kQSObjectAlternateName])
-		[self setLabel:[meta objectForKey:kQSObjectAlternateName]];
-    if ([meta objectForKey:kQSObjectPrimaryName])
-        [self setName:[meta objectForKey:kQSObjectPrimaryName]];
-	if ([meta objectForKey:kQSObjectObjectID]) {
-        [self setIdentifier:[meta objectForKey:kQSObjectObjectID]];
-    }
-	if ([meta objectForKey:kQSObjectPrimaryType])
-		[self setPrimaryType:[meta objectForKey:kQSObjectPrimaryType]];
-
-
-	[data removeObjectForKey:QSProcessType]; // Don't carry over process info
-}
-
-- (void)encodeWithCoder:(NSCoder *)coder {
-	[coder encodeObject:meta forKey:@"meta"];
-	[coder encodeObject:data forKey:@"data"];
-}
-
-@end
-
-@implementation QSObject (Icon)
-- (BOOL)loadIcon {
-  NSString *namedIcon = [self objectForMeta:kQSObjectIconName];
-	if ([self iconLoaded] && !namedIcon) {
-        return NO;
-	}
-	[self setIconLoaded:YES];
-    NSTimeInterval now = [NSDate timeIntervalSinceReferenceDate];
-	self.lastAccess = now;
-    @synchronized ([QSObject class]) {
-        globalLastAccess = now;
-    }
-
-	if (namedIcon) {
-        NSImage *image = [QSResourceManager imageNamed:namedIcon];
-		if (image) {
-			[self setIcon:image];
-			return YES;
-		}
-	}
-
-	id handler = nil;
-	if (handler = [self handlerForSelector:@selector(loadIconForObject:)]) {
-        QSObject __weak *weakSelf = self;
-        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0), ^{
-            // loadIconForObject returns a BOOL, but we can't return it from here
-            // nothing ever checks the return from loadIcon anyway
-            [handler loadIconForObject:weakSelf];
-        });
-        return YES;
-    }
-
-	//// if ([primaryType hasPrefix:@"QSCsontact"])
-	//	 return NO;
-    
-	if ([IMAGETYPES intersectsSet:[NSSet setWithArray:[data allKeys]]]) {
-		[self setIcon:[[NSImage alloc] initWithPasteboard:(NSPasteboard *)self]];
-	}
-    
-	if (![self icon]) {
-		[self setIcon:[QSResourceManager imageNamed:@"GenericQuestionMarkIcon"]];
-		return NO;
-	}
-    
-	return NO;
-}
-
-- (BOOL)unloadIcon {
-	if (![self iconLoaded]) return NO;
-	if ([self retainsIcon]) return NO;
-    
-	[self setIcon:nil];
-	[self setIconLoaded:NO];
-	return YES;
-}
-
-- (NSImage *)icon {
-    NSTimeInterval now = [NSDate timeIntervalSinceReferenceDate];
-	self.lastAccess = now;
-    @synchronized ([QSObject class]) {
-        globalLastAccess = now;
-    }
-    
-	if (icon) return icon;
-    
-	id handler = nil;
-	if (handler = [self handlerForSelector:@selector(setQuickIconForObject:)])
-		[handler setQuickIconForObject:self];
-    
-	else if ([[self primaryType] isEqualToString:QSContactPhoneType]) [self setIcon: [QSResourceManager imageNamed:@"ContactPhone"]];
-	else if ([[self primaryType] isEqualToString:QSContactAddressType]) [self setIcon: [QSResourceManager imageNamed:@"ContactAddress"]];
-    else if ([[self primaryType] isEqualToString:QSEmailAddressType]) [self setIcon: [QSResourceManager imageNamed:@"ContactEmail"]];
-    
-	else if ([[self types] containsObject:@"BookmarkDictionaryListPboardType"]) {
-		[self setIcon:[QSResourceManager imageNamed:@"FadedDefaultBookmarkIcon"]];
-	}
-    
-    if (!icon) {
-        // try and get an image from the QSTypeDefinitions dict
-        NSString *namedIcon = [[[QSReg tableNamed:@"QSTypeDefinitions"] objectForKey:[self primaryType]] objectForKey:@"icon"];
-        if (namedIcon) {
-            [self setIcon:[QSResourceManager imageNamed:namedIcon]];
-        }
-    }
-	if (!icon) {
-		[self setIcon:[QSResourceManager imageNamed:@"GenericQuestionMarkIcon"]];
-    }
-    
-	if (icon) return icon;
-	return nil;
-}
-
-- (void)setIcon:(NSImage *)newIcon {
-	if (newIcon != icon) {
-        BOOL iconChange = (icon != nil && newIcon != nil);
-		icon = newIcon;
-		[icon setCacheMode:NSImageCacheNever];
-        if (iconChange) {
-            // icon is being replaced, not set - notify UI
-            [[NSNotificationCenter defaultCenter] postNotificationName:QSObjectIconModified object:self];
-        }
-	}
-}
-
-- (void)updateIcon:(NSImage *)newIcon
-{
-    // deprecated - just use setIcon
-    [self setIcon:newIcon];
-}
 @end
 
 @implementation QSObject (Quicklook)
 
 - (NSURL *)previewItemURL
 {
-    if ([[self primaryType] isEqualToString:QSURLType]) {
-        NSString *urlString = [[[self dataDictionary] objectForKey:QSURLType] URLEncoding];
-        if (urlString) {
-        return [NSURL URLWithString:urlString];
-        }
-    }
-    else {
-        NSString *filePathString = [self singleFilePath];
-        if (filePathString) {
-        return [NSURL fileURLWithPath:filePathString];
-        }
-    }
-    return nil;
+	if ([self.primaryType isEqualToString:QSURLType]) {
+		NSString *urlString = [self.data[QSURLType] URLEncoding];
+		if (urlString) {
+			return [NSURL URLWithString:urlString];
+		}
+	}
+	else {
+		NSString *filePathString = self.singleFilePath;
+		if (filePathString) {
+			return [NSURL fileURLWithPath:filePathString];
+		}
+	}
+	return nil;
 }
 
 - (NSString *)previewItemTitle
 {
-    return [self name];
+	return self.name;
+}
+
+@end
+
+@implementation QSObject (QSDeprecated)
+
+- (NSMutableDictionary *)dataDictionary { return self.data; }
+- (void)setDataDictionary:(NSMutableDictionary *)newDataDictionary {
+	self.data = newDataDictionary;
 }
 
 @end

--- a/Quicksilver/Code-QuickStepCore/QSObject.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject.m
@@ -11,6 +11,16 @@ BOOL QSObjectInitialized = NO;
 
 NSSize QSMaxIconSize;
 
+typedef struct _QSObjectFlags {
+	unsigned int		multiTyped:1;
+	unsigned int		iconLoaded:1;
+	unsigned int		childrenLoaded:1;
+	unsigned int		contentsLoaded:1;
+	unsigned int		noIdentifier:1;
+	unsigned int		isProxy:1;
+	unsigned int		retainsIcon:1;
+} QSObjectFlags;
+
 @interface QSObject () {
 	/* Access mush be protected by @synchronized */
 	NSString *_identifier;

--- a/Quicksilver/Code-QuickStepCore/QSObject.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject.m
@@ -477,8 +477,7 @@ typedef struct _QSObjectFlags {
 
 - (void)setAltChildren:(NSArray *)newAltChildren {
 	if (newAltChildren) {
-		/* FIXME: Looks like a bug */
-		if (self.cache[kQSObjectChildren] != newAltChildren) {
+		if (self.cache[kQSObjectAltChildren] != newAltChildren) {
 			self.cache[kQSObjectAltChildren] = newAltChildren;
 			NSString *parentID = self.identifier;
 			for (QSObject *child in newAltChildren) {

--- a/Quicksilver/Code-QuickStepCore/QSObject.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject.m
@@ -675,9 +675,7 @@ NSSize QSMaxIconSize;
 #pragma mark Type-handling
 
 - (NSArray *)types {
-	/* FIXME: make not mutable */
-	NSMutableArray *array = [[self.data allKeys] mutableCopy];
-	return array;
+	return [self.data allKeys];
 }
 
 - (NSArray *)decodedTypes {

--- a/Quicksilver/Code-QuickStepCore/QSObject.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject.m
@@ -170,19 +170,16 @@ NSSize QSMaxIconSize;
 	return [_data descriptionWithLocale:locale indent:level];
 }
 
-/* TODO: rename -debugDescription */
-- (const char *) gdbDataFormatter {
-	return [[NSString stringWithFormat:@"name: %@, label: %@, identifier: %@, primaryType: %@, primaryObject: %@, meta: %@, data: %@, cache: %@, icon: %@, lastAccess: %f",
-			 (_name ? _name : @"nil"),
-			 (_label ? _label : @"nil"),
-			 (_identifier ? _identifier : @"nil"),
-			 (_primaryType ? _primaryType : @"nil"),
-			 (_primaryObject ? _primaryObject : @"nil"),
-			 (_meta ? [_meta descriptionInStringsFileFormat] : @"nil"),
-			 (_data ? [_data descriptionInStringsFileFormat] : @"nil"),
-			 (_cache ? [_cache descriptionInStringsFileFormat] : @"nil"),
-			 (_icon ? [_icon description] : @"nil"),
-			 (_lastAccess ? _lastAccess : 0.0f)] UTF8String];
+// Used by the debugger
+- (NSString *)debugDescription
+{
+	return [NSString stringWithFormat:@"name: %@, label: %@, identifier: %@, primaryType: %@, primaryObject: %@, meta: %@, data: %@, cache: %@, icon: %@, lastAccess: %f",
+			self.name, self.label, self.identifier, self.primaryType, self.primaryObject,
+			self.meta.descriptionInStringsFileFormat,
+			self.data.descriptionInStringsFileFormat,
+			self.cache.descriptionInStringsFileFormat,
+			self.icon.debugDescription,
+			_lastAccess];
 }
 
 - (id)copyWithZone:(NSZone *)zone {

--- a/Quicksilver/Code-QuickStepCore/QSObject_Pasteboard.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject_Pasteboard.m
@@ -119,7 +119,7 @@ id objectForPasteboardType(NSPasteboard *pasteboard, NSString *type) {
             source =  @"Clipboard";
             sourceApp = source;
         }
-        [data removeAllObjects];
+
 		[self addContentsOfPasteboard:pasteboard types:types];
 
 		[self setObject:source forMeta:kQSObjectSource];

--- a/Quicksilver/Code-QuickStepCore/QSObject_Pasteboard.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject_Pasteboard.m
@@ -170,14 +170,14 @@ id objectForPasteboardType(NSPasteboard *pasteboard, NSString *type) {
 }
 
 - (void)guessName {
-	if (itemForKey(QSFilePathType) ) {
+	if ([self objectForType:QSFilePathType]) {
 		[self setPrimaryType:QSFilePathType];
 		[self getNameFromFiles];
 	} else {
-        NSString *textString = itemForKey(QSTextType);
+        NSString *textString = [self objectForType:QSTextType];
         // some objects (images from the web) don't have a text string but have a URL
         if (!textString) {
-            textString = itemForKey(NSURLPboardType);
+			textString = [self objectForType:NSURLPboardType];
         }
         textString = [textString stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
         
@@ -210,7 +210,7 @@ id objectForPasteboardType(NSPasteboard *pasteboard, NSString *type) {
         }
 
         for (NSString *key in keys) {
-			if (itemForKey(key) ) {
+			if ([self objectForType:key]) {
                 if ([key isEqualToString:QSTextType]) {
                     [self setDetails:nil];
                 } else {
@@ -337,7 +337,7 @@ id objectForPasteboardType(NSPasteboard *pasteboard, NSString *type) {
 }
 
 - (NSData *)dataForType:(NSString *)dataType {
-	id theData = [data objectForKey:dataType];
+	id theData = [self objectForType:dataType];
 	if ([theData isKindOfClass:[NSData class]]) return theData;
 	return nil;
 }

--- a/Quicksilver/Code-QuickStepCore/QSObject_PropertyList.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject_PropertyList.m
@@ -35,12 +35,14 @@
 }
 
 - (id)initWithString:(NSString *)string name:(NSString *)aName type:(NSString *)aType {
-	if (self = [self init]) {
-		[self setName:aName];
-		[self setPrimaryType:aType];
-		[data setObject:string forKey:aType];
-		[data setObject:string forKey:QSTextType];
-	}
+	self = [self init];
+	if (!self) return nil;
+
+	self.name = aName;
+	self.primaryType = aType;
+	self.data[aType] = string;
+	self.data[QSTextType] = string;
+
 	return self;
 }
 
@@ -48,13 +50,16 @@
 	return[(QSObject *)[QSObject alloc] initWithType:(NSString *)type value:(id)value name:(NSString *)newName];
 }
 - (id)initWithType:(NSString *)type value:(id)value name:(NSString *)newName {
-	if (self = [self init]) {
-		[data setObject:value forKey:type];
-		[self setName:newName];
-		[self setPrimaryType:type];
-	}
+	self = [self init];
+	if (!self) return nil;
+
+	[self.data setObject:value forKey:type];
+	[self setName:newName];
+	[self setPrimaryType:type];
+
 	return self;
 }
+
 + (id)objectsWithDictionaryArray:(NSArray *)dictionaryArray {
 	NSMutableArray *dictObjectArray = [NSMutableArray arrayWithCapacity:[dictionaryArray count]];
 	for (id loopItem in dictionaryArray) {
@@ -69,9 +74,9 @@
 }
 
 - (void)changeFilesToPaths {
-	id object = [data objectForKey:QSFilePathType]; //[self arrayForType:];
+	id object = [self objectForType:QSFilePathType];
 	if (object)
-		[data setObject:[object valueForKey:@"stringByStandardizingPath"] forKey:QSFilePathType];
+		[self setObject:[object valueForKey:@"stringByStandardizingPath"] forType:QSFilePathType];
 }
 
 - (id)initWithDictionary:(NSDictionary *)dictionary {
@@ -89,14 +94,14 @@
     self = [self init];
     if (!self) return nil;
 
-    [data setDictionary:dataDict];
-    [meta setDictionary:metaDict];
+    [self.data setDictionary:dataDict];
+    [self.meta setDictionary:metaDict];
 
     [self extractMetadata];
 
     // Check immediately if we already have loaded that object
     // ***warning  * should this update the name for files?
-    id dup = [QSLib objectWithIdentifier:identifier];
+    id dup = [QSLib objectWithIdentifier:self.identifier];
     if (dup) return dup;
 
     if ([self containsType:QSFilePathType] || [self containsType:NSFilenamesPboardType]) {
@@ -109,8 +114,8 @@
 - (NSDictionary *)dictionaryRepresentation {
     // copies of data and meta are made to avoid them being mutated down the line
     return [NSDictionary dictionaryWithObjectsAndKeys:
-            [data copy], kData,
-            [meta copy], kMeta,
+            [self.data copy], kData,
+            [self.meta copy], kMeta,
             NSStringFromClass([self class]), kQSObjectClass,
             nil];
 }

--- a/Quicksilver/Code-QuickStepCore/QSObject_StringHandling.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject_StringHandling.m
@@ -66,12 +66,15 @@
     if (![string length]) {
         return nil;
     }
-	if (self = [self init]) {
-		[data setObject:string forKey:QSTextType];
-		[self setName:string];
-		[self setPrimaryType:QSTextType];
-		[self sniffString];
-	}
+
+	self = [self init];
+	if (!self) return nil;
+
+	[self setObject:string forType:QSTextType];
+	[self setName:string];
+	[self setPrimaryType:QSTextType];
+	[self sniffString];
+
 	return self;
 }
 

--- a/Quicksilver/Code-QuickStepCore/QSObject_StringHandling.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject_StringHandling.m
@@ -122,6 +122,7 @@
 				[self setObject:[NSDictionary dictionaryWithObjectsAndKeys:[files lastObject] , @"path", [NSNumber numberWithInteger:line] , @"line", nil] forType:@"QSLineReferenceType"];
 			}
             // wipe existing types and set this up as a file
+			/* FIXME: Just after doing a bunch of QSLineReferenceType things above ? */
             [[self dataDictionary] removeAllObjects];
 			[self setObject:files forType:QSFilePathType];
 			[self setPrimaryType:QSFilePathType];

--- a/Quicksilver/Code-QuickStepCore/QSProxyObject.h
+++ b/Quicksilver/Code-QuickStepCore/QSProxyObject.h
@@ -21,28 +21,24 @@
 
 @protocol QSProxyObjectProvider
 - (id)resolveProxyObject:(id)proxy;
-@end
-
-@interface NSObject (QSProxyObjectProvider)
+@optional
 - (NSArray *)typesForProxyObject:(id)proxy;
 - (BOOL)bypassValidation;
 - (NSTimeInterval)cacheTimeForProxy:(id)proxy;
 @end
 
 @interface QSProxyObject : QSObject
-+ (id)proxyWithDictionary:(NSDictionary*)dictionary;
-+ (id)proxyWithIdentifier:(NSString*)identifier;
++ (instancetype)proxyWithDictionary:(NSDictionary*)dictionary;
++ (instancetype)proxyWithIdentifier:(NSString*)identifier;
+
 - (NSObject <QSProxyObjectProvider> *)proxyProvider;
-- (QSObject*)proxyObject;
+- (QSObject *)proxyObject;
 
 - (void)releaseProxy:(NSNotification *)notif;
 
 - (BOOL)bypassValidation;
 - (NSArray *)proxyTypes;
-//- (id)proxyObjectWithProviderClass:(NSString *)providerClass;
-- (void)objectIconModified:(NSNotification *)notif;
 @end
-
 
 @interface QSGlobalSelectionProxyProvider : NSObject
 - (QSObject *)proxy;

--- a/Quicksilver/Code-QuickStepCore/QSProxyObject.m
+++ b/Quicksilver/Code-QuickStepCore/QSProxyObject.m
@@ -96,10 +96,10 @@
 			return;
 		}
 	}
-	// Send the notification before niling our target
-	/* FIXME: I'm not actually quite sure what we're trying to do here... */
-	[[NSNotificationCenter defaultCenter] removeObserver:self name:QSObjectIconModified object:self.cache[QSProxyTargetCache]];
+
+	/* Release our proxied object (and observations) so we refresh it next time */
 	self.cache[QSProxyTargetCache] = nil;
+	[[NSNotificationCenter defaultCenter] removeObserver:self name:QSObjectIconModified object:nil];
 	[[NSNotificationCenter defaultCenter] removeObserver:self name:QSInterfaceDeactivatedNotification object:nil];
 	[[NSNotificationCenter defaultCenter] removeObserver:self name:QSCommandExecutedNotification object:nil];
 }

--- a/Quicksilver/Code-QuickStepCore/QSProxyObject.m
+++ b/Quicksilver/Code-QuickStepCore/QSProxyObject.m
@@ -170,12 +170,7 @@
     NSString *namedIcon = [self objectForMeta:kQSObjectIconName];
     if (!namedIcon || [namedIcon isEqualToString:@"ProxyIcon"]) {
         // use the resolved object's icon instead
-		/* FIXME: WTF... */
-        QSObject *resolved = self.resolvedObject;
-        self.icon = resolved.icon;
-        self.iconLoaded = YES;
-	    [resolved loadIcon];
-        return YES;
+		return [self.resolvedObject loadIcon];
     }
     return [super loadIcon];
 }

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Code/QSHTMLLinkParser.m
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Code/QSHTMLLinkParser.m
@@ -106,7 +106,6 @@
 			if (imageurl.length) {
 				imageurl = [[NSURL URLWithString:imageurl relativeToURL:source] absoluteString];
 				[newObject setObject:imageurl forMeta:kQSObjectIconName];
-				[newObject setIconLoaded:NO];
 			}
 			if (newObject) {
 				[objects addObject:newObject];


### PR DESCRIPTION
This is the result of my weekend's code-crunching-fest. Now I'm depressed.

I enabled TSan. I noticed a bunch of races, and tried to fix them all. There's more in `QSIconLoader`, which I tried to look at but ended up resetting everything. The icon loading system is hopeless.

This has broken icon loading, and guaranteed deadlocks, instead of weird crashes (did you know you could nil objects *inside* a set ? I didn't. At one point I had an `iconLoadedSet` with mostly nils inside, which exception-ed on `-copy`).

Also, exception aren't catchable anymore. See those `@try/@catch` handlers ? They're useless, and the runloop will skip whatever it's doing and start anew, dropping whatever you were trying to accomplish.

So "Contacts" raises because it expects an array as its object identifier (PR for that), and "Displays" because it.. fails to do stuff with strings.

At least we have guaranteed deadlocks ☹️. I'll try to run that, as I'm trying to pin-point the weird autorelease crash we have.