### PR TITLE
Don't trigger VDKQueue on the main thread

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSVoyeur.m
+++ b/Quicksilver/Code-QuickStepCore/QSVoyeur.m
@@ -18,16 +18,17 @@ id QSVoy;
 	self = [super init];
 	if (self != nil) {
 		[self setDelegate:self];
+		self.queue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0);
 	}
 	return self;
 }
 
-- (void)VDKQueue:(id)kq receivedNotification:(NSString*)nm forPath:(NSString*)fpath {
-	if ([nm isEqualToString:@"VDKQueueFileDeletedNotification"]) {
+- (void)queue:(VDKQueue *)queue didReceiveNotification:(NSString *)notificationName forPath:(NSString *)fpath {
+	if ([notificationName isEqualToString:VDKQueueDeleteNotification]) {
 		[self removePath:fpath];
 		[self addPath:fpath notifyingAbout:NOTE_DELETE];
 	}
-	[[[NSWorkspace sharedWorkspace] notificationCenter] postNotificationName:nm object:fpath];
+	[[[NSWorkspace sharedWorkspace] notificationCenter] postNotificationName:notificationName object:fpath];
 }
 
 @end

--- a/Quicksilver/Quicksilver.xcodeproj/project.pbxproj
+++ b/Quicksilver/Quicksilver.xcodeproj/project.pbxproj
@@ -327,7 +327,7 @@
 		92E9461A0D04CCEF0013377F /* QSModifierKeyEvents.m in Sources */ = {isa = PBXBuildFile; fileRef = 92E946180D04CCEF0013377F /* QSModifierKeyEvents.m */; };
 		CD14B79018D06604000FE86A /* QSThreadSafeMutableDictionary.h in Headers */ = {isa = PBXBuildFile; fileRef = CD14B78C18D065F5000FE86A /* QSThreadSafeMutableDictionary.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CD14B79118D06609000FE86A /* QSThreadSafeMutableDictionary.m in Sources */ = {isa = PBXBuildFile; fileRef = CD14B78D18D065F5000FE86A /* QSThreadSafeMutableDictionary.m */; };
-		CD1B17D9158A573000E4A030 /* VDKQueue.m in Sources */ = {isa = PBXBuildFile; fileRef = CDE1E661158A4D0900355A9F /* VDKQueue.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		CD1B17D9158A573000E4A030 /* VDKQueue.m in Sources */ = {isa = PBXBuildFile; fileRef = CDE1E661158A4D0900355A9F /* VDKQueue.m */; };
 		CD1B17DA158A573200E4A030 /* VDKQueue.h in Headers */ = {isa = PBXBuildFile; fileRef = CDE1E660158A4D0900355A9F /* VDKQueue.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CD29AEB2195663770052C893 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = CD29AEB0195663770052C893 /* InfoPlist.strings */; };
 		CD29AEB4195663770052C893 /* Core_Support_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = CD29AEB3195663770052C893 /* Core_Support_Tests.m */; };


### PR DESCRIPTION
I pushed an updated version of VDKQueue to our fork (there was some movement in the Github Network).

Note that I don't think VDKQueue is responsible for our deadlocks 😉.