### PR TITLE
Fix CA transactions warnings

### DIFF
--- a/Quicksilver/Code-App/QSTaskViewController.m
+++ b/Quicksilver/Code-App/QSTaskViewController.m
@@ -47,7 +47,7 @@ const NSString *QSTaskProxyObservationContext = @"QSTaskProxyObservationContext"
 	}
 }
 
-- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary<NSKeyValueChangeKey,id> *)change context:(void *)context {
+- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary<NSString *,id> *)change context:(void *)context {
 	if (context == (__bridge void *)QSTaskProxyObservationContext) {
 		QSGCDMainAsync(^{
 			[self willChangeValueForKey:keyPath];

--- a/Quicksilver/Code-App/QSTaskViewController.m
+++ b/Quicksilver/Code-App/QSTaskViewController.m
@@ -8,6 +8,68 @@
 
 #import "QSTaskViewController.h"
 
+const NSString *QSTaskProxyObservationContext = @"QSTaskProxyObservationContext";
+#define QSTaskKeyPaths @[@"name", @"status", @"progress", @"icon"]
+
+@interface QSTaskProxy : NSObject {
+	QSTask *_task;
+}
++ (instancetype)proxyTaskWithTask:(QSTask *)task;
+- (instancetype)initWithTask:(QSTask *)task;
+@end
+
+@implementation QSTaskProxy
+
+
++ (instancetype)proxyTaskWithTask:(QSTask *)task {
+	return [[self alloc] initWithTask:task];
+}
+
+- (instancetype)initWithTask:(QSTask *)task {
+	NSParameterAssert(task != nil);
+	self = [super init];
+	if (!self) return nil;
+
+	_task = task;
+	for (NSString *keyPath in QSTaskKeyPaths) {
+		[_task addObserver:self
+				forKeyPath:keyPath
+				   options:NSKeyValueObservingOptionOld|NSKeyValueObservingOptionNew
+				   context:(__bridge void *)QSTaskProxyObservationContext];
+	}
+
+	return self;
+}
+
+- (void)dealloc {
+	for (NSString *keyPath in QSTaskKeyPaths) {
+		[_task removeObserver:self forKeyPath:keyPath];
+	}
+}
+
+- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary<NSKeyValueChangeKey,id> *)change context:(void *)context {
+	if (context == (__bridge void *)QSTaskProxyObservationContext) {
+		QSGCDMainAsync(^{
+			[self willChangeValueForKey:keyPath];
+			[self didChangeValueForKey:keyPath];
+		});
+	}
+}
+
+- (id)valueForKey:(NSString *)key {
+	return [_task valueForKey:key];
+}
+
+- (NSMethodSignature *)methodSignatureForSelector:(SEL)sel {
+	return [_task methodSignatureForSelector:sel];
+}
+
+- (void)forwardInvocation:(NSInvocation *)invocation {
+	[invocation invokeWithTarget:_task];
+}
+
+@end
+
 @implementation QSTaskViewController
 
 + (instancetype)controllerWithTask:(QSTask *)task {
@@ -18,11 +80,9 @@
     NSParameterAssert(task != nil);
 
     self = [super initWithNibName:@"QSTaskView" bundle:[NSBundle bundleForClass:[self class]]];
-    if (self == nil) {
-        return nil;
-    }
+    if (!self) return nil;
 
-    self.representedObject = task;
+    self.representedObject = [QSTaskProxy proxyTaskWithTask:task];
 
     return self;
 }

--- a/Quicksilver/Code-QuickStepInterface/QSInterfaceController.m
+++ b/Quicksilver/Code-QuickStepInterface/QSInterfaceController.m
@@ -132,8 +132,20 @@
 	[self searchObjectChanged:nil];
 
 	NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
-	[nc addObserver:progressIndicator selector:@selector(startAnimation:) name:QSTasksStartedNotification object:nil];
-	[nc addObserver:progressIndicator selector:@selector(stopAnimation:) name:QSTasksEndedNotification object:nil];
+	[nc addObserver:self selector:@selector(taskStarted:) name:QSTasksStartedNotification object:nil];
+	[nc addObserver:self selector:@selector(taskEnded:) name:QSTasksEndedNotification object:nil];
+}
+
+- (void)taskStarted:(NSNotification *)notif {
+	QSGCDMainAsync(^{
+		[progressIndicator startAnimation:self];
+	});
+}
+
+- (void)taskEnded:(NSNotification *)notif {
+	QSGCDMainAsync(^{
+		[progressIndicator stopAnimation:self];
+	});
 }
 
 - (QSCommand *)currentCommand { 


### PR DESCRIPTION
This should fix the CA transaction warnings we have (at least the ones I saw).

I went pretty heavy-handed on the proxy thing, but I didn't want to make all `QSTask`'s accessors to become main-thready-asyncy...

I'll check that I didn't forget some of the keypaths though (I haven't checked everything, and I don't think we have an easy indeterminate progress one anywhere).

It seems to also fix the flicker we had, so 👍.