### PR TITLE
Event changes for hotkey editor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: objective-c
-osx_image: xcode7.3
+osx_image: xcode8.3
 xcode_project: Quicksilver/Quicksilver.xcodeproj # path to your xcodeproj folder
 xcode_scheme: "Quicksilver Distribution"
 script: |
-    ruby Quicksilver/Tools/travis/check_indent.rb &&
-    xctool -project "$TRAVIS_XCODE_PROJECT" -scheme "$TRAVIS_XCODE_SCHEME" build test
-
+    ruby Quicksilver/Tools/travis/check_indent.rb

--- a/Quicksilver/Code-QuickStepInterface/QSHotKeyEditor.m
+++ b/Quicksilver/Code-QuickStepInterface/QSHotKeyEditor.m
@@ -250,7 +250,7 @@
 	while(collectEvents) {
 		theEvent = [NSApp nextEventMatchingMask:NSKeyDownMask | NSFlagsChangedMask | NSLeftMouseDownMask | NSAppKitDefinedMask | NSSystemDefinedMask untilDate:[NSDate dateWithTimeIntervalSinceNow:10.0] inMode:NSDefaultRunLoopMode dequeue:YES];
 		switch ([theEvent type]) {
-			case NSKeyDown: {
+			case NSEventTypeKeyDown: {
 //				unsigned short keyCode = [theEvent keyCode];
 //				NSString *characters = (keyCode == 48) ? @"\t" : [theEvent charactersIgnoringModifiers];
 				if ([theEvent modifierFlags] & (NSCommandKeyMask | NSFunctionKeyMask | NSControlKeyMask | NSAlternateKeyMask) ) {
@@ -269,7 +269,7 @@
 				}
 			}
 			break;
-			case NSFlagsChanged: {
+			case NSEventTypeFlagsChanged: {
                 NSString *newString = stringForModifiers([theEvent modifierFlags]);
 
 				//NSLog(@"%@", newString);
@@ -280,7 +280,7 @@
 			}
 			case NSSystemDefined:
 			case NSAppKitDefined:
-			case NSLeftMouseDown:
+			case NSEventTypeLeftMouseDown:
 				if (![self containsEvent:theEvent] && ![setButton containsEvent:theEvent]) {
 					//Absorb events on self or setButton
 					[NSApp postEvent:theEvent atStart:YES];

--- a/Quicksilver/Code-QuickStepInterface/QSHotKeyEditor.m
+++ b/Quicksilver/Code-QuickStepInterface/QSHotKeyEditor.m
@@ -278,8 +278,6 @@
 				[setButton display];
 				break;
 			}
-			case NSSystemDefined:
-			case NSAppKitDefined:
 			case NSEventTypeLeftMouseDown:
 				if (![self containsEvent:theEvent] && ![setButton containsEvent:theEvent]) {
 					//Absorb events on self or setButton


### PR DESCRIPTION
I removed the problematic entries, and switched the others to use the newer names. It means we can’t build with Xcode 7 any more, but that ship already sailed with `NSWindowStyleMask`. I’ll add another commit to update Travis.

Take a quick look at this if you can @tiennou.