### PR TITLE
use string value as identifier for string objects

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSLibrarian.m
+++ b/Quicksilver/Code-QuickStepCore/QSLibrarian.m
@@ -321,12 +321,12 @@ static CGFloat searchSpeed = 0.0;
             if ([obj identifier]) {
                 [self setIdentifier:[obj identifier] forObject:obj];
             } else {
+                NSString *ident = [NSString stringWithFormat:@"QSID:%@:%@", [entry identifier], [obj displayName]];
 				if ([[obj primaryType] isEqualToString:QSTextType]) {
 					// don't add identifiers to string objects
 					// it ends up replacing the string value
-					continue;
+					ident = [obj objectForType:QSTextType];
 				}
-                NSString *ident = [NSString stringWithFormat:@"QSID:%@:%@", [entry identifier], [obj displayName]];
                 [obj setIdentifier:ident];
             }
         }


### PR DESCRIPTION
I nearly did this before, but decided not to based on the fear that if you were to type (or paste) an existing object’s identifier in text mode, the string object representing the identifier would replace the real object in the catalog. That doesn’t seem to be the case.

You do get some weirdness with history (you can’t store both an object and a string with its identifier), but that’s an edge case I don’t think we need to worry about.