### PR TITLE
Transliterate non-latin strings into latin if there's no match

### DIFF
--- a/Quicksilver/Code-QuickStepFoundation/QSSense.h
+++ b/Quicksilver/Code-QuickStepFoundation/QSSense.h
@@ -10,4 +10,5 @@
 
 
 CGFloat QSScoreForAbbreviation(CFStringRef string, CFStringRef abbr, id hitMask);
+CGFloat QSScoreForAbbreviationOrTransliteration(CFStringRef str, CFStringRef abbr, id mask);
 CGFloat QSScoreForAbbreviationWithRanges(CFStringRef str, CFStringRef abbr, id mask, CFRange strRange, CFRange abbrRange);

--- a/Quicksilver/Code-QuickStepFoundation/QSSense.m
+++ b/Quicksilver/Code-QuickStepFoundation/QSSense.m
@@ -25,8 +25,8 @@ CGFloat QSScoreForAbbreviationOrTransliteration(CFStringRef str, CFStringRef abb
 	if (score == 0) {
 		CFMutableStringRef mutableString = CFStringCreateMutableCopy(kCFAllocatorDefault, 0, str);
 		CFStringTransform(mutableString, nil, kCFStringTransformToLatin, false);
-		CFStringTransform(mutableString, nil, kCFStringTransformStripCombiningMarks, false);
-		if (!CFStringCompare(str, mutableString, 0) == kCFCompareEqualTo) {
+		
+		if (CFStringCompare(str, mutableString, 0) != kCFCompareEqualTo) {
 			// only do this if the two strings are not equal (otherwise it's a wasted compute)
 			score = QSScoreForAbbreviationWithRanges(mutableString, abbr, nil, CFRangeMake(0, CFStringGetLength(mutableString)), CFRangeMake(0, CFStringGetLength(abbr)));
 		}

--- a/Quicksilver/Code-QuickStepFoundation/QSSense.m
+++ b/Quicksilver/Code-QuickStepFoundation/QSSense.m
@@ -17,7 +17,25 @@
 CGFloat QSScoreForAbbreviationWithRanges(CFStringRef str, CFStringRef abbr, id mask, CFRange strRange, CFRange abbrRange);
 
 CGFloat QSScoreForAbbreviation(CFStringRef str, CFStringRef abbr, id mask) {
-	return QSScoreForAbbreviationWithRanges(str, abbr, mask, CFRangeMake(0, CFStringGetLength(str)), CFRangeMake(0, CFStringGetLength(abbr)));
+	return QSScoreForAbbreviationOrTransliteration(str, abbr, mask);
+}
+
+CGFloat QSScoreForAbbreviationOrTransliteration(CFStringRef str, CFStringRef abbr, id mask) {
+	CGFloat score = QSScoreForAbbreviationWithRanges(str, abbr, mask, CFRangeMake(0, CFStringGetLength(str)), CFRangeMake(0, CFStringGetLength(abbr)));
+	if (score == 0) {
+		CFMutableStringRef mutableString = CFStringCreateMutableCopy(kCFAllocatorDefault, 0, str);
+		CFStringTransform(mutableString, nil, kCFStringTransformToLatin, false);
+		CFStringTransform(mutableString, nil, kCFStringTransformStripCombiningMarks, false);
+		if (!CFStringCompare(str, mutableString, 0) == kCFCompareEqualTo) {
+			// only do this if the two strings are not equal (otherwise it's a wasted compute)
+			score = QSScoreForAbbreviationWithRanges(mutableString, abbr, nil, CFRangeMake(0, CFStringGetLength(mutableString)), CFRangeMake(0, CFStringGetLength(abbr)));
+		}
+		if (mutableString) {
+			CFRelease(mutableString);
+		}
+		return score;
+	}
+	return score;
 }
 
 CGFloat QSScoreForAbbreviationWithRanges(CFStringRef str, CFStringRef abbr, id mask, CFRange strRange, CFRange abbrRange) {


### PR DESCRIPTION
I'm back! Although for my own selfish needs :'(

Most non-latin languages have formal romanizations from the native script to latin (e.g. 中国 -> zhongguo). This change allows you to search using latin characters for non-latin names/labels. It should apply to all latin languages that have formal romanizations.

One issue that I had with this is that when you romanize a non-latin search string (e.g. 中国) its length is changed (often increased):

```
中国 => length 2
zhongguo => length 8
```

This would cause problems when displaying the characters that matched in the string (normally done by underlining them in the SOV. To solve this problem I just opted to not show which letters matched:

![screen shot 2017-09-19 at 10 05 32](https://user-images.githubusercontent.com/150431/30572732-185592f2-9d22-11e7-9205-3255a6d0d654.png)

Note that this change will have an affect on all users, and my suspicion is most of our users are limited to latin-character only languages. As such I'd be interested to:

a) know if this makes searching slower for people
b) if so, should it just be included as a hidden pref?