### PR TITLE
Support for recent documents in High Sierra

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSObject_FileHandling.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject_FileHandling.m
@@ -35,8 +35,23 @@ NSArray *recentDocumentsForBundle(NSString *bundleIdentifier) {
 
     NSMutableArray *documentsArray = [NSMutableArray arrayWithCapacity:0];
 	NSURL *url;
-	if ([NSApplication isElCapitan]) {
-		NSString *sflPath = [NSString stringWithFormat:pSharedFileListPathTemplate, bundleIdentifier];
+	if ([NSApplication isHighSierra]) {
+		NSString *sflPath = [NSString stringWithFormat:pSharedFileListPathTemplate, bundleIdentifier, @"sfl2"];
+		NSString *sflStandardized = [sflPath stringByStandardizingPath];
+		if ([[NSFileManager defaultManager] fileExistsAtPath:sflStandardized isDirectory:nil]) {
+			NSDictionary *sflData = [NSKeyedUnarchiver unarchiveObjectWithFile:sflStandardized];
+			for (NSDictionary *item in sflData[@"items"]) {
+				NSData *bookmarkData = item[@"Bookmark"];
+				url = [NSURL URLByResolvingBookmarkData:bookmarkData options:NSURLBookmarkResolutionWithoutUI|NSURLBookmarkResolutionWithoutMounting relativeToURL:nil bookmarkDataIsStale:NO error:nil];
+				if (url && [url isFileURL]) {
+					[documentsArray addObject:[url path]];
+				}
+			}
+		}
+		return documentsArray;
+	}
+	else if ([NSApplication isElCapitan]) {
+		NSString *sflPath = [NSString stringWithFormat:pSharedFileListPathTemplate, bundleIdentifier, @"sfl"];
 		NSString *sflStandardized = [sflPath stringByStandardizingPath];
 		if ([[NSFileManager defaultManager] fileExistsAtPath:sflStandardized isDirectory:nil]) {
 			NSDictionary *sflData = [NSKeyedUnarchiver unarchiveObjectWithFile:sflStandardized];
@@ -321,7 +336,7 @@ NSArray *recentDocumentsForBundle(NSString *bundleIdentifier) {
             // Does the app have valid recent documents
             if (bundleIdentifier) {
                 if ([NSApplication isElCapitan]) {
-                    NSString *sflPath = [NSString stringWithFormat:pSharedFileListPathTemplate, bundleIdentifier];
+                    NSString *sflPath = [NSString stringWithFormat:pSharedFileListPathTemplate, bundleIdentifier, @"sfl"];
                     if ([[NSFileManager defaultManager] fileExistsAtPath:[sflPath stringByStandardizingPath] isDirectory:nil]) {
                         return YES;
                     }

--- a/Quicksilver/Code-QuickStepCore/QSPaths.h
+++ b/Quicksilver/Code-QuickStepCore/QSPaths.h
@@ -9,7 +9,7 @@
 #define pCrashReporterFolder [@"~/Library/Logs/DiagnosticReports" stringByStandardizingPath]
 #define pShelfLocation		QSApplicationSupportSubPath(@"Shelves/", NO)
 #define pICloudDocumentsPrefix [@"~/Library/Mobile Documents/" stringByStandardizingPath]
-#define pSharedFileListPathTemplate @"~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/%@.sfl"
+#define pSharedFileListPathTemplate @"~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/%@.%@"
 #define appSupportSubpath @"Application Support/Quicksilver/PlugIns"
 
 #define psMainPlugInsLocation QSApplicationSupportSubPath(@"PlugIns/", NO)

--- a/Quicksilver/Code-QuickStepFoundation/NSApplication_BLTRExtensions.h
+++ b/Quicksilver/Code-QuickStepFoundation/NSApplication_BLTRExtensions.h
@@ -129,4 +129,11 @@ typedef NSInteger QSApplicationLaunchStatusFlags;
  @returns YES, if 10.12+. NO otherwise
  */
 + (BOOL)isSierra;
+
+/**
+ Checks, if system is at least macOS 10.13 (High Sierra)
+ 
+ @returns YES, if 10.13+. NO otherwise
+ */
++ (BOOL)isHighSierra;
 @end

--- a/Quicksilver/Code-QuickStepFoundation/NSApplication_BLTRExtensions.m
+++ b/Quicksilver/Code-QuickStepFoundation/NSApplication_BLTRExtensions.m
@@ -201,4 +201,8 @@
 + (BOOL)isSierra {
 	return ([NSApplication macOSXMajorVersion] >= 10 && [NSApplication macOSXMinorVersion] >= 12);
 }
+
++ (BOOL)isHighSierra {
+	return ([NSApplication macOSXMajorVersion] >= 10 && [NSApplication macOSXMinorVersion] >= 13);
+}
 @end


### PR DESCRIPTION
…and various recent/favorite catalog presets.

Doing a string replacement on the extension feels ugly, but I don’t think we have a way to restrict presets by OS version, and that’s where the path is defined.

As discussed in #2396