### PR TITLE
redefine Relaunch as a trigger

### DIFF
--- a/Quicksilver/Code-App/QSController.h
+++ b/Quicksilver/Code-App/QSController.h
@@ -67,6 +67,7 @@
 - (NSString *)crashReportPath;
 - (void)showDockIcon;
 - (void)clearHistory;
+- (void)relaunchQuicksilver;
 
 @end
 

--- a/Quicksilver/Code-App/QSController.m
+++ b/Quicksilver/Code-App/QSController.m
@@ -788,6 +788,11 @@ static QSController *defaultController = nil;
 	[[[self interfaceController] dSelector] clearHistory];
 }
 
+- (void)relaunchQuicksilver
+{
+	[NSApp relaunch:nil];
+}
+
 @end
 
 @implementation QSController (Application)

--- a/Quicksilver/Nibs/MainMenu.xib
+++ b/Quicksilver/Nibs/MainMenu.xib
@@ -1,8 +1,8 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="9532" systemVersion="14F2009" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="13196" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="9532"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="13196"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="QSApp">
@@ -12,7 +12,7 @@
             </connections>
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
-        <customObject id="-3" userLabel="Application"/>
+        <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <menu title="OldMainMenu" systemMenu="main" id="29" userLabel="MainMenu">
             <items>
                 <menuItem title="Quicksilver" id="56">
@@ -103,12 +103,6 @@
                                 <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
                                 <connections>
                                     <action selector="terminate:" target="-2" id="1600"/>
-                                </connections>
-                            </menuItem>
-                            <menuItem title="Relaunch Quicksilver" alternate="YES" keyEquivalent="q" id="1834">
-                                <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
-                                <connections>
-                                    <action selector="relaunch:" target="-2" id="1835"/>
                                 </connections>
                             </menuItem>
                         </items>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/QSCorePlugIn-Info.plist
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/QSCorePlugIn-Info.plist
@@ -35,6 +35,30 @@
 			<key>ID</key>
 			<string>QSActivateTextModeTrigger</string>
 		</dict>
+		<dict>
+			<key>set</key>
+			<string>Quicksilver</string>
+			<key>applicationScopeType</key>
+			<integer>1</integer>
+			<key>keyCode</key>
+			<integer>12</integer>
+			<key>enabled</key>
+			<true/>
+			<key>modifiers</key>
+			<integer>1835305</integer>
+			<key>onPress</key>
+			<true/>
+			<key>type</key>
+			<string>QSHotKeyTrigger</string>
+			<key>command</key>
+			<string>QSRelaunchSelfCommand</string>
+			<key>ID</key>
+			<string>QSRelaunchSelfTrigger</string>
+			<key>applicationScope</key>
+			<array>
+				<string>com.blacktree.Quicksilver</string>
+			</array>
+		</dict>
 	</array>
 	<key>CFBundleIdentifier</key>
 	<string>com.blacktree.Quicksilver.QSCorePlugIn</string>
@@ -1437,6 +1461,18 @@
 				</dict>
 				<key>name</key>
 				<string>Show Command Window </string>
+			</dict>
+			<key>QSRelaunchSelfCommand</key>
+			<dict>
+				<key>command</key>
+				<dict>
+					<key>actionID</key>
+					<string>QSObjCSendMessageAction</string>
+					<key>directID</key>
+					<string>QSRelaunch</string>
+				</dict>
+				<key>name</key>
+				<string>Relaunch Quicksilver</string>
 			</dict>
 		</dict>
 		<key>QSObjectHandlers</key>

--- a/Quicksilver/PropertyLists/QSRegistration.plist
+++ b/Quicksilver/PropertyLists/QSRegistration.plist
@@ -165,6 +165,17 @@
 			<key>name</key>
 			<string>Clear Quicksilver History</string>
 		</dict>
+		<key>QSRelaunch</key>
+		<dict>
+			<key>actionClass</key>
+			<string>QSController</string>
+			<key>actionSelector</key>
+			<string>relaunchQuicksilver</string>
+			<key>icon</key>
+			<string>Quicksilver</string>
+			<key>name</key>
+			<string>Relaunch Quicksilver</string>
+		</dict>
 	</dict>
 	<key>QSInternalURLHandlers</key>
 	<dict>


### PR DESCRIPTION
As promised.

* enabled by default
* scoped to be active only in Quicksilver
* uses ⌃⌥⌘Q by default

Since it’s a trigger, users on 10.12 or older can change it back or change it to something else if they want.