### PR TITLE
Action config

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSAction.h
+++ b/Quicksilver/Code-QuickStepCore/QSAction.h
@@ -13,6 +13,7 @@
 + (id)actionWithDictionary:(NSDictionary *)dict;
 + (id)actionWithDictionary:(NSDictionary *)dict identifier:(NSString *)ident;
 + (id)actionWithIdentifier:(NSString *)newIdentifier;
++ (id)actionWithDictionary:(NSDictionary *)dict identifier:(NSString *)ident bundle:(NSBundle *)bundle;
 + (id)actionWithIdentifier:(NSString *)newIdentifier bundle:(NSBundle *)newBundle;
 
 - (id)initWithDictionary:(NSDictionary *)dict identifier:(NSString *)ident bundle:(NSBundle *)bundle;

--- a/Quicksilver/Code-QuickStepCore/QSAction.h
+++ b/Quicksilver/Code-QuickStepCore/QSAction.h
@@ -33,6 +33,7 @@
 - (NSInteger)rank;
 - (void)setRank:(NSInteger)newRank;
 - (CGFloat)precedence;
+- (void)setPrecedence:(CGFloat)precedence;
 - (BOOL)enabled;
 - (void)setEnabled:(BOOL)flag;
 - (BOOL)menuEnabled;
@@ -46,6 +47,8 @@
 - (BOOL)canThread;
 - (BOOL)indirectOptional;
 - (void)setIndirectOptional:(BOOL)flag;
+- (BOOL)validatesObjects;
+- (void)setValidatesObjects:(BOOL)flag;
 
 // resolveProxy is a BOOL set in an action's dict to specify whether an object should be resolved
 // before being sent to an action. Action's like 'assign abbreviation...' should not resolve the proxy
@@ -67,6 +70,7 @@
 - (id)objectForKey:(NSString*)key;
 
 - (NSString *)commandFormat;
+- (void)setCommandFormat:(NSString *)commandFormat;
 @end
 
 @interface QSActionHandler : NSObject

--- a/Quicksilver/Code-QuickStepCore/QSAction.h
+++ b/Quicksilver/Code-QuickStepCore/QSAction.h
@@ -30,6 +30,38 @@
 - (SEL)action;
 - (void)setAction:(SEL)newAction;
 
+/**
+ * Use a predefined block as an action method. Useful for programatically creating many similar actions.
+ *
+ * @param actionBlock A block that does the action's work
+ * @param selectorName A selector name like "openThing:"
+ *
+ * @return YES if the action method was added to the provider, otherwise NO
+ *
+ * Example action block with no indirect object:
+ * QSObject *(^actionBlock)(id, QSObject *) = ^ QSObject *(id _self, QSObject *dObject) {
+ * 	   // action code
+ * 	   return nil;
+ * };
+ */
+- (BOOL)setActionUisngBlock:(QSObject *(^)(id, QSObject *))actionBlock  selectorName:(NSString *)selName;
+
+/**
+ * Use a predefined block as an action method. Useful for programatically creating many similar actions.
+ *
+ * @param actionBlock A block that does the action's work
+ * @param selectorName A selector name like "openThing:usingOtherThing:"
+ *
+ * @return YES if the action method was added to the provider, otherwise NO
+ *
+ * Example action block with an indirect object:
+ * QSObject *(^actionBlock)(id, QSObject *, QSObject *) = ^ QSObject *(id _self, QSObject *dObject, QSObject *iObject) {
+ * 	   // action code
+ * 	   return nil;
+ * };
+ */
+- (BOOL)setActionWithIndirectUisngBlock:(QSObject *(^)(id, QSObject *, QSObject *))actionBlock  selectorName:(NSString *)selName;
+
 - (NSInteger)rank;
 - (void)setRank:(NSInteger)newRank;
 - (CGFloat)precedence;

--- a/Quicksilver/Code-QuickStepCore/QSAction.h
+++ b/Quicksilver/Code-QuickStepCore/QSAction.h
@@ -45,7 +45,7 @@
  * 	   return nil;
  * };
  */
-- (BOOL)setActionUisngBlock:(QSObject *(^)(id, QSObject *))actionBlock  selectorName:(NSString *)selName;
+- (BOOL)setActionUsingBlock:(QSObject *(^)(id, QSObject *))actionBlock  selectorName:(NSString *)selName;
 
 /**
  * Use a predefined block as an action method. Useful for programatically creating many similar actions.
@@ -61,7 +61,7 @@
  * 	   return nil;
  * };
  */
-- (BOOL)setActionWithIndirectUisngBlock:(QSObject *(^)(id, QSObject *, QSObject *))actionBlock  selectorName:(NSString *)selName;
+- (BOOL)setActionWithIndirectUsingBlock:(QSObject *(^)(id, QSObject *, QSObject *))actionBlock  selectorName:(NSString *)selName;
 
 - (NSInteger)rank;
 - (void)setRank:(NSInteger)newRank;

--- a/Quicksilver/Code-QuickStepCore/QSAction.m
+++ b/Quicksilver/Code-QuickStepCore/QSAction.m
@@ -82,7 +82,7 @@ static BOOL gModifiersAreIgnored;
 		return nil;
 	}
 	if (self = [self init]) {
-		[self setObject:dict forType:QSActionType];
+		[self setObject:[dict mutableCopy] forType:QSActionType];
 		[self setPrimaryType:QSActionType];
 	}
 	return self;

--- a/Quicksilver/Code-QuickStepCore/QSAction.m
+++ b/Quicksilver/Code-QuickStepCore/QSAction.m
@@ -199,7 +199,7 @@ static BOOL gModifiersAreIgnored;
 		[[self actionDict] removeObjectForKey:kActionSelector];
 }
 
-- (BOOL)setActionUisngBlock:(QSObject *(^)(id, QSObject *))actionBlock selectorName:(NSString *)selName
+- (BOOL)setActionUsingBlock:(QSObject *(^)(id, QSObject *))actionBlock selectorName:(NSString *)selName
 {
 	NSAssert([self provider], @"Define an action provider before creating an action with a block");
 
@@ -214,7 +214,7 @@ static BOOL gModifiersAreIgnored;
 	return actionDefined;
 }
 
-- (BOOL)setActionWithIndirectUisngBlock:(QSObject *(^)(id, QSObject *, QSObject *))actionBlock  selectorName:(NSString *)selName
+- (BOOL)setActionWithIndirectUsingBlock:(QSObject *(^)(id, QSObject *, QSObject *))actionBlock  selectorName:(NSString *)selName
 {
 	NSAssert([self provider], @"Define an action provider before creating an action with a block");
 

--- a/Quicksilver/Code-QuickStepCore/QSAction.m
+++ b/Quicksilver/Code-QuickStepCore/QSAction.m
@@ -208,7 +208,11 @@ static BOOL gModifiersAreIgnored;
 	IMP actionFunction = imp_implementationWithBlock(actionBlock);
 	SEL actionSelector = NSSelectorFromString(selName);
 	BOOL actionDefined = class_addMethod([[self provider] class], actionSelector, actionFunction, "@@:@");
-	[self setAction:actionSelector];
+	if (actionDefined) {
+		[self setAction:actionSelector];
+	} else {
+		NSLog(@"Unable to add action %@ to %@", selName, [self provider]);
+	}
 	return actionDefined;
 }
 
@@ -221,7 +225,11 @@ static BOOL gModifiersAreIgnored;
 	IMP actionFunction = imp_implementationWithBlock(actionBlock);
 	SEL actionSelector = NSSelectorFromString(selName);
 	BOOL actionDefined = class_addMethod([[self provider] class], actionSelector, actionFunction, "@@:@@");
-	[self setAction:actionSelector];
+	if (actionDefined) {
+		[self setAction:actionSelector];
+	} else {
+		NSLog(@"Unable to add action %@ to %@", selName, [self provider]);
+	}
 	return actionDefined;
 }
 

--- a/Quicksilver/Code-QuickStepCore/QSAction.m
+++ b/Quicksilver/Code-QuickStepCore/QSAction.m
@@ -119,6 +119,12 @@ static BOOL gModifiersAreIgnored;
 	return num ? [num doubleValue] : 0.0;
 }
 
+- (void)setPrecedence:(CGFloat)precedence
+{
+	NSNumber *num = [NSNumber numberWithFloat:precedence];
+	[[self actionDict] setObject:num forKey:kActionPrecedence];
+}
+
 - (NSInteger)rank { return rank;  }
 - (void)_setRank:(NSInteger)newRank {
 	[self willChangeValueForKey:@"rank"];
@@ -220,6 +226,15 @@ static BOOL gModifiersAreIgnored;
 
 - (void)setIndirectOptional:(BOOL)flag {
  	[[self actionDict] setObject:[NSNumber numberWithInteger:flag] forKey:kActionIndirectOptional];
+}
+
+- (BOOL)validatesObjects
+{
+	return [[[self actionDict] objectForKey:kActionValidatesObjects] boolValue];
+}
+- (void)setValidatesObjects:(BOOL)flag
+{
+	[[self actionDict] setObject:[NSNumber numberWithInteger:flag] forKey:kActionValidatesObjects];
 }
 
 - (BOOL)resolvesProxy {
@@ -364,7 +379,7 @@ static BOOL gModifiersAreIgnored;
     
 	//Check the action dictionary
 	if (!format)
-		format = [[self actionDict] objectForKey:@"commandFormat"];
+		format = [[self actionDict] objectForKey:kActionCommandFormat];
     
 	// Check the main bundle
 	if (!format)
@@ -375,6 +390,11 @@ static BOOL gModifiersAreIgnored;
 		format = [NSString stringWithFormat:@"%%@ (%@) %@", [self name], ([self argumentCount] > 1 ? @" %@" : @"")];
     
     return format;
+}
+
+- (void)setCommandFormat:(NSString *)commandFormat
+{
+	[[self actionDict] setObject:commandFormat forKey:kActionCommandFormat];
 }
 
 - (CGFloat)score {

--- a/Quicksilver/Code-QuickStepCore/QSAction.m
+++ b/Quicksilver/Code-QuickStepCore/QSAction.m
@@ -201,10 +201,8 @@ static BOOL gModifiersAreIgnored;
 
 - (BOOL)setActionUisngBlock:(QSObject *(^)(id, QSObject *))actionBlock selectorName:(NSString *)selName
 {
-	if (![self provider]) {
-		NSLog(@"define provider before setting a block as the action");
-		return NO;
-	}
+	NSAssert([self provider], @"Define an action provider before creating an action with a block");
+
 	IMP actionFunction = imp_implementationWithBlock(actionBlock);
 	SEL actionSelector = NSSelectorFromString(selName);
 	BOOL actionDefined = class_addMethod([[self provider] class], actionSelector, actionFunction, "@@:@");
@@ -218,10 +216,8 @@ static BOOL gModifiersAreIgnored;
 
 - (BOOL)setActionWithIndirectUisngBlock:(QSObject *(^)(id, QSObject *, QSObject *))actionBlock  selectorName:(NSString *)selName
 {
-	if (![self provider]) {
-		NSLog(@"define provider before setting a block as the action");
-		return NO;
-	}
+	NSAssert([self provider], @"Define an action provider before creating an action with a block");
+
 	IMP actionFunction = imp_implementationWithBlock(actionBlock);
 	SEL actionSelector = NSSelectorFromString(selName);
 	BOOL actionDefined = class_addMethod([[self provider] class], actionSelector, actionFunction, "@@:@@");

--- a/Quicksilver/Code-QuickStepCore/QSAction.m
+++ b/Quicksilver/Code-QuickStepCore/QSAction.m
@@ -6,6 +6,7 @@
 #import "QSResourceManager.h"
 #import "NSBundle_BLTRExtensions.h"
 #import "QSExecutor.h"
+#import <objc/objc-runtime.h>
 
 //static NSDictionary *actionPrecedence;
 
@@ -196,6 +197,32 @@ static BOOL gModifiersAreIgnored;
 		[[self actionDict] setObject:NSStringFromSelector(newAction) forKey:kActionSelector];
 	else
 		[[self actionDict] removeObjectForKey:kActionSelector];
+}
+
+- (BOOL)setActionUisngBlock:(QSObject *(^)(id, QSObject *))actionBlock selectorName:(NSString *)selName
+{
+	if (![self provider]) {
+		NSLog(@"define provider before setting a block as the action");
+		return NO;
+	}
+	IMP actionFunction = imp_implementationWithBlock(actionBlock);
+	SEL actionSelector = NSSelectorFromString(selName);
+	BOOL actionDefined = class_addMethod([[self provider] class], actionSelector, actionFunction, "@@:@");
+	[self setAction:actionSelector];
+	return actionDefined;
+}
+
+- (BOOL)setActionWithIndirectUisngBlock:(QSObject *(^)(id, QSObject *, QSObject *))actionBlock  selectorName:(NSString *)selName
+{
+	if (![self provider]) {
+		NSLog(@"define provider before setting a block as the action");
+		return NO;
+	}
+	IMP actionFunction = imp_implementationWithBlock(actionBlock);
+	SEL actionSelector = NSSelectorFromString(selName);
+	BOOL actionDefined = class_addMethod([[self provider] class], actionSelector, actionFunction, "@@:@@");
+	[self setAction:actionSelector];
+	return actionDefined;
 }
 
 - (NSInteger)argumentCount {

--- a/Quicksilver/Code-QuickStepCore/QSDefines.h
+++ b/Quicksilver/Code-QuickStepCore/QSDefines.h
@@ -58,6 +58,7 @@
 #define kActionInitialize           @"initialize"
 #define kActionEnabled              @"enabled"
 #define kActionResolvesProxy        @"resolvesProxy"
+#define kActionCommandFormat        @"commandFormat"
 
 // NSNumber (float) :
 #define kActionPrecedence @"precedence"

--- a/Quicksilver/Code-QuickStepCore/QSDefines.h
+++ b/Quicksilver/Code-QuickStepCore/QSDefines.h
@@ -41,6 +41,7 @@
 #define kActionName                 @"name"
 #define kActionUserData             @"userData"
 #define kActionIdentifier           @"id"
+#define kActionCommandFormat        @"commandFormat"
 
 // arrays:
 #define kActionDirectTypes          @"directTypes"
@@ -58,7 +59,6 @@
 #define kActionInitialize           @"initialize"
 #define kActionEnabled              @"enabled"
 #define kActionResolvesProxy        @"resolvesProxy"
-#define kActionCommandFormat        @"commandFormat"
 
 // NSNumber (float) :
 #define kActionPrecedence @"precedence"


### PR DESCRIPTION
Allow more things to be defined for actions. Basically because I needed some of this for the new Audio plug-in.

I could have just created 12 actions by hand in less time than it took to figure out the block stuff, but I think it’s worth it. For an actual use-case, see https://github.com/quicksilver/Audio-qsplugin/blob/master/Audio/AudioAction.m#L31

Another place it can be used is Remote Hosts where many of the actions are just opening a URL with a different scheme.