### PR TITLE
add an action for dumping object details

### DIFF
--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Code/QSObjectActions.m
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Code/QSObjectActions.m
@@ -201,6 +201,13 @@
 	return nil;
 }
 
+- (QSObject *)logObjectToConsole:(QSObject *)dObject
+{
+	NSLog(@"Printing Object\n%@", [dObject name]);
+	NSLog(@"\n%@", [dObject dictionaryRepresentation]);
+	return nil;
+}
+
 - (NSArray *)validIndirectObjectsForAction:(NSString *)action directObject:(QSObject *)dObject {
 	if ([action isEqualToString:@"QSCreateFileAction"]) {
 		return nil;

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/QSCorePlugIn-Info.plist
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/QSCorePlugIn-Info.plist
@@ -255,6 +255,21 @@
 			<key>icon</key>
 			<string>Clipboard</string>
 		</dict>
+		<key>QSObjectLogConsoleAction</key>
+		<dict>
+			<key>validatesObjects</key>
+			<false/>
+			<key>actionClass</key>
+			<string>QSObjectActions</string>
+			<key>directTypes</key>
+			<array>
+				<string>*</string>
+			</array>
+			<key>actionSelector</key>
+			<string>logObjectToConsole:</string>
+			<key>enabled</key>
+			<false/>
+		</dict>
 		<key>QSCommandExecuteAfterDelayAction</key>
 		<dict>
 			<key>actionClass</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/en.lproj/QSAction.description.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/en.lproj/QSAction.description.strings
@@ -46,6 +46,8 @@
 	<string>Open Contents of Item in Quicksilver</string>
 	<key>QSObjectExplodeCombinedAction</key>
 	<string>Show selected items in the results list</string>
+	<key>QSObjectLogConsoleAction</key>
+	<string>Log details of this object to the Console</string>
 	<key>QSShellScriptRunAction</key>
 	<string>Run a Shell Script</string>
 	<key>QSObjectSelectAction</key>

--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/en.lproj/QSAction.name.strings
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Resources/en.lproj/QSAction.name.strings
@@ -204,6 +204,8 @@
 	<string>Show Contents</string>
 	<key>QSObjectExplodeCombinedAction</key>
 	<string>Explode Selection</string>
+	<key>QSObjectLogConsoleAction</key>
+	<string>Log Object to Console</string>
 	<key>QSObjectShowSourceAction</key>
 	<string>Show Source in Catalog</string>
 	<key>QSPutOnShelfAction</key>


### PR DESCRIPTION
Disabled by default.

Should have done this years ago. Yes, there’s an item like this in the menu for debug builds, but what kind of animal has the Dock icon enabled? And what if you need to see something currently in memory and aren’t running a debug build? What if you need info from a user on another system?