### PR TITLE
Don't store IDs and archives for a QSCommand (in the plist)

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSCommand.m
+++ b/Quicksilver/Code-QuickStepCore/QSCommand.m
@@ -295,49 +295,40 @@ NSTimeInterval QSTimeIntervalForString(NSString *intervalString) {
 	[[NSDictionary dictionaryWithObject:[self dictionaryRepresentation] forKey:@"command"] writeToFile:path atomically:NO];
 }
 
+- (void)storeObject:(QSObject *)newObject forType:(NSString*)type {
+    
+    NSString *idString = [NSString stringWithFormat:@"%@ID", type];
+    NSString *archiveString = [NSString stringWithFormat:@"%@Archive", type];
+    
+    id rep = [newObject identifier];
+	if(rep != nil) {
+        [[self commandDict] setObject:rep forKey:idString];
+        [[self commandDict] removeObjectForKey:archiveString];
+	} else {
+        rep = [newObject dictionaryRepresentation];
+        if(rep)
+            [[self commandDict] setObject:rep forKey:archiveString];
+    }
+}
+
 - (void)setDirectObject:(QSObject*)newObject {
     if (newObject != nil && dObject != newObject) {
         dObject = newObject;
-        
-        id rep = [dObject identifier];
-        if(rep != nil)
-            [[self commandDict] setObject:rep forKey:@"directID"];
-        else {
-            rep = [dObject dictionaryRepresentation];
-            if(rep)
-                [[self commandDict] setObject:rep forKey:@"directArchive"];
-        }
-        
+        [self storeObject:dObject forType:@"direct"];
     }
 }
 
 - (void)setActionObject:(QSAction*)newObject {
     if (newObject != nil && aObject != newObject) {
         aObject = newObject;
-    
-        id rep = [aObject identifier];
-        if(rep != nil)
-            [[self commandDict] setObject:rep forKey:@"actionID"];
-        else {
-            rep = [aObject dictionaryRepresentation];
-            if(rep)
-                [[self commandDict] setObject:rep forKey:@"actionArchive"];
-        }
+        [self storeObject:aObject forType:@"action"];
     }
 }
 
 - (void)setIndirectObject:(QSObject*)newObject {
     if (newObject != nil && iObject != newObject) {
         iObject = newObject;
-    
-        id rep = [iObject identifier];
-        if(rep != nil)
-            [[self commandDict] setObject:rep forKey:@"indirectID"];
-        else {
-            rep = [iObject dictionaryRepresentation];
-            if(rep)
-                [[self commandDict] setObject:rep forKey:@"indirectArchive"];
-        }
+        [self storeObject:iObject forType:@"indirect"];
     }
 }
 


### PR DESCRIPTION
Fixes issue #2419

This *should* fix #2419 (I think), it seems that in this case:

1. You create a trigger for an dObject that's not in the catalog
2. That dObject subsequently gets added to the catalog
3. You resave the trigger (I guess it happens on every quit of the app)

Then the trigger would have both a directArchive (created originally when the object isn't in the catalog) and then subsequently a directID (when the object gets added to the catalog). This causes problems in `QSCommand.m:-(QSObject *)dObject` (I think).

Now the ideal solution would be to store *both* the directID and directArchive, and (for the event that you add a trigger for something that's in the catalog, then it subsequently gets removed from the catalog) but that's another task for another day.