### PR TITLE
fix test for recent documents under 10.13

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSObject_FileHandling.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject_FileHandling.m
@@ -336,7 +336,12 @@ NSArray *QSGetRecentDocumentsForBundle(NSString *bundleIdentifier) {
             // Does the app have valid recent documents
             if (bundleIdentifier) {
                 if ([NSApplication isElCapitan]) {
-                    NSString *sflPath = [NSString stringWithFormat:pSharedFileListPathTemplate, bundleIdentifier, @"sfl"];
+					NSString *sflPath;
+					if ([NSApplication isHighSierra]) {
+						sflPath = [NSString stringWithFormat:pSharedFileListPathTemplate, bundleIdentifier, @"sfl2"];
+					} else {
+						sflPath = [NSString stringWithFormat:pSharedFileListPathTemplate, bundleIdentifier, @"sfl"];
+					}
                     if ([[NSFileManager defaultManager] fileExistsAtPath:[sflPath stringByStandardizingPath] isDirectory:nil]) {
                         return YES;
                     }


### PR DESCRIPTION
Children will only be loaded with right-arrow if `objectHasChildren:` returns `YES`. This was working for any application that still had `.sfl` files laying around, but it should have been checking for `.sfl2` files on 10.13+.