### PR TITLE
small changes to the scoring algorithm

### DIFF
--- a/Quicksilver/Code-QuickStepFoundation/QSSense.m
+++ b/Quicksilver/Code-QuickStepFoundation/QSSense.m
@@ -58,7 +58,7 @@ CGFloat QSScoreForAbbreviationWithRanges(CFStringRef str, CFStringRef abbr, id m
 	// Create an inline buffer version of str.  Will be used in loop below
 	// for faster lookups.
 	CFStringInlineBuffer inlineBuffer;
-	CFStringInitInlineBuffer(str, &inlineBuffer, strRange);
+	CFStringInitInlineBuffer(str, &inlineBuffer, CFRangeMake(0, CFStringGetLength(str)));
 	CFLocaleRef userLoc = CFLocaleCopyCurrent();
 
 	CGFloat score = 0.0, remainingScore = 0.0;

--- a/Quicksilver/Code-QuickStepFoundation/QSSense.m
+++ b/Quicksilver/Code-QuickStepFoundation/QSSense.m
@@ -114,7 +114,7 @@ CGFloat QSScoreForAbbreviationWithRanges(CFStringRef str, CFStringRef abbr, id m
 							score -= SKIPPED_SCORE;
 					}
 				} else {
-					score -= (matchedRange.location-strRange.location)/2;
+					score -= (matchedRange.location-strRange.location) / 2.0;
 				}
 			}
 			score += remainingScore * remainingStrRange.length;

--- a/Quicksilver/Tests/Tests-QSFoundation/TestQSSense.m
+++ b/Quicksilver/Tests/Tests-QSFoundation/TestQSSense.m
@@ -56,43 +56,43 @@
 	NSMutableIndexSet *indexes = [[NSMutableIndexSet alloc] init];
 	NSIndexSet *results = nil;
 
-	score = QSScoreForAbbreviationWithRanges(str, CFSTR("test"), indexes, strRange, abbrRange);
+	score = QSScoreForAbbreviationWithRanges(str, abbr, indexes, strRange, abbrRange);
 	XCTAssertEqualWithAccuracy(score, 0.901851, ACC);
 	results = [NSIndexSet indexSetFromArray:@[@(0), @(5), @(15), @(16), @(22), @(23)]];
 	XCTAssertEqualObjects(indexes, results);
 
 	strRange.length += STEP;
-	score = QSScoreForAbbreviationWithRanges(str, CFSTR("test"), indexes, strRange, abbrRange);
+	score = QSScoreForAbbreviationWithRanges(str, abbr, indexes, strRange, abbrRange);
 	XCTAssertEqualWithAccuracy(score, 0.901612, ACC);
 	results = [NSIndexSet indexSetFromArray:@[@(0), @(5), @(15), @(16), @(22), @(23), @(26)]];
 	XCTAssertEqualObjects(indexes, results);
 
 	strRange.length += STEP;
-	score = QSScoreForAbbreviationWithRanges(str, CFSTR("test"), indexes, strRange, abbrRange);
+	score = QSScoreForAbbreviationWithRanges(str, abbr, indexes, strRange, abbrRange);
 	XCTAssertEqualWithAccuracy(score, 0.901428, ACC);
 	results = [NSIndexSet indexSetFromArray:@[@(0), @(5), @(15), @(16), @(22), @(23), @(26)]];
 	XCTAssertEqualObjects(indexes, results);
 
 	strRange.length += STEP;
-	score = QSScoreForAbbreviationWithRanges(str, CFSTR("test"), indexes, strRange, abbrRange);
+	score = QSScoreForAbbreviationWithRanges(str, abbr, indexes, strRange, abbrRange);
 	XCTAssertEqualWithAccuracy(score, 0.72948, ACC);
 	results = [NSIndexSet indexSetFromArray:@[@(0), @(5), @(15), @(16), @(22), @(23), @(26), @(36)]];
 	XCTAssertEqualObjects(indexes, results);
 
 	strRange.length += STEP;
-	score = QSScoreForAbbreviationWithRanges(str, CFSTR("test"), indexes, strRange, abbrRange);
+	score = QSScoreForAbbreviationWithRanges(str, abbr, indexes, strRange, abbrRange);
 	XCTAssertEqualWithAccuracy(score, 0.69883, ACC);
 	results = [NSIndexSet indexSetFromArray:@[@(0), @(5), @(15), @(16), @(22), @(23), @(26), @(36), @(40), @(41)]];
 	XCTAssertEqualObjects(indexes, results);
 
 	strRange.length += STEP;
-	score = QSScoreForAbbreviationWithRanges(str, CFSTR("test"), indexes, strRange, abbrRange);
+	score = QSScoreForAbbreviationWithRanges(str, abbr, indexes, strRange, abbrRange);
 	XCTAssertEqualWithAccuracy(score, 0.71595, ACC);
 	results = [NSIndexSet indexSetFromArray:@[@(0), @(5), @(15), @(16), @(22), @(23), @(26), @(36), @(40), @(41)]];
 	XCTAssertEqualObjects(indexes, results);
 
 	strRange.length += STEP;
-	score = QSScoreForAbbreviationWithRanges(str, CFSTR("test"), indexes, strRange, abbrRange);
+	score = QSScoreForAbbreviationWithRanges(str, abbr, indexes, strRange, abbrRange);
 	XCTAssertEqualWithAccuracy(score, 0.73039, ACC);
 	results = [NSIndexSet indexSetFromArray:@[@(0), @(5), @(15), @(16), @(22), @(23), @(26), @(36), @(40), @(41)]];
 	XCTAssertEqualObjects(indexes, results);

--- a/Quicksilver/Tests/Tests-QSFoundation/TestQSSense.m
+++ b/Quicksilver/Tests/Tests-QSFoundation/TestQSSense.m
@@ -57,25 +57,25 @@
 	NSIndexSet *results = nil;
 
 	score = QSScoreForAbbreviationWithRanges(str, CFSTR("test"), indexes, strRange, abbrRange);
-	XCTAssertEqualWithAccuracy(score, 0.74074, ACC);
+	XCTAssertEqualWithAccuracy(score, 0.901851, ACC);
 	results = [NSIndexSet indexSetFromArray:@[@(0), @(5), @(15), @(16), @(22), @(23)]];
 	XCTAssertEqualObjects(indexes, results);
 
 	strRange.length += STEP;
 	score = QSScoreForAbbreviationWithRanges(str, CFSTR("test"), indexes, strRange, abbrRange);
-	XCTAssertEqualWithAccuracy(score, 0.76129, ACC);
+	XCTAssertEqualWithAccuracy(score, 0.901612, ACC);
 	results = [NSIndexSet indexSetFromArray:@[@(0), @(5), @(15), @(16), @(22), @(23), @(26)]];
 	XCTAssertEqualObjects(indexes, results);
 
 	strRange.length += STEP;
 	score = QSScoreForAbbreviationWithRanges(str, CFSTR("test"), indexes, strRange, abbrRange);
-	XCTAssertEqualWithAccuracy(score, 0.77714, ACC);
+	XCTAssertEqualWithAccuracy(score, 0.901428, ACC);
 	results = [NSIndexSet indexSetFromArray:@[@(0), @(5), @(15), @(16), @(22), @(23), @(26)]];
 	XCTAssertEqualObjects(indexes, results);
 
 	strRange.length += STEP;
 	score = QSScoreForAbbreviationWithRanges(str, CFSTR("test"), indexes, strRange, abbrRange);
-	XCTAssertEqualWithAccuracy(score, 0.74230, ACC);
+	XCTAssertEqualWithAccuracy(score, 0.72948, ACC);
 	results = [NSIndexSet indexSetFromArray:@[@(0), @(5), @(15), @(16), @(22), @(23), @(26), @(36)]];
 	XCTAssertEqualObjects(indexes, results);
 

--- a/Quicksilver/Tests/Tests-QSFoundation/TestQSSense.m
+++ b/Quicksilver/Tests/Tests-QSFoundation/TestQSSense.m
@@ -14,64 +14,35 @@
 
 @implementation TestQSSense
 
-const float ACC = 0.00001;
-
 - (void)testScoreSimple {
 	CFStringRef str  = CFSTR("Test string");
 	CGFloat score = 0;
-
-	score = QSScoreForAbbreviation(str, CFSTR("t"), nil);
-	XCTAssertEqualWithAccuracy(score, 0.90909, ACC);
-
-	score = QSScoreForAbbreviation(str, CFSTR("ts"), nil);
-	XCTAssertEqualWithAccuracy(score, 0.92727, ACC);
-
-	score = QSScoreForAbbreviation(str, CFSTR("te"), nil);
-	XCTAssertEqualWithAccuracy(score, 0.91818, ACC);
-
-	score = QSScoreForAbbreviation(str, CFSTR("tet"), nil);
-	XCTAssertEqualWithAccuracy(score, 0.93636, ACC);
-
-	score = QSScoreForAbbreviation(str, CFSTR("str"), nil);
-	XCTAssertEqualWithAccuracy(score, 0.91818, ACC);
-
-	score = QSScoreForAbbreviation(str, CFSTR("tstr"), nil);
-	XCTAssertEqualWithAccuracy(score, 0.79090, ACC);
-
-	score = QSScoreForAbbreviation(str, CFSTR("ng"), nil);
-	XCTAssertEqualWithAccuracy(score, 0.63636, ACC);
+	CGFloat prev_score = 0;
+	// each abbreviation should score higher than the one before
+	NSArray *testAbbreviations = @[
+		@"ng", @"ts", @"tet", @"t", @"str", @"te", @"tstr"
+	];
+	for (NSString *abbr in testAbbreviations) {
+		score = QSScoreForAbbreviation(str, (__bridge CFStringRef)(abbr), nil);
+		XCTAssertGreaterThanOrEqual(score, prev_score, @"score for %@ was not higher", abbr);
+		prev_score = score;
+	}
 }
 
 - (void)testScoreLongString {
 	CFStringRef str = CFSTR("This is a really long test string for testing");
 	CGFloat score = 0;
-
-	score = QSScoreForAbbreviation(str, CFSTR("t"), nil);
-	XCTAssertEqualWithAccuracy(score, 0.90222, ACC);
-
-	score = QSScoreForAbbreviation(str, CFSTR("ts"), nil);
-	XCTAssertEqualWithAccuracy(score, 0.88666, ACC);
-
-	score = QSScoreForAbbreviation(str, CFSTR("te"), nil);
-	XCTAssertEqualWithAccuracy(score, 0.80777, ACC);
-
-	score = QSScoreForAbbreviation(str, CFSTR("tet"), nil);
-	XCTAssertEqualWithAccuracy(score, 0.81222, ACC);
-
-	score = QSScoreForAbbreviation(str, CFSTR("str"), nil);
-	XCTAssertEqualWithAccuracy(score, 0.78555, ACC);
-
-	score = QSScoreForAbbreviation(str, CFSTR("tstr"), nil);
-	XCTAssertEqualWithAccuracy(score, 0.67777, ACC);
-
-	score = QSScoreForAbbreviation(str, CFSTR("testi"), nil);
-	XCTAssertEqualWithAccuracy(score, 0.74000, ACC);
-
-	score = QSScoreForAbbreviation(str, CFSTR("for"), nil);
-	XCTAssertEqualWithAccuracy(score, 0.75888, ACC);
-
-	score = QSScoreForAbbreviation(str, CFSTR("ng"), nil);
-	XCTAssertEqualWithAccuracy(score, 0.74666, ACC);
+	CGFloat prev_score = 0;
+	// each abbreviation should score higher than the one before
+	NSArray *testAbbreviations = @[
+		@"ng", @"testi", @"for", @"str", @"tstr", @"tet", @"te", @"ts", @"t"
+	];
+	for (NSString *abbr in testAbbreviations) {
+		score = QSScoreForAbbreviation(str, (__bridge CFStringRef)(abbr), nil);
+		NSLog(@"%@ %g", abbr, score);
+		XCTAssertGreaterThanOrEqual(score, prev_score, @"score for %@ was not higher", abbr);
+		prev_score = score;
+	}
 }
 
 - (void)testLongString {
@@ -80,6 +51,7 @@ const float ACC = 0.00001;
 	CFStringRef abbr = CFSTR("test");
 	CFRange abbrRange = CFRangeMake(0, CFStringGetLength(abbr));
 	CGFloat score = 0;
+	const float ACC = 0.00001;
 	const int STEP = 4;
 	NSMutableIndexSet *indexes = [[NSMutableIndexSet alloc] init];
 	NSIndexSet *results = nil;


### PR DESCRIPTION
I addressed the first two points here @fwextensions. On the third, I don’t doubt the bug, but the fix doesn’t seem right. At that point in the code, `mask` is going to be thrown away forever anyway. Clearing it wouldn’t make a difference. (I tried and the scores didn’t change.) I haven’t had a chance to dig in and figure out the actual fix.

closes #2450 