### PR TITLE
refer to the manual instead of the wiki

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSPaths.h
+++ b/Quicksilver/Code-QuickStepCore/QSPaths.h
@@ -23,7 +23,7 @@
 #define kForumsURL				@"http://groups.google.com/group/blacktree-quicksilver"
 #define kBugsURL				@"https://github.com/quicksilver/Quicksilver/issues"
 #define kWebSiteURL             @"https://qsapp.com/"
-#define kHelpURL				@"https://qsapp.com/wiki/"
+#define kHelpURL				@"https://qsapp.com/manual/"
 #define kHelpSearchURL			@"https://qsapp.com/w/index.php?title=Special:Search&search=%@&go=Go"
 // URL to crash reporter server/script
 #define kCrashReporterURL       @"https://qs0.qsapp.com/crashreports/reporter.php"

--- a/Quicksilver/Resources/CrashReporterText.html
+++ b/Quicksilver/Resources/CrashReporterText.html
@@ -1,4 +1,4 @@
 <div style="font-family:'Lucida Grande';font-size:12px;text-align:justify;padding:0px;margin:0px">
     <p>In order to help improve Quicksilver, please consider sending a crash report to the developers. Quicksilver will restart when this window closes.</p>
-    <p>To troubleshoot your problem, see the <a href="https://qsapp.com/wiki/FAQ" style="text-decoration:underline;color:blue">FAQ</a> or alternatively report your issue on the <a href="https://github.com/quicksilver/Quicksilver/issues" style="text-decoration:underline;color:blue">issue tracker</a>.</p>
+    <p>To troubleshoot your problem, see the <a href="https://qsapp.com/manual/FAQ/" style="text-decoration:underline;color:blue">FAQ</a> or alternatively report your issue on the <a href="https://github.com/quicksilver/Quicksilver/issues" style="text-decoration:underline;color:blue">issue tracker</a>.</p>
 </div>

--- a/Quicksilver/Resources/GettingSupport.html
+++ b/Quicksilver/Resources/GettingSupport.html
@@ -1,7 +1,7 @@
 <div style="font-family:'Lucida Grande';font-size:13px;text-align: justify;">
     <h4>Support</h4>
     <p>Quicksilver's flexibility may seem daunting at first. The Quicksilver community is invaluable for new users.</p>
-    <p><b><a href="https://qsapp.com/wiki">Wiki</a></b> - Extensive documentation and FAQ on Quicksilver.</p>
+    <p><b><a href="https://qsapp.com/manual">Manual</a></b> - Extensive documentation and FAQ on Quicksilver.</p>
     <p><b><a href="http://groups.google.com/group/blacktree-quicksilver/">Forums</a></b> - Get hints, help, and ideas from other users. Suggestions and comments are always welcome.</p>
     <p><a href="https://github.com/quicksilver/Quicksilver/issues"><b>Bug Reporter</a></b> - Report and track issues with Quicksilver.</p>
     <hr>

--- a/Quicksilver/Resources/Guide.html
+++ b/Quicksilver/Resources/Guide.html
@@ -127,7 +127,7 @@ ul li a img{
 	<div class="quicklinks">
 		<div class="content">
 		<h3>Resources</h3>
-		<p><b><a href="https://qsapp.com/wiki/">Documentation</a></b> of Quicksilver's features</p>
+		<p><b><a href="https://qsapp.com/manual/">Documentation</a></b> of Quicksilver's features</p>
 
 		<p><b><a href="http://groups.google.com/group/blacktree-quicksilver">Forums</a></b> offering hints, help, and ideas from other users.
 			Suggestions and comments are welcome.</p>

--- a/Quicksilver/Resources/PluginReporterText.html
+++ b/Quicksilver/Resources/PluginReporterText.html
@@ -1,5 +1,5 @@
 <div style="font-family:'Lucida Grande';font-size:12px;text-align:justify;padding:0px;margin:0px">
 <p>The *** plugin caused Quicksilver to crash, you may wish to delete it.
     In order to help improve Quicksilver, please consider sending a crash report to the developers. Quicksilver will restart when this window closes.</p>
-    <p>To troubleshoot your problem, see the <a href="https://qsapp.com/wiki/FAQ" style="text-decoration:underline;color:blue">FAQ</a> or alternatively report your issue on the <a href="https://github.com/quicksilver/Quicksilver/issues" style="text-decoration:underline;color:blue">issue tracker</a>.</p>
+    <p>To troubleshoot your problem, see the <a href="https://qsapp.com/manual/FAQ/" style="text-decoration:underline;color:blue">FAQ</a> or alternatively report your issue on the <a href="https://github.com/quicksilver/Quicksilver/issues" style="text-decoration:underline;color:blue">issue tracker</a>.</p>
 </div>


### PR DESCRIPTION
Probably anything useful in the wiki should be relocated to the manual. The idea behind the wiki was that anyone could contribute, but no one does. And the manual is a public git repo now, so it’s not as exclusive.