### PR TITLE
Background proxy side-effects

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSProxyObject.h
+++ b/Quicksilver/Code-QuickStepCore/QSProxyObject.h
@@ -33,7 +33,10 @@
 + (id)proxyWithDictionary:(NSDictionary*)dictionary;
 + (id)proxyWithIdentifier:(NSString*)identifier;
 - (NSObject <QSProxyObjectProvider> *)proxyProvider;
-- (QSObject*)proxyObject;
+- (QSObject *)proxyObject;
+
+// return whatever is cached, but don't resolve it if nil
+- (QSObject *)cachedProxyTarget;
 
 - (void)releaseProxy:(NSNotification *)notif;
 

--- a/Quicksilver/Code-QuickStepCore/QSProxyObject.m
+++ b/Quicksilver/Code-QuickStepCore/QSProxyObject.m
@@ -60,23 +60,23 @@
 }
 
 - (QSObject*)proxyObject {
-	id proxy = nil;
-	if (proxy = [self objectForCache:QSProxyTargetCache])
-		return proxy;
+	id target = nil;
+	if (target = [self objectForCache:QSProxyTargetCache])
+		return target;
     
     id provider = [self proxyProvider];        
-    proxy = [provider resolveProxyObject:self];
+    target = [provider resolveProxyObject:self];
     
-    if ([self isEqual:proxy]) return nil;
+    if ([self isEqual:target]) return nil;
     
-    //NSLog(@"Proxy: %@", proxy);
-    if (proxy) {
-        [self setObject:proxy forCache:QSProxyTargetCache];
+	// NSLog(@"Proxy: %@", target);
+    if (target) {
+        [self setObject:target forCache:QSProxyTargetCache];
 		[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(releaseProxy:) name:QSInterfaceDeactivatedNotification object:nil];
 		[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(releaseProxy:) name:QSCommandExecutedNotification object:nil];
-        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(objectIconModified:) name:QSObjectIconModified object:proxy];
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(objectIconModified:) name:QSObjectIconModified object:target];
     }
-	return proxy;
+	return target;
 }
 
 

--- a/Quicksilver/Code-QuickStepCore/QSProxyObject.m
+++ b/Quicksilver/Code-QuickStepCore/QSProxyObject.m
@@ -120,6 +120,11 @@
 
 - (QSObject *)resolvedObject {return [self proxyObject];}
 
+- (QSObject *)cachedProxyTarget
+{
+	return [self objectForCache:QSProxyTargetCache];
+}
+
 - (NSString *)stringValue {
 	return [[self resolvedObject] stringValue];
 }


### PR DESCRIPTION
I was trying to show nicer details for a proxy object by pulling them from the resolved object, but calling `resolvedObject` while getting details tends to happen before the object gets selected in the main interface. (I think because it appears in the results during a partial match.) That forces the object to be resolved and cached before it’s actually displayed.

There also seems to be something calling for details just after the interface is dismissed, which is even worse because of this sequence:

1. The user dismisses the interface
2. The proxy cache is intentionally cleared
3. Something calls `detailsOfObject:` which calls `resolvedObject` which grabs and immediately re-caches the current value of the proxy

Then, sometime later:

4. The user calls up the proxy
5. It has a (potentially very old) cached value, so that gets returned

I’m not sure what the best answer is here, other than for developers to avoid calling `resolvedObject` when they just want the already resolved value. So for now, this gives us a way to do that.