### PR TITLE
Use NSRunningApplication for app management

### DIFF
--- a/Quicksilver/Code-QuickStepFoundation/NSWorkspace_BLTRExtensions.h
+++ b/Quicksilver/Code-QuickStepFoundation/NSWorkspace_BLTRExtensions.h
@@ -14,11 +14,8 @@
 - (NSArray <NSString *>*)allApplications;
 - (NSInteger) pidForApplication:(NSDictionary *)theApp;
 - (BOOL)applicationIsRunning:(NSString *)pathOrID;
-- (NSDictionary *)dictForApplicationName:(NSString *)path;
 - (void)killApplication:(NSString *)path;
-- (BOOL)applicationIsHidden:(NSDictionary *)theApp;
 - (BOOL)applicationIsFrontmost:(NSDictionary *)theApp;
-- (BOOL)PSN:(ProcessSerialNumber *)psn forApplication:(NSDictionary *)theApp;
 - (void)switchToApplication:(NSDictionary *)theApp frontWindowOnly:(BOOL)frontOnly;
 - (void)activateFrontWindowOfApplication:(NSDictionary *)theApp;
 - (void)hideApplication:(NSDictionary *)theApp;
@@ -27,11 +24,8 @@
 - (void)activateApplication:(NSDictionary *)theApp;
 - (void)reopenApplication:(NSDictionary *)theApp;
 - (void)quitApplication:(NSDictionary *)theApp;
-- (NSString *)nameForPID:(pid_t)pid;
-- (NSString *)pathForPID:(pid_t)pid;
-- (void)quitPSN:(ProcessSerialNumber)psn;
 - (void)quitOtherApplications:(NSArray *)theApps;
-- (NSDictionary *)dictForApplicationIdentifier:(NSString *)ident;
+- (NSDictionary *)dictForApplicationIdentifier:(NSString *)ident QS_DEPRECATED;
 - (NSString *)commentForFile:(NSString *)path;
 - (BOOL)setComment:(NSString*)comment forFile:(NSString *)path;
 - (BOOL)openFileInBackground:(NSString *)fullPath;


### PR DESCRIPTION
Deprecate and move away from the old NSWorkspace style app dicts.
This should fix #2482 as well as just generally clean up the code

We can't move away from the old style completely, because some plugins still use it. But it's nice to at least make a start... baby steps :P

Also: ideally we'd switch QSObjects that represent running processes (stored in the `QSProcessType` data key) to also use NSRunningApplication instead of these NSDicts, but again... baby steps. Assuming this code has no big problems, that would be the next step