### PR TITLE
don’t release Large Type windows on close

### DIFF
--- a/Quicksilver/Code-QuickStepInterface/QSLargeTypeDisplay.m
+++ b/Quicksilver/Code-QuickStepInterface/QSLargeTypeDisplay.m
@@ -13,8 +13,6 @@
 
 #define EDGEINSET 16
 
-static NSMutableArray *_largeTypeWindows;
-
 #pragma mark QSLargeTypeDisplay
 
 void QSShowLargeType(NSString *aString) {
@@ -85,12 +83,7 @@ void QSShowLargeType(NSString *aString) {
 	windowRect = NSInsetRect(windowRect, -EDGEINSET, -EDGEINSET);
 	windowRect = NSIntegralRect(windowRect);
     
-    if (!_largeTypeWindows) {
-        _largeTypeWindows = [[NSMutableArray alloc] init];
-    }
-    
 	QSVanishingWindow *largeTypeWindow = [[QSVanishingWindow alloc] initWithContentRect:windowRect styleMask:NSBorderlessWindowMask | NSNonactivatingPanelMask backing:NSBackingStoreBuffered defer:NO];
-    [_largeTypeWindows addObject:largeTypeWindow];
 	[largeTypeWindow setIgnoresMouseEvents:NO];
 	[largeTypeWindow setFrame:centerRectInRect(windowRect, screenRect) display:YES];
 	[largeTypeWindow setBackgroundColor: [NSColor clearColor]];
@@ -131,13 +124,6 @@ void QSShowLargeType(NSString *aString) {
 - (void)keyDown:(NSEvent *)theEvent {
 	[self setAlphaValue:0 fadeTime:0.333];
 	[self close];
-}
-
-- (void)dealloc {
-    [_largeTypeWindows removeObject:self];
-    if ([_largeTypeWindows count] == 0) {
-        _largeTypeWindows = nil;
-    }
 }
 
 - (void)resignKeyWindow {

--- a/Quicksilver/Code-QuickStepInterface/QSLargeTypeDisplay.m
+++ b/Quicksilver/Code-QuickStepInterface/QSLargeTypeDisplay.m
@@ -97,8 +97,6 @@ void QSShowLargeType(NSString *aString) {
 	[largeTypeWindow setOpaque:NO];
 	[largeTypeWindow setLevel:NSFloatingWindowLevel];
 	[largeTypeWindow setHidesOnDeactivate:NO];
-    [largeTypeWindow setReleasedWhenClosed:YES];
-	//	[largeTypeWindow setNextResponder:self];
 
 	QSBezelBackgroundView *content = [[NSClassFromString(@"QSBezelBackgroundView") alloc] initWithFrame:NSZeroRect];
 	[content setRadius:32];
@@ -121,12 +119,6 @@ void QSShowLargeType(NSString *aString) {
 #pragma mark QSVainishingWindow
 
 @implementation QSVanishingWindow
-- (id)initWithContentRect:(NSRect)contentRect styleMask:(NSWindowStyleMask)aStyle backing:(NSBackingStoreType)bufferingType defer:(BOOL)flag {
-	if (self = [super initWithContentRect:contentRect styleMask:aStyle backing:bufferingType defer:flag]) {
-		[self setReleasedWhenClosed:YES];
-	}
-	return self;
-}
 
 - (IBAction)copy:(id)sender {
 	NSPasteboard *pb = [NSPasteboard generalPasteboard];

--- a/Quicksilver/Code-QuickStepInterface/QSTextViewer.m
+++ b/Quicksilver/Code-QuickStepInterface/QSTextViewer.m
@@ -42,7 +42,7 @@ QSTextViewer * QSShowTextViewerWithFile(NSString *path) {
 	[window setContentView:textview];
 	[textview release];*/
 	[window setReleasedWhenClosed:YES];
-	[window center];
+	[(QSWindow *)window center];
 
 	NSScrollView *scrollview = [[NSScrollView alloc] initWithFrame:[[window contentView] frame]];
 	[scrollview setBorderType:NSNoBorder];


### PR DESCRIPTION
This prevents the app from crashing when dismissing the Large Type interface. I have a VM running Catalina, so I was able to test there too.