### PR TITLE
use the octal representation of the escape character

### DIFF
--- a/Quicksilver/PropertyLists/Quicksilver-Info.plist
+++ b/Quicksilver/PropertyLists/Quicksilver-Info.plist
@@ -277,7 +277,7 @@
 			<key>NSKeyEquivalent</key>
 			<dict>
 				<key>default</key>
-				<string></string>
+				<string>\033</string>
 			</dict>
 		</dict>
 	</array>


### PR DESCRIPTION
Some packaging tools were getting tripped up on the representation of the Escape key. This appears to work just as well.

See #2527