### PR TITLE
Potential fix for Fn modifier-only activation problem. (issue #2533)

### DIFF
--- a/Quicksilver/Code-App/QSModifierKeyEvents.h
+++ b/Quicksilver/Code-App/QSModifierKeyEvents.h
@@ -19,11 +19,6 @@ NSUInteger lastModifiers;
     NSUInteger _modifierActivationMask;
 	NSString *identifier;
 	SEL action;
-
-	@private
-    NSTimeInterval timeSinceLastKeyDown;
-    NSDate *firstModifierPressedTime;
-    
 }
 
 @property __block NSInteger timesKeysPressed;

--- a/Quicksilver/Code-App/QSModifierKeyEvents.m
+++ b/Quicksilver/Code-App/QSModifierKeyEvents.m
@@ -61,7 +61,7 @@ BOOL modifierEventsEnabled = YES;
         }
     }];
     
-    BOOL modsAdded = mods >= lastModifiers;
+    BOOL modsAdded = mods > lastModifiers;
     
 	lastModifiers = mods;
     [match checkForModifierTap:modsAdded];
@@ -156,22 +156,10 @@ BOOL modifierEventsEnabled = YES;
             // keyUp events aren't sent for the caps lock key, so we have to check it here and manually increase the key pressed count
             self.timesKeysPressed += 1;
         }
-        NSTimeInterval timeDiff = [firstModifierPressedTime timeIntervalSinceNow];
-        NSTimeInterval newTimeSinceLastKeyDown = CGEventSourceSecondsSinceLastEventType (
-                                                                 kCGEventSourceStateHIDSystemState,
-                                                                 kCGEventKeyDown
-                                                                 );
-        
-        NSTimeInterval keyPressDif = timeSinceLastKeyDown - newTimeSinceLastKeyDown;
-        if (fabs(timeDiff - keyPressDif) < 0.001 && self.timesKeysPressed == self.modifierActivationCount) {
+        if (self.timesKeysPressed == self.modifierActivationCount) {
             [self sendAction];
         }
     } else {
-        firstModifierPressedTime = [NSDate date];
-        timeSinceLastKeyDown = CGEventSourceSecondsSinceLastEventType (
-                                                               kCGEventSourceStateHIDSystemState,
-                                                               kCGEventKeyDown
-                                                               );
         double window = 0.3;
         self.timesKeysPressed += 1;
         [self performSelector:@selector(resetTimesKeysPressed:) withObject:nil afterDelay:window extend:YES];

--- a/Quicksilver/Code-App/QSModifierKeyEvents.m
+++ b/Quicksilver/Code-App/QSModifierKeyEvents.m
@@ -156,7 +156,16 @@ BOOL modifierEventsEnabled = YES;
             // keyUp events aren't sent for the caps lock key, so we have to check it here and manually increase the key pressed count
             self.timesKeysPressed += 1;
         }
-        if (self.timesKeysPressed == self.modifierActivationCount) {
+        NSTimeInterval timeSinceLastKeyDown = CGEventSourceSecondsSinceLastEventType (
+                                                                 kCGEventSourceStateHIDSystemState,
+                                                                 kCGEventKeyDown
+                                                                 );
+        NSTimeInterval timeSinceLastFlagsChanged = CGEventSourceSecondsSinceLastEventType (
+                                                                 kCGEventSourceStateHIDSystemState,
+                                                                 kCGEventFlagsChanged
+                                                                 );
+
+        if ((timeSinceLastKeyDown - timeSinceLastFlagsChanged) < 0.001 && self.timesKeysPressed == self.modifierActivationCount) {
             [self sendAction];
         }
     } else {


### PR DESCRIPTION
This is really just a potential fix.
It removes the timing test that seems to block single function keys in my test.
I’m not sure what this test is supposed to do anyways.
There is already a 0.3s timer that resets the keys pressed.
