### PR TITLE
Relaunch as ARM64 if running ARM64

### DIFF
--- a/Quicksilver/Code-QuickStepFoundation/NSApplication_BLTRExtensions.m
+++ b/Quicksilver/Code-QuickStepFoundation/NSApplication_BLTRExtensions.m
@@ -113,8 +113,18 @@
 	[[NSNotificationCenter defaultCenter] postNotificationName:QSApplicationWillRelaunchNotification object:self userInfo:nil];
     NSString *arch = @"/usr/bin/arch";
     NSRunningApplication *Quicksilver = [NSRunningApplication currentApplication];
-    NSString *currentArchitecture = ([Quicksilver executableArchitecture] == NSBundleExecutableArchitectureX86_64) ? @"-x86_64" : @"-i386";
-	[NSTask launchedTaskWithLaunchPath:arch arguments:[NSArray arrayWithObjects:currentArchitecture, path,nil]];
+	NSString *currentArchitecture;
+	switch ([Quicksilver executableArchitecture]) {
+		case NSBundleExecutableArchitectureX86_64:
+			currentArchitecture = @"-x86_64";
+			break;
+		case NSBundleExecutableArchitectureARM64:
+		    currentArchitecture = @"-arm64";
+			break;
+		default:
+			currentArchitecture = @"-i386";
+	}
+	[NSTask launchedTaskWithLaunchPath:arch arguments:[NSArray arrayWithObjects:currentArchitecture, path, nil]];
 
 	[self terminate:self];
 }

--- a/Quicksilver/Code-QuickStepFoundation/NSApplication_BLTRExtensions.m
+++ b/Quicksilver/Code-QuickStepFoundation/NSApplication_BLTRExtensions.m
@@ -113,17 +113,8 @@
 	[[NSNotificationCenter defaultCenter] postNotificationName:QSApplicationWillRelaunchNotification object:self userInfo:nil];
     NSString *arch = @"/usr/bin/arch";
     NSRunningApplication *Quicksilver = [NSRunningApplication currentApplication];
-	NSString *currentArchitecture;
-	switch ([Quicksilver executableArchitecture]) {
-		case NSBundleExecutableArchitectureX86_64:
-			currentArchitecture = @"-x86_64";
-			break;
-		case NSBundleExecutableArchitectureARM64:
-		    currentArchitecture = @"-arm64";
-			break;
-		default:
-			currentArchitecture = @"-i386";
-	}
+
+	NSString *currentArchitecture = ([Quicksilver executableArchitecture] == NSBundleExecutableArchitectureARM64) ? @"-arm64" : @"-x86_64";
 	[NSTask launchedTaskWithLaunchPath:arch arguments:[NSArray arrayWithObjects:currentArchitecture, path, nil]];
 
 	[self terminate:self];


### PR DESCRIPTION
Without this, running as Apple architecture -> `Relaunch Quicksilver` -> running as Intel.

This is the first line of Objective C I've ever written, but seems to work.

Related issue: https://github.com/quicksilver/Quicksilver/issues/2543