### PR TITLE
cleanup qsrelease: Make POSIX, fail on errors

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   build:
     runs-on: macos-11
+    env:
+      SIGNING_IDENTITY: "-"
     steps:
     - uses: actions/checkout@v2
       with:

--- a/Quicksilver/Tools/qsrelease
+++ b/Quicksilver/Tools/qsrelease
@@ -63,22 +63,14 @@ cd "${BUILT_PRODUCTS_DIR}"
 ## Set the correct plist permissions
 chmod 644 Quicksilver.app/Contents/Info.plist
 
-## Codesign everything from inside out
-## This descending sorts by path length, since directory contents should always
-## have a longer path then its parent
-find ./Quicksilver.app -path './Quicksilver.app/Contents/Frameworks/*.framework' -o \
-  -path './Quicksilver.app/Contents/PlugIns/*.qsplugin' -o \
-  -path './Quicksilver.app/Contents/Resources/QSDroplet.app' -o \
-  -path './Quicksilver.app/Contents/Library/Automator/*.action' -o \
-  -path './Quicksilver.app/Contents/Resources/*.plist' -o \
-  -path './Quicksilver.app/Contents/Info.plist' -o \
-  -path './Quicksilver.app' |  # find everything we want to sign
-  awk '{ print length, $0 }' | # prepend the path length
-  sort -rn |                   # reverse numeric sort
-  sed 's/^[0-9]\{1,\} //' |    # strip the number and leading space
-  while read -r item; do
-    codesign --force --sign "${SIGNING_IDENTITY}" "${item}"
-  done
+# Mass codesign everything. Will fail the first time through due to unsignable
+# items; here we explicitly ignore the error and hide a bunch of "bundle format
+# unrecognized" and "already signed" errors
+
+find ./Quicksilver.app -exec codesign --continue --sign "${SIGNING_IDENTITY}" {} + 2> /dev/null || true
+
+# Codesign the whole app now that all contents are signed
+codesign --force --sign "${SIGNING_IDENTITY}" ./Quicksilver.app
 
 ## Package it in a disk image
 mkdir -p "${DMG_TEMP}"
@@ -94,7 +86,7 @@ ln -sf /Applications .
   .DS_Store Quicksilver.app Applications \
   >> "${LOG}"
 
-codesign --sign "${SIGNING_IDENTITY}" Quicksilver.dmg
+codesign --deep --sign "${SIGNING_IDENTITY}" Quicksilver.dmg
 mv Quicksilver.dmg "../Quicksilver ${QS_INFO_VERSION}".dmg
 cd ..
 
@@ -110,7 +102,11 @@ codesign --verify --deep --strict --verbose=1 Quicksilver.app || true
 ## Will fail with a self-signed cert unless added to spctl
 ## https://stackoverflow.com/a/53814748/1588795
 ## https://stackoverflow.com/a/40605003/1588795
-## Uncomment to add self-signed cert with label `QuicksilverTest`
+## Run below to approve self-signed cert with label `QuicksilverTest` (requires
+## admin password), and the line below that to remove the approval
 # spctl --add --requirement "certificate leaf[subject.CN] = \"${SIGNING_IDENTITY}\"" --label "QuicksilverSelfSignedTest"
+# spctl --remove --label QuicksilverTest
+spctl --assess --verbose --type open --type exec ./Quicksilver.app
+
+## Will fail with a self-signed cert
 spctl --assess --verbose --type open --context context:primary-signature "Quicksilver ${QS_INFO_VERSION}.dmg"
-## Run this to remove self-signed cert with label `QuicksilverTest`

--- a/Quicksilver/Tools/qsrelease
+++ b/Quicksilver/Tools/qsrelease
@@ -1,65 +1,81 @@
-#!/bin/zsh
+#!/bin/sh
+
+set -euf
+
+cleanup() {
+  rm -f "${SETTINGS}"
+}
+trap cleanup EXIT
+
+# Allow users to pass in a custom signing identity name for testing with
+# self-signed certs
+SIGNING_IDENTITY=${SIGNING_IDENTITY:-"Developer ID Application"}
 
 ## Quicksilver Release build
 ## Cache settings to save time
 SETTINGS=/tmp/qs_build_settings
-xcodebuild -configuration Release -scheme 'Quicksilver Distribution' -showBuildSettings | sort -u > $SETTINGS
+xcodebuild -configuration Release \
+  -scheme 'Quicksilver Distribution' \
+  -showBuildSettings |
+  sort -u > "${SETTINGS}"
 
-SOURCE_ROOT="$( egrep '\bSOURCE_ROOT\b' $SETTINGS | sed -e 's/.*SOURCE_ROOT *= *\(.*\)/\1/' )"
-BUILT_PRODUCTS_DIR="$( egrep '\bBUILT_PRODUCTS_DIR\b' $SETTINGS | sed -e 's/.*BUILT_PRODUCTS_DIR *= *\(.*\)/\1/' )"
-QS_INFO_VERSION="$( egrep '\bQS_INFO_VERSION\b' $SETTINGS | sed -e 's/.*QS_INFO_VERSION *= *\(.*\)/\1/' )"
+SOURCE_ROOT=$(awk '$1 == "SOURCE_ROOT" { print $NF }' < "${SETTINGS}")
+BUILT_PRODUCTS_DIR=$(awk '$1 == "BUILT_PRODUCTS_DIR" { print $NF }' < "${SETTINGS}")
+QS_INFO_VERSION=$(awk '$1 == "QS_INFO_VERSION" { print $NF }' < "${SETTINGS}")
 
 ## Create the directory (for logging purposes)
-mkdir -p "$BUILT_PRODUCTS_DIR"
-LOG="$BUILT_PRODUCTS_DIR/build.log"
-DMG_TEMP="$BUILT_PRODUCTS_DIR/dmg"
+mkdir -p "${BUILT_PRODUCTS_DIR}"
+LOG=${BUILT_PRODUCTS_DIR}/build.log
+DMG_TEMP=${BUILT_PRODUCTS_DIR}/dmg
 
 ## Clean and Build
 ## (This could be done with a single command, but if `clean` fails, the
 ## exit status won't be 0. It usually fails because something didn't exist
 ## in the first place. We don't care.)
 # xcodebuild -configuration Debug -scheme 'Quicksilver' test > $LOG
-xcodebuild -scheme 'Quicksilver Distribution' test > $LOG
-xcodebuild -configuration Release -scheme 'Quicksilver Distribution' clean > $LOG
-xcodebuild -configuration Release -scheme 'Quicksilver Distribution' build >> $LOG
+xcodebuild -scheme 'Quicksilver Distribution' test > "${LOG}" || true
+xcodebuild -configuration Release -scheme 'Quicksilver Distribution' clean >> "${LOG}" || true
+xcodebuild -configuration Release -scheme 'Quicksilver Distribution' build >> "${LOG}"
 
-if [[ $? == 0 ]]; then
-  ## Build succeeded
-  cd $BUILT_PRODUCTS_DIR
+## Build succeeded
+cd "${BUILT_PRODUCTS_DIR}"
 
-  ## Set the correct plist permissions
-  chmod 644 Quicksilver.app/Contents/Info.plist
+## Set the correct plist permissions
+chmod 644 Quicksilver.app/Contents/Info.plist
 
-  ## Sign for Gatekeeper
-  codesign -s "Developer ID Application" Quicksilver.app/Contents/Frameworks/*.framework
-  codesign -s "Developer ID Application" Quicksilver.app/Contents/PlugIns/*.qsplugin
-  codesign -s "Developer ID Application" Quicksilver.app/Contents/Resources/QSDroplet.app
-  codesign -s "Developer ID Application" Quicksilver.app/Contents/Library/Automator/*.action
-  codesign -s "Developer ID Application" Quicksilver.app/Contents/Resources/*.plist
-  codesign -s "Developer ID Application" Quicksilver.app/Contents/Info.plist
-  codesign -s "Developer ID Application" Quicksilver.app
+## Sign for Gatekeeper
+codesign --sign "${SIGNING_IDENTITY}" Quicksilver.app/Contents/Frameworks/*.framework
+codesign --sign "${SIGNING_IDENTITY}" Quicksilver.app/Contents/PlugIns/*.qsplugin
+codesign --sign "${SIGNING_IDENTITY}" Quicksilver.app/Contents/Resources/QSDroplet.app
+codesign --sign "${SIGNING_IDENTITY}" Quicksilver.app/Contents/Library/Automator/*.action
+codesign --sign "${SIGNING_IDENTITY}" Quicksilver.app/Contents/Resources/*.plist
+codesign --sign "${SIGNING_IDENTITY}" Quicksilver.app/Contents/Info.plist
+codesign --sign "${SIGNING_IDENTITY}" Quicksilver.app
 
-  ## Package it in a disk image
-  mkdir $DMG_TEMP
-  cp -a Quicksilver.app $DMG_TEMP
-  cp $SOURCE_ROOT/Resources/DMG_DS_Store $DMG_TEMP/.DS_Store
-  cd $DMG_TEMP
-  ln -s /Applications
-  $SOURCE_ROOT/Tools/buildDMG.pl -dmgName Quicksilver -volName Quicksilver -volIcon $SOURCE_ROOT/Resources/Images/QuicksilverDMG.icns -compressionLevel 9 .DS_Store Quicksilver.app Applications >> $LOG
-  codesign -s "Developer ID Application" Quicksilver.dmg
-  mv Quicksilver.dmg "../Quicksilver $QS_INFO_VERSION.dmg"
-  cd ..
+## Package it in a disk image
+mkdir -p "${DMG_TEMP}"
+cp -a Quicksilver.app "${DMG_TEMP}"
+cp "${SOURCE_ROOT}"/Resources/DMG_DS_Store "${DMG_TEMP}"/.DS_Store
+cd "${DMG_TEMP}"
+ln -s /Applications .
+"${SOURCE_ROOT}"/Tools/buildDMG.pl \
+  -dmgName Quicksilver \
+  -volName Quicksilver \
+  -volIcon "${SOURCE_ROOT}"/Resources/Images/QuicksilverDMG.icns \
+  -compressionLevel 9 \
+  .DS_Store Quicksilver.app Applications \
+  >> "${LOG}"
 
-  ## Easy access to plist
-  cp Quicksilver.app/Contents/Info.plist $BUILT_PRODUCTS_DIR
+codesign --sign "${SIGNING_IDENTITY}" Quicksilver.dmg
+mv Quicksilver.dmg "../Quicksilver ${QS_INFO_VERSION}".dmg
+cd ..
 
-  ## Show the folder
-  open $BUILT_PRODUCTS_DIR
+## Easy access to plist
+cp Quicksilver.app/Contents/Info.plist "${BUILT_PRODUCTS_DIR}"
 
-  ## Verify app and DMG signing
-  codesign --verify --deep --strict --verbose=1 Quicksilver.app
-  spctl -avt open --context context:primary-signature "Quicksilver $QS_INFO_VERSION.dmg"
-fi
+## Show the folder
+open "${BUILT_PRODUCTS_DIR}"
 
-## Cleanup
-rm $SETTINGS
+## Verify app and DMG signing
+codesign --verify --deep --strict --verbose=1 Quicksilver.app
+spctl -avt open --context context:primary-signature "Quicksilver ${QS_INFO_VERSION}.dmg"

--- a/Quicksilver/Tools/qsrelease
+++ b/Quicksilver/Tools/qsrelease
@@ -63,9 +63,22 @@ cd "${BUILT_PRODUCTS_DIR}"
 ## Set the correct plist permissions
 chmod 644 Quicksilver.app/Contents/Info.plist
 
-## Codesign everything
-## Ignore exit 1 due to `is already signed`
-find ./Quicksilver.app -exec codesign --continue --sign "${SIGNING_IDENTITY}" {} + || true
+## Codesign everything from inside out
+## This descending sorts by path length, since directory contents should always
+## have a longer path then its parent
+find ./Quicksilver.app -path './Quicksilver.app/Contents/Frameworks/*.framework' -o \
+  -path './Quicksilver.app/Contents/PlugIns/*.qsplugin' -o \
+  -path './Quicksilver.app/Contents/Resources/QSDroplet.app' -o \
+  -path './Quicksilver.app/Contents/Library/Automator/*.action' -o \
+  -path './Quicksilver.app/Contents/Resources/*.plist' -o \
+  -path './Quicksilver.app/Contents/Info.plist' -o \
+  -path './Quicksilver.app' |  # find everything we want to sign
+  awk '{ print length, $0 }' | # prepend the path length
+  sort -rn |                   # reverse numeric sort
+  sed 's/^[0-9]\{1,\} //' |    # strip the number and leading space
+  while read -r item; do
+    codesign --force --sign "${SIGNING_IDENTITY}" "${item}"
+  done
 
 ## Package it in a disk image
 mkdir -p "${DMG_TEMP}"

--- a/Quicksilver/Tools/qsrelease
+++ b/Quicksilver/Tools/qsrelease
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 set -euf
+set -x
 
 cleanup() {
   rm -f "${SETTINGS}"
@@ -21,6 +22,8 @@ xcodebuild \
   -scheme 'Quicksilver Distribution' \
   -showBuildSettings |
   sort -u > "${SETTINGS}"
+
+cat "${SETTINGS}"
 
 SOURCE_ROOT=$(awk '$1 == "SOURCE_ROOT" { print $NF }' < "${SETTINGS}")
 BUILT_PRODUCTS_DIR=$(awk '$1 == "BUILT_PRODUCTS_DIR" { print $NF }' < "${SETTINGS}")

--- a/Quicksilver/Tools/qsrelease
+++ b/Quicksilver/Tools/qsrelease
@@ -85,7 +85,7 @@ mkdir -p "${DMG_TEMP}"
 cp -a Quicksilver.app "${DMG_TEMP}"
 cp "${SOURCE_ROOT}"/Resources/DMG_DS_Store "${DMG_TEMP}"/.DS_Store
 cd "${DMG_TEMP}"
-ln -s /Applications .
+ln -sf /Applications .
 "${SOURCE_ROOT}"/Tools/buildDMG.pl \
   -dmgName Quicksilver \
   -volName Quicksilver \

--- a/Quicksilver/Tools/qsrelease
+++ b/Quicksilver/Tools/qsrelease
@@ -11,7 +11,13 @@ trap cleanup EXIT
 # Allow users to pass in a custom signing identity name for testing with
 # self-signed certs
 SIGNING_IDENTITY=${SIGNING_IDENTITY:-"Developer ID Application"}
-CURRENT_ARCH=$(arch)
+
+# Default to x86_64 for CI builds
+if [ -n "${CI:-}" ]; then
+  CURRENT_ARCH=x86_64
+else
+  CURRENT_ARCH=$(arch)
+fi
 
 ## Quicksilver Release build
 ## Cache settings to save time

--- a/Quicksilver/Tools/qsrelease
+++ b/Quicksilver/Tools/qsrelease
@@ -10,11 +10,14 @@ trap cleanup EXIT
 # Allow users to pass in a custom signing identity name for testing with
 # self-signed certs
 SIGNING_IDENTITY=${SIGNING_IDENTITY:-"Developer ID Application"}
+CURRENT_ARCH=$(arch)
 
 ## Quicksilver Release build
 ## Cache settings to save time
 SETTINGS=/tmp/qs_build_settings
-xcodebuild -configuration Release \
+xcodebuild \
+  -destination "platform=macOS,arch=${CURRENT_ARCH}" \
+  -configuration Release \
   -scheme 'Quicksilver Distribution' \
   -showBuildSettings |
   sort -u > "${SETTINGS}"
@@ -32,10 +35,27 @@ DMG_TEMP=${BUILT_PRODUCTS_DIR}/dmg
 ## (This could be done with a single command, but if `clean` fails, the
 ## exit status won't be 0. It usually fails because something didn't exist
 ## in the first place. We don't care.)
-# xcodebuild -configuration Debug -scheme 'Quicksilver' test > $LOG
-xcodebuild -scheme 'Quicksilver Distribution' test > "${LOG}" || true
-xcodebuild -configuration Release -scheme 'Quicksilver Distribution' clean >> "${LOG}" || true
-xcodebuild -configuration Release -scheme 'Quicksilver Distribution' build >> "${LOG}"
+{
+  # xcodebuild -configuration Debug -scheme 'Quicksilver' test > $LOG
+  xcodebuild \
+    -destination "platform=macOS,arch=x86_64" \
+    -destination "platform=macOS,arch=arm64" \
+    -scheme 'Quicksilver Distribution' \
+    test || true
+
+  # TODO: https://github.com/quicksilver/Quicksilver/issues/2583
+  xcodebuild \
+    -destination "platform=macOS,arch=${CURRENT_ARCH}" \
+    -configuration Release \
+    -scheme 'Quicksilver Distribution' \
+    clean || true
+  xcodebuild \
+    -destination 'platform=macOS,arch=x86_64' \
+    -destination 'platform=macOS,arch=arm64' \
+    -configuration Release \
+    -scheme 'Quicksilver Distribution' \
+    build
+} > "${LOG}"
 
 ## Build succeeded
 cd "${BUILT_PRODUCTS_DIR}"
@@ -43,14 +63,9 @@ cd "${BUILT_PRODUCTS_DIR}"
 ## Set the correct plist permissions
 chmod 644 Quicksilver.app/Contents/Info.plist
 
-## Sign for Gatekeeper
-codesign --sign "${SIGNING_IDENTITY}" Quicksilver.app/Contents/Frameworks/*.framework
-codesign --sign "${SIGNING_IDENTITY}" Quicksilver.app/Contents/PlugIns/*.qsplugin
-codesign --sign "${SIGNING_IDENTITY}" Quicksilver.app/Contents/Resources/QSDroplet.app
-codesign --sign "${SIGNING_IDENTITY}" Quicksilver.app/Contents/Library/Automator/*.action
-codesign --sign "${SIGNING_IDENTITY}" Quicksilver.app/Contents/Resources/*.plist
-codesign --sign "${SIGNING_IDENTITY}" Quicksilver.app/Contents/Info.plist
-codesign --sign "${SIGNING_IDENTITY}" Quicksilver.app
+## Codesign everything
+## Ignore exit 1 due to `is already signed`
+find ./Quicksilver.app -exec codesign --continue --sign "${SIGNING_IDENTITY}" {} + || true
 
 ## Package it in a disk image
 mkdir -p "${DMG_TEMP}"
@@ -76,6 +91,13 @@ cp Quicksilver.app/Contents/Info.plist "${BUILT_PRODUCTS_DIR}"
 ## Show the folder
 open "${BUILT_PRODUCTS_DIR}"
 
-## Verify app and DMG signing
-codesign --verify --deep --strict --verbose=1 Quicksilver.app
-spctl -avt open --context context:primary-signature "Quicksilver ${QS_INFO_VERSION}.dmg"
+## Verify app and DMG signing, don't fail due to already signed
+codesign --verify --deep --strict --verbose=1 Quicksilver.app || true
+
+## Will fail with a self-signed cert unless added to spctl
+## https://stackoverflow.com/a/53814748/1588795
+## https://stackoverflow.com/a/40605003/1588795
+## Uncomment to add self-signed cert with label `QuicksilverTest`
+# spctl --add --requirement "certificate leaf[subject.CN] = \"${SIGNING_IDENTITY}\"" --label "QuicksilverSelfSignedTest"
+spctl --assess --verbose --type open --context context:primary-signature "Quicksilver ${QS_INFO_VERSION}.dmg"
+## Run this to remove self-signed cert with label `QuicksilverTest`

--- a/Quicksilver/Tools/qsrelease
+++ b/Quicksilver/Tools/qsrelease
@@ -1,7 +1,6 @@
 #!/bin/sh
 
 set -euf
-set -x
 
 cleanup() {
   rm -f "${SETTINGS}"
@@ -28,8 +27,6 @@ xcodebuild \
   -scheme 'Quicksilver Distribution' \
   -showBuildSettings |
   sort -u > "${SETTINGS}"
-
-cat "${SETTINGS}"
 
 SOURCE_ROOT=$(awk '$1 == "SOURCE_ROOT" { print $NF }' < "${SETTINGS}")
 BUILT_PRODUCTS_DIR=$(awk '$1 == "BUILT_PRODUCTS_DIR" { print $NF }' < "${SETTINGS}")

--- a/Quicksilver/Tools/qsrelease
+++ b/Quicksilver/Tools/qsrelease
@@ -111,7 +111,7 @@ codesign --verify --deep --strict --verbose=1 Quicksilver.app || true
 ## admin password), and the line below that to remove the approval
 # spctl --add --requirement "certificate leaf[subject.CN] = \"${SIGNING_IDENTITY}\"" --label "QuicksilverSelfSignedTest"
 # spctl --remove --label QuicksilverTest
-spctl --assess --verbose --type open --type exec ./Quicksilver.app
+spctl --assess --verbose --type open --type exec ./Quicksilver.app || true
 
 ## Will fail with a self-signed cert
-spctl --assess --verbose --type open --context context:primary-signature "Quicksilver ${QS_INFO_VERSION}.dmg"
+spctl --assess --verbose --type open --context context:primary-signature "Quicksilver ${QS_INFO_VERSION}.dmg" || true

--- a/Quicksilver/Tools/qsrelease
+++ b/Quicksilver/Tools/qsrelease
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 set -euf
+set -x
 
 cleanup() {
   rm -f "${SETTINGS}"

--- a/Quicksilver/Tools/qsrelease
+++ b/Quicksilver/Tools/qsrelease
@@ -23,7 +23,7 @@ fi
 ## Cache settings to save time
 SETTINGS=/tmp/qs_build_settings
 xcodebuild \
-  -destination "platform=macOS,arch=${CURRENT_ARCH}" \
+  -destination generic/platform=macos \
   -configuration Release \
   -scheme 'Quicksilver Distribution' \
   -showBuildSettings |
@@ -47,20 +47,18 @@ DMG_TEMP=${BUILT_PRODUCTS_DIR}/dmg
 {
   # xcodebuild -configuration Debug -scheme 'Quicksilver' test > $LOG
   xcodebuild \
-    -destination "platform=macOS,arch=x86_64" \
-    -destination "platform=macOS,arch=arm64" \
+    -destination "platform=macOS,arch=${CURRENT_ARCH}" \
     -scheme 'Quicksilver Distribution' \
     test || true
 
   # TODO: https://github.com/quicksilver/Quicksilver/issues/2583
   xcodebuild \
-    -destination "platform=macOS,arch=${CURRENT_ARCH}" \
+    -destination generic/platform=macos \
     -configuration Release \
     -scheme 'Quicksilver Distribution' \
     clean || true
   xcodebuild \
-    -destination 'platform=macOS,arch=x86_64' \
-    -destination 'platform=macOS,arch=arm64' \
+    -destination generic/platform=macos \
     -configuration Release \
     -scheme 'Quicksilver Distribution' \
     build


### PR DESCRIPTION
- If errors are acceptable, explicity ignore them.
- Move cleanup to a trap instead of a long conditional
- Add and remove quoting where it can / can't make a difference
- Break long lines for readability
- Enable users to pass in a custom signing identity for local testing
