### PR TITLE
Replace git:// URLs with https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,10 +3,10 @@
 	url = https://github.com/quicksilver/VDKQueue.git
 [submodule "Quicksilver/Code-External/DisableSubviews"]
 	path = Quicksilver/Code-External/DisableSubviews
-	url = git://github.com/ardalahmet/DisableSubviews.git
+	url = https://github.com/ardalahmet/DisableSubviews.git
 [submodule "Quicksilver/Code-External/LaunchAtLoginController"]
 	path = Quicksilver/Code-External/LaunchAtLoginController
 	url = https://github.com/quicksilver/LaunchAtLoginController.git
 [submodule "Quicksilver/Code-External/FMDB"]
 	path = Quicksilver/Code-External/FMDB
-	url = git://github.com/ccgus/fmdb.git
+	url = https://github.com/ccgus/fmdb.git


### PR DESCRIPTION
GitHub is removing the unencrypted Git protocol, see https://github.blog/2021-09-01-improving-git-protocol-security-github/.