### PR TITLE
Send task notifs from the main thread only

### DIFF
--- a/Quicksilver/Code-App/QSUpdateController.m
+++ b/Quicksilver/Code-App/QSUpdateController.m
@@ -232,14 +232,16 @@ typedef enum {
 
 				if (!userInitiated) return;
 
-				NSAlert *alert = [[NSAlert alloc] init];
+				QSGCDMainSync(^{
+					NSAlert *alert = [[NSAlert alloc] init];
 
-				alert.alertStyle = NSInformationalAlertStyle;
-				alert.messageText = NSLocalizedString(@"You're up-to-date!", @"QSUpdateController - no update alert title"),
-				alert.informativeText = [NSString stringWithFormat:NSLocalizedString(@"You already have the latest version of Quicksilver (%@) and all installed plugins", @"no update alert message"), [[NSBundle mainBundle] objectForInfoDictionaryKey:(NSString *)kCFBundleVersionKey]];
-				[alert addButtonWithTitle:NSLocalizedString(@"OK", @"no update alert default button")];
+					alert.alertStyle = NSAlertStyleInformational;
+					alert.messageText = NSLocalizedString(@"You're up-to-date!", @"QSUpdateController - no update alert title"),
+					alert.informativeText = [NSString stringWithFormat:NSLocalizedString(@"You already have the latest version of Quicksilver (%@) and all installed plugins", @"no update alert message"), [[NSBundle mainBundle] objectForInfoDictionaryKey:(NSString *)kCFBundleVersionKey]];
+					[alert addButtonWithTitle:NSLocalizedString(@"OK", @"no update alert default button")];
 
-				[[QSAlertManager defaultManager] beginAlert:alert onWindow:nil completionHandler:nil];
+					[[QSAlertManager defaultManager] beginAlert:alert onWindow:nil completionHandler:nil];
+				});
 			}
 			return;
 		}

--- a/Quicksilver/PlugIns-Main/PrimerInterface/QSPrimerInterfaceController.m
+++ b/Quicksilver/PlugIns-Main/PrimerInterface/QSPrimerInterfaceController.m
@@ -16,7 +16,7 @@
 - (void)windowDidLoad {
 	[super windowDidLoad];
 	// logRect([[self window] frame]);
-	[[self window] addInternalWidgetsForStyleMask:NSUtilityWindowMask closeOnly:YES];
+	[[self window] addInternalWidgetsForStyleMask:NSWindowStyleMaskUtilityWindow closeOnly:YES];
 	[[self window] setLevel:NSPopUpMenuWindowLevel];
 	[[self window] setFrameAutosaveName:@"PrimerInterfaceWindow"];
     


### PR DESCRIPTION
Fixes warnings from Xcode of calling UI APIs on a background thread. Fixes #2579

Simple, just make sure that notifications about tasks are sent from the main thread, that way any view-stuff will also only be done from the main thread. 