### PR TITLE
Allow 'run an applescript' to run on scptd files

### DIFF
--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/QSCorePlugIn-Info.plist
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/QSCorePlugIn-Info.plist
@@ -219,6 +219,7 @@
 				<string>'osas'</string>
 				<string>scpt</string>
 				<string>applescript</string>
+				<string>scptd</string>
 			</array>
 			<key>directTypes</key>
 			<array>


### PR DESCRIPTION
Fixes #1268

One liner, easy fix.