### PR TITLE
Fix for #460

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSObject_FileHandling.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject_FileHandling.m
@@ -563,7 +563,7 @@ NSArray *QSGetRecentDocumentsForBundle(NSString *bundleIdentifier) {
         NSString *bundleIdentifier = [[NSBundle bundleWithPath:path] bundleIdentifier];
 
         //NSLog(@"actions %d", [actions count]);
-        NSDictionary *appActions = [[QSReg tableNamed:@"QSApplicationActions"] objectForKey:bundleIdentifier];
+        NSDictionary *appActions = [[QSReg tableNamed:QSApplicationActions] objectForKey:bundleIdentifier];
         if([appActions count]) {
             for(NSString *actionID in appActions) {
 				NSDictionary *actionDict = [appActions objectForKey:actionID];

--- a/Quicksilver/Code-QuickStepCore/QSRegistry.h
+++ b/Quicksilver/Code-QuickStepCore/QSRegistry.h
@@ -2,6 +2,7 @@
 
 #define QSPlugInLoadedNotification    @"QSPlugInLoaded"
 #define QSPlugInInstalledNotification @"QSPlugInInstalled"
+#define QSApplicationActions 		  @"QSApplicationActions"
 
 #define kQSActionProviders     @"QSActionProviders"
 #define kQSFSParsers           @"QSFSParsers"

--- a/Quicksilver/Code-QuickStepCore/QSRegistry.m
+++ b/Quicksilver/Code-QuickStepCore/QSRegistry.m
@@ -279,7 +279,20 @@ QSRegistry* QSReg = nil;
             }];
             providers = [providersMut copy];
         }
-        [[self tableNamed:table] addEntriesFromDictionary:providers];
+		NSMutableDictionary *regDict = [self tableNamed:table];
+		if ([table isEqualToString:QSApplicationActions]) {
+			// for application actions types, add each action individually to each app bundle id. See #460
+			[providers enumerateKeysAndObjectsUsingBlock:^(NSString *bundleID, NSDictionary *appActions, BOOL * _Nonnull stop) {
+				NSMutableDictionary *appActionsTable = [regDict objectForKey:bundleID];
+				if (!appActionsTable) {
+					appActionsTable = [NSMutableDictionary dictionaryWithCapacity:1];
+					[regDict setObject:appActionsTable forKey:bundleID];
+				}
+				[appActionsTable addEntriesFromDictionary:appActions];
+			}];
+		} else {
+			[regDict addEntriesFromDictionary:providers];
+		}
 		NSMutableDictionary *retainedInstances = [tableInstances objectForKey:table];
 		for(NSString *provider in providers) {
 			id entry = [providers objectForKey:provider];


### PR DESCRIPTION
Another very simple one. Add new actions to the existing dict, instead of replacing the dict entirely.

Right now, the last plugin to load QSApplicationActions for a certain app's bundle ID would chomp and overwrite any existing dictionary that was already loaded.

This change makes a Mutable dict for QSApplicationActions, and adds any new actions to the existing list, instead of blindly over-writing

Fixes #460