### PR TITLE
Remove QSBackgroundView

### DIFF
--- a/Quicksilver/Code-QuickStepInterface/QSBackgroundView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSBackgroundView.m
@@ -44,14 +44,8 @@
 		[cornerEraser appendBezierPathWithRoundedRectangle:[self frame] withRadius:4];
 		[cornerEraser addClip];
 	}
-	NSRect topRect, bottomRect;
-	NSDivideRect(fullRect, &topRect, &bottomRect, NSHeight(fullRect) /2, NSMaxYEdge);
 	[backgroundColor set];
 	NSRectFill(fullRect);
-	NSColor *highlightColor = [backgroundColor colorWithLighting:0.5*depth plasticity:0.667*depth];
-	NSColor *shadowColor = [backgroundColor colorWithLighting:-0.1*depth];
-	QSFillRectWithGradientFromEdge(topRect, highlightColor, backgroundColor, NSMaxYEdge);
-	QSFillRectWithGradientFromEdge(bottomRect, shadowColor, backgroundColor, NSMinYEdge);
 	[super drawRect:rect];
 }
 

--- a/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
@@ -794,7 +794,7 @@ NSMutableDictionary *bindingsDict = nil;
 - (void)performSearch:(NSTimer *)timer {
 	//NSLog(@"perform search, %d", self);
 	if (validSearch) {
-		[resultController.searchStringField setTextColor:[NSColor blackColor]];
+		[resultController.searchStringField setTextColor:[[NSUserDefaults standardUserDefaults] colorForKey:@"QSAppearance2T"]];
 		[resultController.searchStringField display];
 		[self performSearchFor:partialString from:timer];
 		[resultController.searchStringField display];
@@ -907,7 +907,8 @@ NSMutableDictionary *bindingsDict = nil;
 	}
 	
 	if (validSearch) {
-		[resultController.searchStringField setTextColor:[NSColor blueColor]];
+		NSColor *color = [[NSUserDefaults standardUserDefaults] colorForKey:@"QSAppearance2T"];
+		[resultController.searchStringField setTextColor:color];
 	}
     
 	[self setVisibleString:[partialString uppercaseString]];
@@ -1481,7 +1482,7 @@ NSMutableDictionary *bindingsDict = nil;
 		[self partialStringChanged];
 		if (validMnemonic) {
 			// some objects found, change the colour of the results string
-			[resultController.searchStringField setTextColor:[NSColor blackColor]];
+			[resultController.searchStringField setTextColor:[[NSUserDefaults standardUserDefaults] colorForKey:@"QSAppearance2T"]];
 		}
 	}
     if ([self matchedString] == nil && ![[[self window] currentEvent] isARepeat]) {

--- a/Quicksilver/Nibs/ResultWindow.xib
+++ b/Quicksilver/Nibs/ResultWindow.xib
@@ -55,6 +55,13 @@
                             <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
+                        <connections>
+                            <binding destination="195" name="textColor" keyPath="values.QSAppearance2T" id="vxc-hs-xPk">
+                                <dictionary key="options">
+                                    <string key="NSValueTransformerName">NSUnarchiveFromData</string>
+                                </dictionary>
+                            </binding>
+                        </connections>
                     </textField>
                     <splitView fixedFrame="YES" vertical="YES" translatesAutoresizingMaskIntoConstraints="NO" id="71">
                         <rect key="frame" x="-1" y="14" width="324" height="169"/>
@@ -190,6 +197,13 @@
                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
+                        <connections>
+                            <binding destination="195" name="textColor" keyPath="values.QSAppearance2T" id="0aR-kQ-07J">
+                                <dictionary key="options">
+                                    <string key="NSValueTransformerName">NSUnarchiveFromData</string>
+                                </dictionary>
+                            </binding>
+                        </connections>
                     </textField>
                     <textField toolTip="Search string" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="307">
                         <rect key="frame" x="225" y="183" width="72" height="13"/>
@@ -199,6 +213,13 @@
                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
+                        <connections>
+                            <binding destination="195" name="textColor" keyPath="values.QSAppearance2T" id="yii-Oc-yvq">
+                                <dictionary key="options">
+                                    <string key="NSValueTransformerName">NSUnarchiveFromData</string>
+                                </dictionary>
+                            </binding>
+                        </connections>
                     </textField>
                     <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="248" customClass="QSMenuButton">
                         <rect key="frame" x="297" y="180" width="25" height="20"/>


### PR DESCRIPTION
In the same light as removing QSGlossyBar, this removes QSBackground view, and its custom 'fancy' drawing.

**Edit:** removing the view was a bit premature, it is actually used by a couple of plugins. Instead, I just removed the code draws the gradient backgrounds.

It makes the Results Window more 'flat' and hopefully more 'modern':
![Screenshot 2022-02-13 at 21 45 51](https://user-images.githubusercontent.com/150431/153756051-6d95ef21-40ce-45f0-b0bd-c50e3e3fd6c4.png)

I also properly bound the results view header/footer text colour to the appearance prefs, fixing #1235

I'm a little bit more confident that these changes may help with the Catalina/Big Sur colour problems. Less archaic code is good, right?! :D