### PR TITLE
Fix PYTHONPATH issues with markdown instructions

### DIFF
--- a/Quicksilver/Tools/bltrversion
+++ b/Quicksilver/Tools/bltrversion
@@ -11,6 +11,7 @@ os.environ['MACOSX-DEPLOYMENT-TARGET'] = '.'.join(
     platform.mac_ver()[0].split('.')[0:2]
 )
 import markdown
+from markdown.extensions.extra import extensions as extra_extensions
 
 info_plist = Path(os.environ['INFOPLIST_FILE'])
 
@@ -44,7 +45,10 @@ srcroot = os.getenv('SRCROOT')
 if srcroot is not None and os.path.exists(srcroot + '/Documentation.mdown'):
     docfile = srcroot + '/Documentation.mdown'
     doctext = codecs.open(docfile, mode='r', encoding='utf8').read()
-    md = markdown.Markdown(extensions=['extra'], output_format='html')
+    md = markdown.Markdown(
+        extensions=[f"markdown.extensions.{ext}" for ext in extra_extensions],
+        output_format='html',
+    )
     extended_description = md.convert(doctext)
     info['QSPlugIn']['extendedDescription'] = extended_description
 


### PR DESCRIPTION
[See](See) also: https://github.com/Python-Markdown/markdown/issues/884

Python can't find the extensions when vendored like this; this change
seems to resolve the issue.

Additionally, it looks like the `extra` package may be deprecated.
