### PR TITLE
Watch all directories down to the 'depth' level

### DIFF
--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Code/QSFileSystemObjectSource.h
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Code/QSFileSystemObjectSource.h
@@ -23,7 +23,6 @@
 - (IBAction)chooseFile:(id)sender;
 - (BOOL)chooseFile;
 
-- (NSString *)fullPathForSettings:(NSDictionary *)settings;
 - (IBAction)endContainingSheet:(id)sender;
 
 @end
@@ -34,4 +33,5 @@
 -(void)enableWatching;
 -(void)disableWatching;
 @property (readonly) NSString *fullWatchPath;
+@property (readonly) NSArray *fullWatchPaths;
 @end


### PR DESCRIPTION
Previously, if you have a Catalog entry with depth of 3, the file/folder watching would only work on the 'top' folder level and lower level folders wouldn't be watched. This change makes QS watch folders down to the 'depth' specified in the catalog entry's settings. Fixes #2509


https://user-images.githubusercontent.com/150431/154812514-19b8347a-aa11-4cca-866c-98587d2b1894.mov


Caveat: if you're to create a new sub-folder while QS is running, it won't add that to the watch list. QS will either need to be re-started, or the catalog entry toggled on/off. But I think that's a fairly small edge case.