### PR TITLE
Fix 'Get Current Selection' service menu

### DIFF
--- a/Quicksilver/PropertyLists/Quicksilver-Info.plist
+++ b/Quicksilver/PropertyLists/Quicksilver-Info.plist
@@ -207,7 +207,7 @@
 			<key>NSMenuItem</key>
 			<dict>
 				<key>default</key>
-				<string>Get Current Selection (Do Not Change Shortcut)</string>
+				<string>Send to Quicksilver</string>
 			</dict>
 			<key>NSMessage</key>
 			<string>getSelection</string>

--- a/Quicksilver/PropertyLists/Quicksilver-Info.plist
+++ b/Quicksilver/PropertyLists/Quicksilver-Info.plist
@@ -202,7 +202,7 @@
 			<key>NSKeyEquivalent</key>
 			<dict>
 				<key>default</key>
-				<string>\033</string>
+				<string>⎋</string>
 			</dict>
 			<key>NSMenuItem</key>
 			<dict>


### PR DESCRIPTION
This fixes the hotkey to ⌘⎋ and fixes #2646

I've also added another change here to rename the service to "Send to Quicksilver" as per #2119

I send to agree that 'get current selection' is not that descriptive. I also decided to remove the `(Do not change)` part:  it is ugly, and in the small edge case that users change it, they'll find that it breaks and likely just click the 'restore defaults' button in the menu any. 

Still, the fact you cannot change the hotkey, and how to fix it if you do (click 'Restore Defaults') should be documented in the manual.