### PR TITLE
Make donation links more prominent + add alert

### DIFF
--- a/Quicksilver/Code-App/QSController.h
+++ b/Quicksilver/Code-App/QSController.h
@@ -22,6 +22,7 @@
 + (id)sharedInstance;
 - (IBAction)runSetupAssistant:(id)sender;
 - (NSProgressIndicator *)progressIndicator;
+- (IBAction)openDonatePage:(id)sender;
 - (IBAction)showPreferences:(id)sender;
 - (IBAction)showGuide:(id)sender;
 - (IBAction)showPlugins:(id)sender;

--- a/Quicksilver/Code-App/QSController.h
+++ b/Quicksilver/Code-App/QSController.h
@@ -15,6 +15,7 @@
 	BOOL versionChanged, runningSetupAssistant;
 	NSObject *dropletProxy;
     NSString *crashReportPath;
+	QSApplicationLaunchStatusFlags launchStatus;
 }
 
 @property (strong) NSString* crashReportPath;

--- a/Quicksilver/Code-App/QSController.m
+++ b/Quicksilver/Code-App/QSController.m
@@ -88,7 +88,7 @@ static QSController *defaultController = nil;
 	if (defaultBool(@"verbose") )
 		setenv("verbose", "1", YES);
 #endif
-
+		
 	// Pre instantiate to avoid bug
 //	[NSColor controlShadowColor];
 	[NSColor setIgnoresAlpha:NO];
@@ -625,16 +625,16 @@ static QSController *defaultController = nil;
 - (void)checkForFirstRun {
 
 #ifdef DEBUG
-    QSApplicationLaunchStatusFlags status = QSApplicationNormalLaunch;
+	launchStatus = QSApplicationNormalLaunch;
 #else
-	QSApplicationLaunchStatusFlags status = [NSApp checkLaunchStatus];
+	launchStatus = [NSApp checkLaunchStatus];
 #endif
 
 	NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
 	NSString *bundlePath = [[NSBundle mainBundle] bundlePath];
 	NSString *lastVersionString = [defaults objectForKey:kLastUsedVersion];
 	NSUInteger lastVersion = [lastVersionString respondsToSelector:@selector(hexIntValue)] ? [lastVersionString hexIntValue] : 0;
-	switch (status) {
+	switch (launchStatus) {
 		case QSApplicationUpgradedLaunch: {
 /** Turn off "running from a new location" and "you are using a new version of QS" popups for DEBUG builds **/
 #ifndef DEBUG     
@@ -1092,7 +1092,9 @@ static QSController *defaultController = nil;
 
     // make sure we're visible on the first activation
     [NSApp unhideWithoutActivation];
-    
+	
+	[[QSDonationController sharedInstance] checkDonationStatus:launchStatus];
+	
 	[QSApp setCompletedLaunch:YES];
 }
 

--- a/Quicksilver/Code-App/QSController.m
+++ b/Quicksilver/Code-App/QSController.m
@@ -11,6 +11,7 @@
 #import "QSTaskViewer.h"
 #import "QSCrashReporterWindowController.h"
 #import "QSDownloads.h"
+#import "QSDonationController.h"
 
 
 #import "QSIntValueTransformer.h"
@@ -221,6 +222,10 @@ static QSController *defaultController = nil;
 	[aboutWindowController showWindow:self];
 }
 
+- (IBAction)openDonatePage:(id)sender {
+	[[QSDonationController sharedInstance] openDonationPage];
+}
+	 
 - (IBAction)showPreferences:(id)sender {
 	[NSApp activateIgnoringOtherApps:YES];
 	[[NSNotificationCenter defaultCenter] postNotificationName:@"WindowsShouldHide" object:self];

--- a/Quicksilver/Code-App/QSDonationController.h
+++ b/Quicksilver/Code-App/QSDonationController.h
@@ -6,6 +6,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "NSApplication_BLTRExtensions.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -13,6 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (QSDonationController * )sharedInstance;
 - (BOOL)openDonationPage;
+- (BOOL)checkDonationStatus:(QSApplicationLaunchStatusFlags)launchStatus;
 
 @end
 

--- a/Quicksilver/Code-App/QSDonationController.h
+++ b/Quicksilver/Code-App/QSDonationController.h
@@ -1,0 +1,19 @@
+//
+//  QSDonationController.h
+//  Quicksilver
+//
+//  Created by Patrick Robertson on 05/03/2022.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface QSDonationController : NSObject
+
++ (QSDonationController * )sharedInstance;
+- (BOOL)openDonationPage;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Quicksilver/Code-App/QSDonationController.m
+++ b/Quicksilver/Code-App/QSDonationController.m
@@ -8,6 +8,12 @@
 #import "QSDonationController.h"
 #import "QSPaths.h"
 
+#define kQSDonateReminderSuppressForever @"donate.reminder.suppress.forever"
+#define kQSDonateReminderSuppressUntilNextVersion @"donate.reminder.suppress.next"
+#define kQSDonateReminderLast @"donate.reminder.last"
+#define kQSDonateReminderInterval (60 * 60 * 24 * 7 ) // 1 week
+
+
 static QSDonationController *_controller;
 
 @implementation QSDonationController
@@ -22,6 +28,61 @@ static QSDonationController *_controller;
 
 - (BOOL)openDonationPage {
 	return [[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:kDonatePageURL]];
+}
+
+- (void)showDonationAlert:(BOOL)allowHideUntilNextVersion {
+	NSAlert *alert = [[NSAlert alloc] init];
+	alert.accessoryView = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, 400, 0)];
+	[alert setMessageText:NSLocalizedString(@"Thank you for using Quicksilver!", @"Donate")];
+	NSString *message = NSLocalizedString(@"Quicksilver is free-to-use, but it costs money to write and support. If you find Quicksilver useful, please consider donating. It will help to make Quicksilver even better!", @"Donate");
+	[alert setInformativeText:message];
+	[alert addButtonWithTitle:NSLocalizedString(@"Donate", @"Donate")];
+	[alert addButtonWithTitle:NSLocalizedString(@"Later", @"Donate")];
+	[alert setAlertStyle:NSAlertStyleInformational];
+	// don't show the suppress option on the first time.
+	[alert setShowsSuppressionButton:allowHideUntilNextVersion];
+	[[alert suppressionButton] setTitle:NSLocalizedString(@"Don't show again for this version", @"Donate")];
+	NSInteger result = [alert runModal];
+	if (result == NSAlertFirstButtonReturn) {
+		[self openDonationPage];
+	}
+	if (alert.showsSuppressionButton) {
+		[[NSUserDefaults standardUserDefaults] setBool:(alert.suppressionButton.state == NSControlStateValueOn) forKey:kQSDonateReminderSuppressUntilNextVersion];
+	}
+}
+
+// Returns Boolean YES if the donation alert was displayed otherwise NO
+- (BOOL)checkDonationStatus:(QSApplicationLaunchStatusFlags)launchStatus {
+	if (launchStatus == QSApplicationFirstLaunch || launchStatus == QSApplicationDowngradedLaunch) {
+		// don't show the donation alert if it's the first launch or a downgrade
+		return NO;
+	}
+	NSUserDefaults *u = [NSUserDefaults standardUserDefaults];
+	if ([u boolForKey:kQSDonateReminderSuppressForever]) {
+		// suppress the notification if it's set in the prefs – for devs, or evil doers ;-)
+		return NO;
+	}
+
+	// show alert if upgraded, or if time since last alert is greater than interval
+	BOOL showAlert = (launchStatus == QSApplicationUpgradedLaunch);
+	NSDate *lastReminderDate = [u objectForKey:kQSDonateReminderLast];
+	if (!showAlert) {
+		if ([u boolForKey:kQSDonateReminderSuppressUntilNextVersion]) {
+			// don't show if the user chose the "Don't show again for this version" option
+			showAlert = NO;
+		} else {
+			showAlert = (!lastReminderDate || (lastReminderDate.timeIntervalSinceNow*-1 > kQSDonateReminderInterval));
+		}
+	}
+	if (showAlert) {
+		// only show the "Don't show again for this version" option if it's not the first time they've seen this message.
+		BOOL allowHideUntilNextVersion = (lastReminderDate != nil);
+		[self showDonationAlert:allowHideUntilNextVersion];
+		[u setObject:[NSDate date] forKey:kQSDonateReminderLast];
+		return YES;
+	}
+	
+	return NO;
 }
 
 @end

--- a/Quicksilver/Code-App/QSDonationController.m
+++ b/Quicksilver/Code-App/QSDonationController.m
@@ -1,0 +1,27 @@
+//
+//  QSDonationController.m
+//  Quicksilver
+//
+//  Created by Patrick Robertson on 05/03/2022.
+//
+
+#import "QSDonationController.h"
+#import "QSPaths.h"
+
+static QSDonationController *_controller;
+
+@implementation QSDonationController
+
++ (QSDonationController * )sharedInstance {
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        _controller = [[[self class] allocWithZone:nil] init];
+    });
+    return _controller;
+}
+
+- (BOOL)openDonationPage {
+	return [[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:kDonatePageURL]];
+}
+
+@end

--- a/Quicksilver/Code-QuickStepCore/QSPaths.h
+++ b/Quicksilver/Code-QuickStepCore/QSPaths.h
@@ -23,6 +23,7 @@
 #define kForumsURL              @"http://groups.google.com/group/blacktree-quicksilver"
 #define kBugsURL                @"https://github.com/quicksilver/Quicksilver/issues"
 #define kWebSiteURL             @"https://qsapp.com/"
+#define kDonatePageURL			@"https://qsapp.com/donate.php"
 #define kChangelogURL           @"https://qsapp.com/changelog.php"
 #define kHelpURL                @"https://qsapp.com/manual/"
 #define kHelpSearchURL          @"https://qsapp.com/w/index.php?title=Special:Search&search=%@&go=Go"

--- a/Quicksilver/Nibs/MainMenu.xib
+++ b/Quicksilver/Nibs/MainMenu.xib
@@ -27,7 +27,7 @@
                             <menuItem title="Donate..." id="fWD-oC-mMX">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
-                                    <action selector="showGuide:" target="217" id="Bda-za-2Yv"/>
+                                    <action selector="openDonatePage:" target="217" id="sqe-dY-lFp"/>
                                 </connections>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="1881">
@@ -103,12 +103,6 @@
                             <menuItem title="Quit Quicksilver..." keyEquivalent="q" id="136">
                                 <connections>
                                     <action selector="unsureQuit:" target="217" id="1601"/>
-                                </connections>
-                            </menuItem>
-                            <menuItem title="Quit Quicksilver" alternate="YES" keyEquivalent="q" id="1599">
-                                <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
-                                <connections>
-                                    <action selector="terminate:" target="-2" id="1600"/>
                                 </connections>
                             </menuItem>
                         </items>
@@ -493,6 +487,12 @@ CA
                         <action selector="showAbout:" target="-1" id="1370"/>
                     </connections>
                 </menuItem>
+                <menuItem title="Donate..." id="iED-Wu-rsI">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <connections>
+                        <action selector="openDonatePage:" target="-1" id="5Ei-3p-3GA"/>
+                    </connections>
+                </menuItem>
                 <menuItem isSeparatorItem="YES" id="1358">
                     <modifierMask key="keyEquivalentModifierMask" command="YES"/>
                 </menuItem>
@@ -538,12 +538,6 @@ CA
                                     <action selector="showForums:" target="217" id="1912"/>
                                 </connections>
                             </menuItem>
-                            <menuItem title="Quicksilver IRC Channel..." id="1907">
-                                <modifierMask key="keyEquivalentModifierMask"/>
-                                <connections>
-                                    <action selector="openIRCChannel:" target="217" id="1913"/>
-                                </connections>
-                            </menuItem>
                             <menuItem isSeparatorItem="YES" id="1908">
                                 <modifierMask key="keyEquivalentModifierMask" command="YES"/>
                             </menuItem>
@@ -562,6 +556,7 @@ CA
                     </menu>
                 </menuItem>
             </items>
+            <point key="canvasLocation" x="-57" y="348"/>
         </menu>
         <customObject id="1493" userLabel="Font Manager" customClass="NSFontManager"/>
     </objects>

--- a/Quicksilver/Nibs/MainMenu.xib
+++ b/Quicksilver/Nibs/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="13196" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="15505" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="13196"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="15505"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="QSApp">
@@ -22,6 +22,12 @@
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
                                     <action selector="showAbout:" target="217" id="1334"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Donate..." id="fWD-oC-mMX">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="showGuide:" target="217" id="Bda-za-2Yv"/>
                                 </connections>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="1881">
@@ -454,12 +460,6 @@ CA
                                     <action selector="showForums:" target="217" id="1916"/>
                                 </connections>
                             </menuItem>
-                            <menuItem title="Quicksilver IRC Channel..." id="1595">
-                                <modifierMask key="keyEquivalentModifierMask"/>
-                                <connections>
-                                    <action selector="openIRCChannel:" target="217" id="1904"/>
-                                </connections>
-                            </menuItem>
                             <menuItem isSeparatorItem="YES" id="1896">
                                 <modifierMask key="keyEquivalentModifierMask" command="YES"/>
                             </menuItem>
@@ -478,6 +478,7 @@ CA
                     </menu>
                 </menuItem>
             </items>
+            <point key="canvasLocation" x="267" y="154"/>
         </menu>
         <customObject id="217" userLabel="Main Controller" customClass="QSController">
             <connections>

--- a/Quicksilver/Quicksilver.xcodeproj/project.pbxproj
+++ b/Quicksilver/Quicksilver.xcodeproj/project.pbxproj
@@ -332,6 +332,8 @@
 		92DC402D0E25A0C40091BD92 /* Action.png in Resources */ = {isa = PBXBuildFile; fileRef = 92DC402B0E25A0C40091BD92 /* Action.png */; };
 		92E946190D04CCEF0013377F /* QSModifierKeyEvents.h in Headers */ = {isa = PBXBuildFile; fileRef = 92E946170D04CCEF0013377F /* QSModifierKeyEvents.h */; };
 		92E9461A0D04CCEF0013377F /* QSModifierKeyEvents.m in Sources */ = {isa = PBXBuildFile; fileRef = 92E946180D04CCEF0013377F /* QSModifierKeyEvents.m */; };
+		CD13225427D301360005EDB1 /* QSDonationController.h in Headers */ = {isa = PBXBuildFile; fileRef = CD13225227D301360005EDB1 /* QSDonationController.h */; };
+		CD13225527D301360005EDB1 /* QSDonationController.m in Sources */ = {isa = PBXBuildFile; fileRef = CD13225327D301360005EDB1 /* QSDonationController.m */; };
 		CD14B79018D06604000FE86A /* QSThreadSafeMutableDictionary.h in Headers */ = {isa = PBXBuildFile; fileRef = CD14B78C18D065F5000FE86A /* QSThreadSafeMutableDictionary.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CD14B79118D06609000FE86A /* QSThreadSafeMutableDictionary.m in Sources */ = {isa = PBXBuildFile; fileRef = CD14B78D18D065F5000FE86A /* QSThreadSafeMutableDictionary.m */; };
 		CD1B17D9158A573000E4A030 /* VDKQueue.m in Sources */ = {isa = PBXBuildFile; fileRef = CDE1E661158A4D0900355A9F /* VDKQueue.m */; };
@@ -1488,6 +1490,8 @@
 		92E946180D04CCEF0013377F /* QSModifierKeyEvents.m */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.objc; path = QSModifierKeyEvents.m; sourceTree = "<group>"; usesTabs = 1; };
 		CD02BB4116A2BA5700DAFE50 /* QSGCD.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = QSGCD.h; sourceTree = "<group>"; usesTabs = 1; };
 		CD02BB4216A2BA5700DAFE50 /* QSGCD.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = QSGCD.m; sourceTree = "<group>"; usesTabs = 1; };
+		CD13225227D301360005EDB1 /* QSDonationController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = QSDonationController.h; sourceTree = "<group>"; };
+		CD13225327D301360005EDB1 /* QSDonationController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = QSDonationController.m; sourceTree = "<group>"; };
 		CD14B78C18D065F5000FE86A /* QSThreadSafeMutableDictionary.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = QSThreadSafeMutableDictionary.h; sourceTree = "<group>"; usesTabs = 1; };
 		CD14B78D18D065F5000FE86A /* QSThreadSafeMutableDictionary.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = QSThreadSafeMutableDictionary.m; sourceTree = "<group>"; usesTabs = 1; };
 		CD17323E1683995700295879 /* nb-NO */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "nb-NO"; path = "nb-NO.lproj/QSActionsPrefPane.strings"; sourceTree = "<group>"; };
@@ -3347,6 +3351,8 @@
 				E180021407B2BBB900010DB0 /* QSUpdateController.h */,
 				E180021507B2BBB900010DB0 /* QSUpdateController.m */,
 				4D00307513116304009040B7 /* Quicksilver.h */,
+				CD13225227D301360005EDB1 /* QSDonationController.h */,
+				CD13225327D301360005EDB1 /* QSDonationController.m */,
 			);
 			path = "Code-App";
 			sourceTree = "<group>";
@@ -3788,6 +3794,7 @@
 				E180025D07B2BBB900010DB0 /* QSTaskViewer.h in Headers */,
 				E180026707B2BBB900010DB0 /* QSTriggersPrefPane.h in Headers */,
 				E180026907B2BBB900010DB0 /* QSUpdateController.h in Headers */,
+				CD13225427D301360005EDB1 /* QSDonationController.h in Headers */,
 				7FF63FF407CC0DF500A5EE4A /* QSPreferencesController.h in Headers */,
 				7F60F12807FA134600922645 /* QSMainPreferencePanes.h in Headers */,
 				7F975A2607FC9C5E007FC20F /* QSDefaultsManager.h in Headers */,
@@ -4939,6 +4946,7 @@
 				E180026A07B2BBB900010DB0 /* QSUpdateController.m in Sources */,
 				E18002D307B2F0B800010DB0 /* main.m in Sources */,
 				7FF63FF507CC0DF500A5EE4A /* QSPreferencesController.m in Sources */,
+				CD13225527D301360005EDB1 /* QSDonationController.m in Sources */,
 				7F60F12907FA134600922645 /* QSMainPreferencePanes.m in Sources */,
 				7F975A2707FC9C5E007FC20F /* QSDefaultsManager.m in Sources */,
 				7F8C658408116FD10051113C /* QSAboutWindowController.m in Sources */,


### PR DESCRIPTION
1. Adds donation links to the main QS menu, and to the menu bar icon
2. Adds a donation alert, which opens on Quicksilver startup
 
The donation alert appears for any of the following:
* User upgraded Quicksilver
* User hasn't seen the alert for 1 week
    
The alert will be suppressed for the following:
* It's the first time the user's launched Quicksilver (we don't want to bother them if they're trying out Quicksilver for the first time)
* The user checked 'Do not show again for this version', and they haven't just upgraded
* For devs who've set a hidden pref (see here)


The only point worth making is that I guess a lot of users (like myself) only shut down their Macs every 2-3 weeks or months. That which means QS is only launched every 2-3 weeks or months, so the donation alert won't appear that often. I'm OK with that, and anyway - we give users the option to disable the alert anyway. The way to get the alert to appear more often is to make more releases of QS ;-)