### PR TITLE
Update QSFadingView

### DIFF
--- a/Quicksilver/Code-QuickStepEffects/QSFadingView.m
+++ b/Quicksilver/Code-QuickStepEffects/QSFadingView.m
@@ -24,24 +24,14 @@
 - (CGFloat)opacity { return opacity;  }
 - (void)setOpacity:(CGFloat)newOpacity {
 	if (opacity != newOpacity)
-		[self setNeedsDisplay:YES];
+		[NSAnimationContext runAnimationGroup:^(NSAnimationContext *context) {
+			context.duration = 0.1;
+			self.animator.alphaValue = newOpacity;
+		}
+		completionHandler:^{
+			
+		}];
 	opacity = newOpacity;
 }
-
-- (void)_recursiveDisplayAllDirtyWithLockFocus:(BOOL)lock visRect:(NSRect)rect {
-	if (opacity >= 1.0) {
-		[super _recursiveDisplayAllDirtyWithLockFocus:lock visRect:rect];
-	} else if(opacity) {
-		CGContextRef context = (CGContextRef) ([[NSGraphicsContext currentContext] graphicsPort]);
-		CGContextSaveGState(context);
-		CGContextSetAlpha(context, opacity);
-		CGContextBeginTransparencyLayer(context, 0);
-		[super _recursiveDisplayAllDirtyWithLockFocus:lock visRect:rect];
-		CGContextEndTransparencyLayer(context);
-		CGContextRestoreGState(context);
-	}
-}
-
-- (void)drawRect:(NSRect)rect {}
 
 @end

--- a/Quicksilver/PlugIns-Main/PrimerInterface/QSPrimerInterfaceController.m
+++ b/Quicksilver/PlugIns-Main/PrimerInterface/QSPrimerInterfaceController.m
@@ -97,6 +97,7 @@
 - (void)hideIndirectSelector:(id)sender {
 	//[super hideIndirectSelector:sender];
 
+	[(QSFadingView*)indirectView setOpacity:0.0];
 	[indirectView setHidden:YES];
 
 	[self adjustWindow:nil];
@@ -123,10 +124,12 @@
 	expandedRect.size.height += DIFF;
 	expandedRect.origin.y -= DIFF;
 	constrainRectToRect(expandedRect, [[[self window] screen] frame]);
-	if (!expanded)
+	if (!expanded) {
+		// expand iSelector then fade in
 		[[self window] setFrame:expandedRect display:YES animate:YES];
+		[(QSFadingView*)indirectView setOpacity:1.0];
+	}
 	[super expandWindow:sender];
-	[(QSFadingView*)indirectView setOpacity:1.0];
 }
 
 - (void)contractWindow:(id)sender {
@@ -135,10 +138,11 @@
 
 	contractedRect.size.height -= DIFF;
 	contractedRect.origin.y += DIFF;
-	//   NSLog(@"expnded? %d", expanded);
-	if (expanded)
+	if (expanded) {
+		// fade out iSelector then contract
+		[(QSFadingView *)indirectView setOpacity:0.0];
 		[[self window] setFrame:contractedRect display:YES animate:YES];
-
+	}
 	[super contractWindow:sender];
 }
 


### PR DESCRIPTION
Updates QSFadingView to drop using a hacky `_recursiveDisplayAllDirtyWithLockFocus` and use `NSAnimationContext` instead.

Also fixes #1215