### PR TITLE
Fix enabling/disabling of proxy objects in catalog

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSProxyObject.m
+++ b/Quicksilver/Code-QuickStepCore/QSProxyObject.m
@@ -105,7 +105,7 @@
     NSNumber *e = [[self proxyDict] objectForKey:@"enabled"];
     if (e)
         return [e boolValue];
-    return YES;
+    return [super enabled];
 }
 
 - (BOOL)hasChildren {return YES;}

--- a/Quicksilver/Code-QuickStepCore/QSProxyObjectSource.m
+++ b/Quicksilver/Code-QuickStepCore/QSProxyObjectSource.m
@@ -83,7 +83,7 @@
 			[proxyObject setObject:name forMeta:kQSObjectIconName];
 		[proxyObject setPrimaryType:QSProxyType];
 
-		if (proxyObject && [proxyObject enabled])
+		if (proxyObject)
 			[array addObject:proxyObject];
 	}
 	return array;


### PR DESCRIPTION
Fixes #1660

Pretty simple fix. `QSProxyObject` (a subclass of QSBasicObject) override the `enabled` method, and did not call through to `super`.
