### PR TITLE
Update plugin updater to use blocks and better background thread management

### DIFF
--- a/Quicksilver/Code-App/QSPlugInsPrefPane.m
+++ b/Quicksilver/Code-App/QSPlugInsPrefPane.m
@@ -52,28 +52,12 @@
 		[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(reloadPlugInsList:) name:QSPlugInInstalledNotification object:nil];
 		[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(reloadPlugInsList:) name:QSPlugInLoadedNotification object:nil];
 		[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(reloadPlugInsList:) name:QSPlugInInfoLoadedNotification object:nil];
-#if 0
-		[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(installStatusChanged:) name:@"QSUpdateControllerStatusChanged" object:nil];
-#endif
+
+		
 		[self reloadPlugInsList:nil];
 	}
 	return self;
 }
-
-#if 0
-- (void)installStatusChanged:(NSNotification *)notif {
-	//	float progress = [[QSUpdateController sharedInstance] downloadProgress];
-	//	[installProgress setDoubleValue:progress];
-	//	[installProgress displayIfNeeded];
-	//
-	//	if (progress == 1) {
-	//		//[installProgress setDoubleValue:progress];
-	//		[self setDownloadComplete:YES];
-	//		[installProgress setHidden:YES];
-	//		[installTextField setStringValue:@"Download Complete"];
-	//	}
-}
-#endif
 
 - (id)manager {
 	return [QSPlugInManager sharedInstance];
@@ -233,7 +217,7 @@
 
 - (IBAction)deleteSelection:(id)sender {
 	[[QSPlugInManager sharedInstance] deletePlugIns:[self selectedPlugIns] fromWindow:[plugInTable window]];
-    [[QSPlugInManager sharedInstance] downloadWebPlugInInfoIgnoringDate];
+	[[QSPlugInManager sharedInstance] downloadWebPlugInInfoIgnoringDate:nil];
 }
 
 - (IBAction)revealSelection:(id)sender { [[self selectedPlugIns] valueForKey:@"reveal"];  }
@@ -259,7 +243,7 @@
 	[pluginInfoPanel makeKeyAndOrderFront:sender];
 }
 
-- (IBAction)updatePlugIns:(id)sender { [[QSPlugInManager sharedInstance] checkForPlugInUpdates];  }
+- (IBAction)updatePlugIns:(id)sender { [[QSPlugInManager sharedInstance] checkForPlugInUpdates:nil];  }
 
 #if 0
 - (IBAction)showPlugInsRSS:(id)sender {
@@ -267,7 +251,7 @@
 }
 #endif
 
-- (IBAction)reloadPlugIns:(id)sender { [[QSPlugInManager sharedInstance] downloadWebPlugInInfoIgnoringDate];  }
+- (IBAction)reloadPlugIns:(id)sender { [[QSPlugInManager sharedInstance] downloadWebPlugInInfoIgnoringDate:nil];  }
 
 - (void)tableView:(NSTableView *)aTableView willDisplayCell:(NSTextFieldCell*)aCell forTableColumn:(NSTableColumn *)aTableColumn row:(NSInteger)rowIndex {
 	if ([[aTableColumn identifier] isEqualToString:@"enabled"]) {

--- a/Quicksilver/Code-App/QSSetupAssistant.m
+++ b/Quicksilver/Code-App/QSSetupAssistant.m
@@ -41,13 +41,17 @@
 	[continueButton setEnabled:NO];
 	[backButton setEnabled:NO];
 	plugInInfoStatus = 0;
-	[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(plugInInfoLoaded) name:QSPlugInInfoLoadedNotification object:nil];
-	[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(plugInInfoFailed) name:QSPlugInInfoFailedNotification object:nil];
-	[[self plugInManager] downloadWebPlugInInfoIgnoringDate];
+	[[self plugInManager] downloadWebPlugInInfo:^(BOOL success) {
+		if (success) {
+			[self plugInInfoLoaded];
+		} else {
+			[self plugInInfoFailed];
+		}
+	}];
 }
+
 - (void)plugInInfoLoaded {
 	plugInInfoStatus = 1;
-	[[self plugInManager] downloadWebPlugInInfoIgnoringDate];
 	NSArray *plugins = [[self plugInManager] knownPlugInsWithWebInfo];
 	plugins = [plugins filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"isInstalled == NO && isRecommended == YES"]];
 

--- a/Quicksilver/Code-QuickStepCore/QSPlugInManager.h
+++ b/Quicksilver/Code-QuickStepCore/QSPlugInManager.h
@@ -19,6 +19,10 @@ typedef enum {
     QSPluginUpdateStatusPluginsUpdated,
 } QSPluginUpdateStatus;
 
+typedef void(^QSPluginUpdateBlock)(BOOL success);
+typedef void(^QSPluginUpdatePromptBlock)(QSPluginUpdateStatus status);
+
+
 @class QSPlugIn;
 @interface QSPlugInManager : NSObject <QSURLDownloadDelegate> {
 	BOOL startupLoadComplete;
@@ -47,7 +51,6 @@ typedef enum {
 	CGFloat installProgress;
 	BOOL isInstalling;
 	BOOL supressRelaunchMessage;
-    NSInteger errorCount;
     NSTimeInterval lastCheck;
 }
 
@@ -62,7 +65,7 @@ typedef enum {
 - (BOOL)plugInIsMostRecent:(QSPlugIn *)plugIn inGroup:(NSDictionary *)loadingBundles;
 - (BOOL)plugInMeetsRequirements:(QSPlugIn *)plugIn;
 - (BOOL)plugInMeetsDependencies:(QSPlugIn *)plugIn;
-- (void)downloadWebPlugInInfoFromDate:(NSDate *)date forUpdateVersion:(NSString *)version synchronously:(BOOL)synchro;
+- (void)downloadWebPlugInInfoFromDate:(NSDate *)date forUpdateVersion:(NSString *)version completionHandler:(QSPluginUpdateBlock)block;
 - (NSMutableDictionary *)loadedPlugIns;
 - (NSMutableArray *)oldPlugIns;
 
@@ -87,9 +90,8 @@ typedef enum {
 //- (NSString *)installPlugInFromFile:(NSString *)path;
 - (BOOL)installPlugInsForIdentifiers:(NSArray *)bundleIDs;
 - (BOOL)installPlugInsForIdentifiers:(NSArray *)bundleIDs version:(NSString *)version;
-- (void)loadNewWebData:(NSData *)data;
-- (QSPluginUpdateStatus)checkForPlugInUpdates;
-- (QSPluginUpdateStatus)checkForPlugInUpdatesForVersion:(NSString *)version;
+- (void)checkForPlugInUpdates:(QSPluginUpdatePromptBlock)block;
+- (void)checkForPlugInUpdatesForVersion:(NSString *)version completionHandler:(QSPluginUpdatePromptBlock)block;
 
 - (NSMutableDictionary *)localPlugIns;
 - (void)setLocalPlugIns:(NSMutableDictionary *)newLocalPlugIns;
@@ -108,9 +110,9 @@ typedef enum {
 - (BOOL)supressRelaunchMessage;
 - (void)setSupressRelaunchMessage:(BOOL)flag;
 - (NSString *)installPlugInFromFile:(NSString *)path;
-- (void)downloadWebPlugInInfo;
-- (void)downloadWebPlugInInfoIgnoringDate;
-- (BOOL)updatePlugInsForNewVersion:(NSString *)version;
+- (void)downloadWebPlugInInfo:(QSPluginUpdateBlock)block;
+- (void)downloadWebPlugInInfoIgnoringDate:(QSPluginUpdateBlock)block;
+- (void)updatePlugInsForNewVersion:(NSString *)version completionHandler:(QSPluginUpdatePromptBlock)block;
 - (CGFloat)downloadProgress;
 - (NSMutableSet *)updatedPlugIns;
 - (BOOL)handleInstallURL:(NSURL *)url;


### PR DESCRIPTION
* Fixes a crash where some NSView updates were done on the background thread
* Removes a lot of the NSNotification calling
* Reduces/removes some obsolete code

The code changes look pretty big and scary, but ultimately all I did was:

Switched to using the new async `NSURLSession` instead of the synchronous `NSURLConnection` to make HTTP requests. This in turn meant that I had to pass `completionHandler` blocks around to know what to do once the request had completed.

The plugin code is really messy/complicated. I tried to tidy it up and remove calls to delegates etc. - blocks are much cleaner