### PR TITLE
Library validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
       working-directory: /tmp/QS/build/Release/
       run: |
         cp /tmp/qs_build_settings ./dmg/
+        cp /tmp/Quicksilver.entitlements ./dmg/
         tar -czvf ./dmg_ingredients.tar.gz ./dmg
     - name: Upload components for sign action
       uses: actions/upload-artifact@v2
@@ -56,7 +57,7 @@ jobs:
       run: |
         tar -xzvf ./dmg_ingredients.tar.gz
         mv ./dmg/qs_build_settings /tmp/
-
+        mv ./dmg/Quicksilver.entitlements /tmp/
         QS_INFO_VERSION=$(awk '/QS_INFO_VERSION/ { print $NF }' /tmp/qs_build_settings)
         echo "QS_INFO_VERSION=${QS_INFO_VERSION}" >> $GITHUB_ENV
     - uses: actions/checkout@v2

--- a/Quicksilver/Quicksilver.entitlements
+++ b/Quicksilver/Quicksilver.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
+</dict>
+</plist>

--- a/Quicksilver/Quicksilver.xcodeproj/project.pbxproj
+++ b/Quicksilver/Quicksilver.xcodeproj/project.pbxproj
@@ -1758,6 +1758,7 @@
 		CD4B1BBF17C259C000F2C5A7 /* th */ = {isa = PBXFileReference; lastKnownFileType = text.xml; name = th; path = th.lproj/QSParser.name.strings; sourceTree = "<group>"; };
 		CD4B1BC017C259C100F2C5A7 /* th */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = th; path = th.lproj/QSAction.commandFormat.strings; sourceTree = "<group>"; };
 		CD4B1BC117C25BC000F2C5A7 /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/About.strings"; sourceTree = "<group>"; };
+		CD4C8FBA27DD6DDE00F5FFE4 /* Quicksilver.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Quicksilver.entitlements; sourceTree = "<group>"; };
 		CD4FA6DF157A13D600E549BD /* QSHotKeyEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = QSHotKeyEvent.h; sourceTree = "<group>"; usesTabs = 1; };
 		CD4FA6E1157A13DE00E549BD /* QSHotKeyEvent.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = QSHotKeyEvent.m; sourceTree = "<group>"; usesTabs = 1; };
 		CD53FEB2151A0ACF006B734B /* PluginReporterText.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = PluginReporterText.html; sourceTree = "<group>"; };
@@ -2618,6 +2619,7 @@
 		29B97314FDCFA39411CA2CEA /* Quicksilver */ = {
 			isa = PBXGroup;
 			children = (
+				CD4C8FBA27DD6DDE00F5FFE4 /* Quicksilver.entitlements */,
 				7F0737A10927023A00782D10 /* CHANGELOG */,
 				4D8A0B3510AB23F7006AF163 /* Configuration */,
 				4DC3DD0B0E0BB27B009902EF /* Configuration */,
@@ -6502,6 +6504,7 @@
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD)";
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGN_ENTITLEMENTS = Quicksilver.entitlements;
 				INFOPLIST_FILE = "PropertyLists/Quicksilver-Info.plist";
 				PRODUCT_BUNDLE_IDENTIFIER = com.blacktree.Quicksilver;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -6515,6 +6518,8 @@
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD)";
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGN_ENTITLEMENTS = Quicksilver.entitlements;
+				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = "PropertyLists/Quicksilver-Info.plist";
 				PRODUCT_BUNDLE_IDENTIFIER = com.blacktree.Quicksilver;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Quicksilver/Tools/qsrelease
+++ b/Quicksilver/Tools/qsrelease
@@ -21,6 +21,9 @@ xcodebuild \
   -showBuildSettings |
   sort -u > "${SETTINGS}"
 
+# Copy library signing entitlements
+cp Quicksilver.entitlements /tmp/Quicksilver.entitlements
+
 SOURCE_ROOT=$(awk '$1 == "SOURCE_ROOT" { print $NF }' < "${SETTINGS}")
 BUILT_PRODUCTS_DIR=$(awk '$1 == "BUILT_PRODUCTS_DIR" { print $NF }' < "${SETTINGS}")
 

--- a/Quicksilver/Tools/qssign
+++ b/Quicksilver/Tools/qssign
@@ -23,8 +23,8 @@ SIGNING_IDENTITY=${SIGNING_IDENTITY:-"Developer ID Application"}
 cd "${DMG_TEMP}"
 
 # QSDroplet.app must be signed *first* (inside-out)
-codesign --force --deep --timestamp --options runtime --sign "${SIGNING_IDENTITY}" Quicksilver.app/Contents/Resources/QSDroplet.app
-codesign --force --deep --timestamp --options runtime --sign "${SIGNING_IDENTITY}" Quicksilver.app
+codesign --force --deep --timestamp --options runtime --sign "${SIGNING_IDENTITY}" --entitlements /tmp/Quicksilver.entitlements Quicksilver.app/Contents/Resources/QSDroplet.app
+codesign --force --deep --timestamp --options runtime --sign "${SIGNING_IDENTITY}" --entitlements /tmp/Quicksilver.entitlements Quicksilver.app
 codesign --verify --deep --strict --verbose=1 Quicksilver.app
 spctl --assess --verbose --type open --type exec Quicksilver.app
 


### PR DESCRIPTION
Turns out I was a bit premature in my last release. I set up the XCode proj to disable library validation, but of course we're signing using `codesign`. 

These changes should fix that.