### PR TITLE
Make QSTask main thread calls async

### DIFF
--- a/Quicksilver/Code-App/QSTaskViewer.m
+++ b/Quicksilver/Code-App/QSTaskViewer.m
@@ -150,27 +150,30 @@ static QSTaskViewer * _sharedInstance;
     QSTask *task = notif.object;
 //    NSLog(@"Adding task: %@", task);
 
+    QSGCDMainAsync(^{
     if (!self.taskControllers[task.identifier]) {
         self.taskControllers[task.identifier] = [QSTaskViewController controllerWithTask:task];
     }
 
-    QSGCDMainAsync(^{
         [self updateTaskView];
     });
 }
 
 - (void)removeTask:(NSNotification *)notif {
+	
     QSTask *task = notif.object;
 //    NSLog(@"Removing task: %@", task);
 
-    QSTaskViewController *removedController = self.taskControllers[task.identifier];
 
-    QSGCDMainDelayed(STOP_DELAY, ^{
-        [self.taskControllers removeObjectForKey:task.identifier];
-        [removedController.view removeFromSuperview];
-
-        [self updateTaskView];
-    });
+	// delay removing the task for 0.5s, so that the user can see
+	usleep(STOP_DELAY*1000000);
+	
+	QSGCDMainAsync(^{
+		QSTaskViewController *removedController = self.taskControllers[task.identifier];
+		[self.taskControllers removeObjectForKey:task.identifier];
+		[removedController.view removeFromSuperview];
+		[self updateTaskView];
+	});
 
 }
 

--- a/Quicksilver/Code-QuickStepCore/QSLibrarian.h
+++ b/Quicksilver/Code-QuickStepCore/QSLibrarian.h
@@ -18,6 +18,7 @@ extern QSLibrarian *QSLib; // Shared Instance
 @interface QSLibrarian : NSObject {
 	QSCatalogEntry *catalog; //Root Catalog Entry
 
+	dispatch_queue_t scanning_queue;
 	NSMutableDictionary *enabledPresetsDictionary;
 	NSMutableSet *defaultSearchSet;
 	NSMutableSet *omittedIDs;
@@ -39,7 +40,6 @@ extern QSLibrarian *QSLib; // Shared Instance
 	NSMutableDictionary *entriesByID;
 
 	NSMutableArray *invalidIndexes;
-	NSInteger scannerCount;
     
     @private
     BOOL catalogLoaded;

--- a/Quicksilver/Code-QuickStepCore/QSTask.m
+++ b/Quicksilver/Code-QuickStepCore/QSTask.m
@@ -93,6 +93,7 @@
 #endif
 
         self.running = NO;
+        [self setStatus:NSLocalizedString(@"Complete", @"Text that is displayed in the task viewer when a task has finished running")];
         [QSTasks taskStopped:self];
     }
 }

--- a/Quicksilver/Code-QuickStepCore/QSTaskController.m
+++ b/Quicksilver/Code-QuickStepCore/QSTaskController.m
@@ -47,7 +47,7 @@ QSTaskController *QSTasks;
 - (void)taskStarted:(QSTask *)task {
     NSAssert(task != nil, @"Task shouldn't be nil");
 
-	QSGCDMainSync(^{
+	QSGCDMainAsync(^{
         self.tasksDictionary[task.identifier] = task;
 
         if (self.tasksDictionary.count == 1) {
@@ -60,7 +60,7 @@ QSTaskController *QSTasks;
 - (void)taskStopped:(QSTask *)task {
     NSAssert(task != nil, @"Task shouldn't be nil");
 	
-	QSGCDMainSync(^{
+	QSGCDMainAsync(^{
 		[[NSNotificationCenter defaultCenter] postNotificationName:QSTaskRemovedNotification object:task];
 		
 		if (self.tasksDictionary.count == 1) {
@@ -73,7 +73,7 @@ QSTaskController *QSTasks;
 
 - (void)updateTask:(NSString *)identifier status:(NSString *)status progress:(CGFloat)progress {
 	NSAssert(identifier != nil, @"Task identifier shouldn't be nil");
-	QSGCDMainSync(^{
+	QSGCDMainAsync(^{
 		
 		QSTask *task = [QSTask taskWithIdentifier:identifier];
 		

--- a/Quicksilver/Code-QuickStepCore/QSTaskController.m
+++ b/Quicksilver/Code-QuickStepCore/QSTaskController.m
@@ -47,41 +47,35 @@ QSTaskController *QSTasks;
 - (void)taskStarted:(QSTask *)task {
     NSAssert(task != nil, @"Task shouldn't be nil");
 
-	QSGCDMainAsync(^{
-        self.tasksDictionary[task.identifier] = task;
-
-        if (self.tasksDictionary.count == 1) {
-            [[NSNotificationCenter defaultCenter] postNotificationName:QSTasksStartedNotification object:task];
-        }
-        [[NSNotificationCenter defaultCenter] postNotificationName:QSTaskAddedNotification object:task];
-	});
+	self.tasksDictionary[task.identifier] = task;
+	
+	if (self.tasksDictionary.count == 1) {
+		[[NSNotificationCenter defaultCenter] postNotificationName:QSTasksStartedNotification object:task];
+	}
+	[[NSNotificationCenter defaultCenter] postNotificationName:QSTaskAddedNotification object:task];
 }
 
 - (void)taskStopped:(QSTask *)task {
     NSAssert(task != nil, @"Task shouldn't be nil");
 	
-	QSGCDMainAsync(^{
-		[[NSNotificationCenter defaultCenter] postNotificationName:QSTaskRemovedNotification object:task];
-		
-		if (self.tasksDictionary.count == 1) {
-			[[NSNotificationCenter defaultCenter] postNotificationName:QSTasksEndedNotification object:task];
-		}
-		
-		[self.tasksDictionary removeObjectForKey:task.identifier];
-	});
+	[[NSNotificationCenter defaultCenter] postNotificationName:QSTaskRemovedNotification object:task];
+	
+	if (self.tasksDictionary.count == 1) {
+		[[NSNotificationCenter defaultCenter] postNotificationName:QSTasksEndedNotification object:task];
+	}
+	
+	[self.tasksDictionary removeObjectForKey:task.identifier];
 }
 
 - (void)updateTask:(NSString *)identifier status:(NSString *)status progress:(CGFloat)progress {
 	NSAssert(identifier != nil, @"Task identifier shouldn't be nil");
-	QSGCDMainAsync(^{
-		
-		QSTask *task = [QSTask taskWithIdentifier:identifier];
-		
-		task.status = status;
-		task.progress = progress;
-		
-		[[NSNotificationCenter defaultCenter] postNotificationName:QSTaskChangedNotification object:task];
-	});
+	
+	QSTask *task = [QSTask taskWithIdentifier:identifier];
+	
+	task.status = status;
+	task.progress = progress;
+	
+	[[NSNotificationCenter defaultCenter] postNotificationName:QSTaskChangedNotification object:task];
 }
 
 - (void)removeTask:(NSString *)identifier {


### PR DESCRIPTION
Fixes #2661

This is a simpler fix than I thought (I hope...)

It turns out we're already running scans on a background thread. See `QSCatalogEntry.m` at `- (NSArray *)scanAndCache;`

A further look at the spindumps in #2681 showed that the specific problem is with QSTask, and locking on showing/hiding tasks:

Main Thread:

```
                                                                    1000  __CFNOTIFICATIONCENTER_IS_CALLING_OUT_TO_AN_OBSERVER__ + 12 (CoreFoundation + 479292) [0x7ff81a95203c]
                                                                      1000  -[QSLibrarian reloadSource:] + 562 (QSCore + 92849) [0x106e8eab1]
                                                                        1000  -[QSTask stop] + 24 (QSCore + 314328) [0x106ec4bd8]
                                                                          1000  objc_sync_enter + 27 (libobjc.A.dylib + 74862) [0x7ff81a73146e]
                                                                            1000  __ulock_wait + 10 (libsystem_kernel.dylib + 12522)
```

2nd thread:
```
              1000  __42-[QSLibrarian scanCatalogIgnoringIndexes:]_block_invoke + 649 (QSCore + 105232) [0x106e91b10]
                1000  -[QSTask stop] + 85 (QSCore + 314389) [0x106ec4c15]
                  1000  -[QSTaskController taskStopped:] + 149 (QSCore + 316325) [0x106ec53a5]
                    1000  _dispatch_sync_f_slow + 170 (libdispatch.dylib + 67222) [0x7ff81a6e8696]
                      1000  __DISPATCH_WAIT_FOR_QUEUE__ + 296 (libdispatch.dylib + 68172) [0x7ff81a6e8a4c]
                        1000  _dispatch_thread_event_wait_slow + 40 (libdispatch.dylib + 14741) [0x7ff81a6db995]
                          1000  __ulock_wait + 10 (libsystem_kernel.dylib + 12522) [0x7ff81a85b0ea]
```

QSTask was posting notifications to the main thread **synchronously** which is what was causing the locking. This PR changes them to be called async, so the scan can finish.

Still, I think the point of making `reloadSource:` run on a background thread (and not the main thread) serially makes a lot of sense as well. If two things invalidate a catalog item within 1ms of each other, then it's better to have then scan one after the other, to pick up any more changes.

I'll implement this 2nd point if @skurfer  - you think it still makes sense after seeing the above fix.