### PR TITLE
Fix for #2533

### DIFF
--- a/Quicksilver/Code-App/QSModifierKeyEvents.h
+++ b/Quicksilver/Code-App/QSModifierKeyEvents.h
@@ -21,9 +21,8 @@ extern NSUInteger lastModifiers;
 	SEL action;
 
 	@private
-    NSTimeInterval timeSinceLastKeyDown;
-    NSDate *firstModifierPressedTime;
-    
+    uint32_t pressedKeyDownCount;
+
 }
 
 @property __block NSInteger timesKeysPressed;

--- a/Quicksilver/Code-App/QSModifierKeyEvents.m
+++ b/Quicksilver/Code-App/QSModifierKeyEvents.m
@@ -156,19 +156,15 @@ BOOL modifierEventsEnabled = YES;
             // keyUp events aren't sent for the caps lock key, so we have to check it here and manually increase the key pressed count
             self.timesKeysPressed += 1;
         }
-        NSTimeInterval timeDiff = [firstModifierPressedTime timeIntervalSinceNow];
-        NSTimeInterval newTimeSinceLastKeyDown = CGEventSourceSecondsSinceLastEventType (
+        uint32_t newPressedKeyDownCount = CGEventSourceCounterForEventType (
                                                                  kCGEventSourceStateHIDSystemState,
                                                                  kCGEventKeyDown
                                                                  );
-        
-        NSTimeInterval keyPressDif = timeSinceLastKeyDown - newTimeSinceLastKeyDown;
-        if (fabs(timeDiff - keyPressDif) < 0.001 && self.timesKeysPressed == self.modifierActivationCount) {
+        if (newPressedKeyDownCount == pressedKeyDownCount && self.timesKeysPressed == self.modifierActivationCount) {
             [self sendAction];
         }
     } else {
-        firstModifierPressedTime = [NSDate date];
-        timeSinceLastKeyDown = CGEventSourceSecondsSinceLastEventType (
+        pressedKeyDownCount = CGEventSourceCounterForEventType(
                                                                kCGEventSourceStateHIDSystemState,
                                                                kCGEventKeyDown
                                                                );


### PR DESCRIPTION
Replaced CGEventSourceSecondsSinceLastEventType by CGEventSourceCounterForEventType since the first seems to consider Fn up shortly after Fn down as key down event on BigSur.

Fixes #2533.