### PR TITLE
Copy over data dict when iterating

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSLibrarian.m
+++ b/Quicksilver/Code-QuickStepCore/QSLibrarian.m
@@ -513,7 +513,8 @@ static CGFloat searchSpeed = 0.0;
 	NSMutableDictionary *dict = [NSMutableDictionary dictionaryWithCapacity:1];
 	NSMutableArray *typeEntry;
 	for(QSObject *object in array) {
-		for (NSString *key in [[object dataDictionary] allKeys]) {
+		NSDictionary *data = [[object dataDictionary] copy];
+		for (NSString *key in [data allKeys]) {
 			if ([key hasPrefix:@"QSObject"]) continue;
 			typeEntry = [dict objectForKey:key];
 			if (!typeEntry) {


### PR DESCRIPTION
Fixes #2718

Very simple. Copy the dict before iterating over it to avoid any mutations during iteration.
