### PR TITLE
QSDownloads: support Safari download folders containing spaces.

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSDownloads.m
+++ b/Quicksilver/Code-QuickStepCore/QSDownloads.m
@@ -45,7 +45,7 @@
     
     if (downloads) {
 		downloads = [downloads stringByResolvingSymlinksInPath];
-		return [NSURL URLWithString:downloads];
+		return [NSURL URLWithString:[downloads stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLHostAllowedCharacterSet]]];
     } else {
 		// fall back to the default downloads folder if the user settings couldn't be resolved
 		NSArray *downloadURLs = [manager URLsForDirectory:NSDownloadsDirectory inDomains:NSUserDomainMask];


### PR DESCRIPTION
`[NSURL URLWithString:downloads]` fails when `downloads` contains spaces. Apparently the solution is to percent-encode the string.