### PR TITLE
Change the main branch reference in the main `README` to `main`.

### DIFF
--- a/Quicksilver/Tools/travis/check_indent.rb
+++ b/Quicksilver/Tools/travis/check_indent.rb
@@ -3,7 +3,7 @@
 
 require 'set'
 
-commit_range = ENV['TRAVIS_COMMIT_RANGE'] || 'master'
+commit_range = ENV['TRAVIS_COMMIT_RANGE'] || 'main'
 
 puts "#{File.basename($0)}: commit range #{commit_range}"
 

--- a/README.markdown
+++ b/README.markdown
@@ -2,7 +2,7 @@
 
 This repository contains the current source code of Quicksilver. If you're having issues with the latest Quicksilver version, feel free to log them at the [issue tracker](https://github.com/quicksilver/Quicksilver/issues). 
 
-The `master` branch contains the source for the currently released Quicksilver.
+The `main` branch contains the source for the currently released Quicksilver.
 
 If you want more info about [Quicksilver](http://qsapp.com) you can read the [about page](http://qsapp.com/about.php) or view it on [Wikipedia](http://en.wikipedia.org/wiki/Quicksilver_%28software%29 "Quicksilver Wikipedia article"). For help and support, visit the [Quicksilver Support Group](http://groups.google.com/group/blacktree-quicksilver "Quicksilver Google Group"). Developers can find help in the [Developer Support Group](https://groups.google.com/forum/?hl=en_US&fromgroups#!forum/quicksilver---development)
 


### PR DESCRIPTION
There are a few other places that could be changed from `master` to
`main`, but they look mostly harmless to me.

The change to `check_indent.rb` may not actually be useful for anything:
https://github.com/quicksilver/Quicksilver/issues/2707#issuecomment-1094361203
But I've gone ahead and included it just in case.

Addresses https://github.com/quicksilver/Quicksilver/issues/2707