### PR TITLE
Give file objects a string value

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSObject_FileHandling.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject_FileHandling.m
@@ -698,6 +698,7 @@ NSArray *QSGetRecentDocumentsForBundle(NSString *bundleIdentifier) {
 		if ([paths count] == 1) {
 			NSString *path = [paths lastObject];
 			[[self dataDictionary] setObject:path forKey:QSFilePathType];
+			[[self dataDictionary] setObject:path forKey:NSPasteboardTypeString];
 			NSString *uti = [self fileUTI];
 			id handler = [QSReg instanceForKey:uti inTable:@"QSFileObjectCreationHandlers"];
 			if (handler) {
@@ -710,6 +711,7 @@ NSArray *QSGetRecentDocumentsForBundle(NSString *bundleIdentifier) {
 			}
 		} else {
 			[[self dataDictionary] setObject:paths forKey:QSFilePathType];
+			[[self dataDictionary] setObject:[paths componentsJoinedByString:@"\n"] forKey:NSPasteboardTypeString];
 		}
 		[self setIdentifier:thisIdentifier];
 		[self setPrimaryType:QSFilePathType];


### PR DESCRIPTION
Useful for when a string type is required e.g. when combining multiple objects (string + file)

Fixes #1673

-----

I'm opening a PR for this since I note that originally @skurfer had earmarked it to fix. The fix I implemented is essentially what I said in [this comment](https://github.com/quicksilver/Quicksilver/issues/1673#issuecomment-29866876). 

I'm not sure of the consequences of giving file objects a 'string type' from the start, so I think it's worth @skurfer running with this build for a while.

P.S If you can download a debug version from here without having to build yourself ;-)
https://github.com/quicksilver/Quicksilver/actions/runs/2483657221