### PR TITLE
keep debug version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,3 +133,4 @@ jobs:
             -o StrictHostKeyChecking=no \
             "${GITHUB_REPOSITORY}" \
             <Quicksilver/SharedSupport/ChangesBare.html
+          rm /tmp/key

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,11 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           path: /tmp/QS/build/Release/checksum.txt
+      - name: Download debug artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: Quicksilver-debug.zip
+          path: /tmp/Quicksilver-debug.zip
       - name: Release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
@@ -120,6 +125,7 @@ jobs:
           files: |
             /tmp/QS/build/Release/Quicksilver*.dmg
             /tmp/QS/build/Release/checksum.txt
+            /tmp/Quicksilver-debug.zip
       - name: Update ChangesBare.html
         if: startsWith(github.ref, 'refs/tags/')
         env:


### PR DESCRIPTION
- Remove the key when we're done with it... just in case.
- This should upload a debug artifact with each release, yet to be tested.
