### PR TITLE
Don't override names for running processes

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSProcessMonitor.m
+++ b/Quicksilver/Code-QuickStepCore/QSProcessMonitor.m
@@ -181,7 +181,6 @@ OSStatus appTerminated(EventHandlerCallRef nextHandler, EventRef theEvent, void 
             // the process isn't an app
             newObject = [QSObject fileObjectWithPath:[dict objectForKey:@"CFBundleExecutable"]];
         }
-		[newObject setLabel:[dict objectForKey:@"CFBundleName"]];
     }
 
 	[newObject setObject:dict forType:QSProcessType];


### PR DESCRIPTION
Fixes issue #2970

Note: This *re-introduces the bug fixed in #2917 - that bug is actually a Finder issue and not a QS issue

I thought I'd make a PR for this, so @skurfer @n8henrie can test. This should also fix #2975

Note that: this 'fix' re-introduces the bug fixed in #2917 - but upon further investigation, that is a Finder/macOS bug. The example used in the bug report was for Firefox. The example I found was for WeChat:
<img width="748" alt="Screenshot 2023-12-02 at 16 06 25" src="https://github.com/quicksilver/Quicksilver/assets/150431/49799d47-0bfd-427f-9f1a-17df5e82f1bc">


This .app bundle inside the main WeChat.app shows up as `WeChat` in Finder. However if you open the .app package and look at the Info.plist, the actual name should be `WeChatAppX` and the actual path in terminal is `WeChatAppX.app` not the supposed `WeChat.app` as shown in Finder:

<img width="299" alt="Screenshot 2023-12-02 at 16 06 21" src="https://github.com/quicksilver/Quicksilver/assets/150431/af0eea6f-a846-41cb-81e0-6e396261531b">

<img width="722" alt="Screenshot 2023-12-02 at 16 06 43" src="https://github.com/quicksilver/Quicksilver/assets/150431/99539ba3-5527-44af-8b78-54ccac707c82">


This is a problem with macOS itself, more specifically the `NSURLLocalizedNameKey` resource key on NSURL. I'm inclined to re-open #2917 but then mark it as "won't fix" because yeah, macOS is buggy.
