### PR TITLE
Force-disable superfluous effects on startup

### DIFF
--- a/Quicksilver/Code-App/QSApp.m
+++ b/Quicksilver/Code-App/QSApp.m
@@ -32,6 +32,13 @@ BOOL QSApplicationCompletedLaunch = NO;
 		setenv("QSDebugCatalog", "1", YES);
 	}
 #endif
+	// #TODO @n8henrie: Hopefully temporary workaround for Sonoma
+	// https://github.com/quicksilver/Quicksilver/issues/2962
+	if (@available(macOS 14, *)) {
+		NSLog(@"Force-disabling superfluous effects at startup");
+		[[NSUserDefaults standardUserDefaults] setBool:false forKey:kUseEffects];
+	}
+
 }
 
 + (void)initialize {


### PR DESCRIPTION
I think this is a reasonable move to automatically help people experiencing
show-stopper bugs on Sonoma.

The `Use Visual Effects` seems to even make first-time setup and installation
impossible on Sonoma in some cases; hopefully I put this early enough in
startup to catch these cases.
