### PR TITLE
Prepare QS to include Swift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-latest
     env:
       QS_DONT_SIGN: 1
     steps:
@@ -52,7 +52,7 @@ jobs:
 
   sign:
     needs: build
-    runs-on: macos-12
+    runs-on: macos-latest
     if: startsWith(github.ref, 'refs/tags/v')
     env:
       MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}

--- a/Quicksilver/Code-App/QSController.m
+++ b/Quicksilver/Code-App/QSController.m
@@ -49,8 +49,8 @@ static QSController *defaultController = nil;
 	if (![NSApplication isMavericks]) {
 		NSBundle *appBundle = [NSBundle mainBundle];
 
-		NSString *minimumVersionString = @"macOS 10.9+";
-		NSString *oldVersionsString = @"10.3–10.8";
+		NSString *minimumVersionString = @"macOS 10.14+";
+		NSString *oldVersionsString = @"10.14";
 
 		NSAlert *alert = [[NSAlert alloc] init];
 		alert.messageText = [NSString stringWithFormat:
@@ -60,7 +60,7 @@ static QSController *defaultController = nil;
 			minimumVersionString
 		];
 		alert.informativeText = [NSString stringWithFormat:
-			NSLocalizedString(@"Recent versions of Quicksilver require %@. Older %@ compatible versions are available from the http://qsapp.com/download.php", @"macOS version required alert message"),
+			NSLocalizedString(@"Recent versions of Quicksilver require %@. Older %@ compatible versions are available from the https://qsapp.com/download.php", @"macOS version required alert message"),
 			minimumVersionString,
 			oldVersionsString];
 		[alert addButtonWithTitle:NSLocalizedString(@"OK", nil)];

--- a/Quicksilver/Code-App/QSController.m
+++ b/Quicksilver/Code-App/QSController.m
@@ -49,8 +49,9 @@ static QSController *defaultController = nil;
 	if (![NSApplication isMavericks]) {
 		NSBundle *appBundle = [NSBundle mainBundle];
 
-		NSString *minimumVersionString = @"macOS 10.14+";
-		NSString *oldVersionsString = @"10.14";
+		NSDictionary *infoDict = [appBundle infoDictionary];
+		NSString *minVer = infoDict[@"LSMinimumSystemVersion"];
+		NSString *minimumVersionString = [NSString stringWithFormat:@"macOS %@+", minVer];
 
 		NSAlert *alert = [[NSAlert alloc] init];
 		alert.messageText = [NSString stringWithFormat:
@@ -60,9 +61,8 @@ static QSController *defaultController = nil;
 			minimumVersionString
 		];
 		alert.informativeText = [NSString stringWithFormat:
-			NSLocalizedString(@"Recent versions of Quicksilver require %@. Older %@ compatible versions are available from the https://qsapp.com/download.php", @"macOS version required alert message"),
-			minimumVersionString,
-			oldVersionsString];
+			NSLocalizedString(@"Recent versions of Quicksilver require %@. Older Quicksilver versions are available from https://qsapp.com/download.php", @"macOS version required alert message"),
+			minimumVersionString];
 		[alert addButtonWithTitle:NSLocalizedString(@"OK", nil)];
 
 		[alert runModal];

--- a/Quicksilver/Code-App/QSController.m
+++ b/Quicksilver/Code-App/QSController.m
@@ -86,7 +86,7 @@ static QSController *defaultController = nil;
 	[QSVoyeur sharedInstance];
 
 #ifdef DEBUG
-	if (defaultBool(@"verbose") )
+	if ([[NSUserDefaults standardUserDefaults] boolForKey:@"verbose"])
 		setenv("verbose", "1", YES);
 #endif
 		

--- a/Quicksilver/Code-App/QSHelpersPrefPane.m
+++ b/Quicksilver/Code-App/QSHelpersPrefPane.m
@@ -97,20 +97,20 @@
 - (void)reloadHelpersList:(id)sender {
 	NSMutableArray *helpers = [NSMutableArray array];
 
-	id header = nil;
-	NSString *key = nil;
-	NSEnumerator *kEnum = [[QSReg tableNamed:@"QSRegistryHeaders"] keyEnumerator];
-	while((key = [kEnum nextObject]) && (header = [[QSReg tableNamed:@"QSRegistryHeaders"] objectForKey:key]) ) {
+	[[QSReg tableNamed:@"QSRegistryHeaders"] enumerateKeysAndObjectsUsingBlock:^(NSString *key, id header, BOOL * _Nonnull stop) {
 		if ([[header objectForKey:@"type"] isEqual:@"mediator"]) {
 			NSMutableDictionary *dict = [NSMutableDictionary dictionaryWithObject:header forKey:INFO];
 			NSMenu *menu = [self menuForTable:key includeDefault:[[header objectForKey:@"allowDefault"] boolValue]];
-			if (!menu) continue;
-			if (menu)
+			if (menu) {
 				[dict setObject:menu forKey:MENU];
+			} else {
+				return;
+			}
 			[dict setObject:key forKey:IDENT];
 			[helpers addObject:dict];
 		}
-	}
+	}];
+
 	[self setHelperInfo:helpers];
 	[helperTable reloadData];
 }

--- a/Quicksilver/Code-App/QSHelpersPrefPane.m
+++ b/Quicksilver/Code-App/QSHelpersPrefPane.m
@@ -96,7 +96,11 @@
 
 - (void)reloadHelpersList:(id)sender {
 	NSMutableArray *helpers = [NSMutableArray array];
-	foreachkey(key, header, [QSReg tableNamed:@"QSRegistryHeaders"]) {
+
+	id header = nil;
+	NSString *key = nil;
+	NSEnumerator *kEnum = [[QSReg tableNamed:@"QSRegistryHeaders"] keyEnumerator];
+	while((key = [kEnum nextObject]) && (header = [[QSReg tableNamed:@"QSRegistryHeaders"] objectForKey:key]) ) {
 		if ([[header objectForKey:@"type"] isEqual:@"mediator"]) {
 			NSMutableDictionary *dict = [NSMutableDictionary dictionaryWithObject:header forKey:INFO];
 			NSMenu *menu = [self menuForTable:key includeDefault:[[header objectForKey:@"allowDefault"] boolValue]];

--- a/Quicksilver/Code-App/QSMainPreferencePanes.m
+++ b/Quicksilver/Code-App/QSMainPreferencePanes.m
@@ -466,7 +466,10 @@
 			break;
 		}
 		case 1: {
-			foreachkey(pluginId, plugin, [[QSPlugInManager sharedInstance] loadedPlugIns]) {
+			id plugin = nil;
+			NSString *pluginId = nil;
+			NSEnumerator *kEnum = [[[QSPlugInManager sharedInstance] loadedPlugIns] keyEnumerator];
+			while((pluginId = [kEnum nextObject]) && (plugin = [[[QSPlugInManager sharedInstance] loadedPlugIns] objectForKey:pluginId]) ) {
 				NSString *name = [plugin shortName];
 				if (!name) name = [plugin identifier];
 				NSArray *actionsArray = [QSExec getArrayForSource:[plugin identifier]];

--- a/Quicksilver/Code-App/QSMainPreferencePanes.m
+++ b/Quicksilver/Code-App/QSMainPreferencePanes.m
@@ -466,19 +466,18 @@
 			break;
 		}
 		case 1: {
-			id plugin = nil;
-			NSString *pluginId = nil;
-			NSEnumerator *kEnum = [[[QSPlugInManager sharedInstance] loadedPlugIns] keyEnumerator];
-			while((pluginId = [kEnum nextObject]) && (plugin = [[[QSPlugInManager sharedInstance] loadedPlugIns] objectForKey:pluginId]) ) {
+			[[[QSPlugInManager sharedInstance] loadedPlugIns] enumerateKeysAndObjectsUsingBlock:^(NSString *pluginId, id plugin, BOOL * _Nonnull stop) {
 				NSString *name = [plugin shortName];
-				if (!name) name = [plugin identifier];
+				if (!name) {
+					name = [plugin identifier];
+				}
 				NSArray *actionsArray = [QSExec getArrayForSource:[plugin identifier]];
 				if ([actionsArray count]) {
 					name = [name stringByAppendingFormat:@" - %lu", (unsigned long)[actionsArray count]];
 					[array addObject:[NSDictionary dictionaryWithObjectsAndKeys:
-                                      [plugin identifier] , @"group", name, @"name", [plugin icon] , @"icon", nil]];
+									  [plugin identifier] , @"group", name, @"name", [plugin icon] , @"icon", nil]];
 				}
-			}
+			}];
 			NSSortDescriptor *desc = [[NSSortDescriptor alloc] initWithKey:@"name" ascending:YES];
 			[array sortUsingDescriptors:[NSArray arrayWithObject:desc]];
 			[array insertObject:[NSDictionary dictionaryWithObjectsAndKeys:kQSAllActionsCategory, @"group", @"All Plugins", @"name", [QSResourceManager imageNamed:@"Quicksilver"] , @"icon", nil] atIndex:0];

--- a/Quicksilver/Code-App/QSPreferencesController.m
+++ b/Quicksilver/Code-App/QSPreferencesController.m
@@ -243,7 +243,7 @@ id QSPrefs;
 	//	 [toolbar performSelector:@selector(setSelectedItemIdentifier:) withObject:[[toolbarTabView selectedTabViewItem] identifier]];
 
 	[win setToolbar:toolbar];
-	if (defaultBool(@"QSSkipGuide") ) {
+	if ([[NSUserDefaults standardUserDefaults] boolForKey:@"QSSkipGuide"] ) {
 		[self selectPaneWithIdentifier:@"QSSettingsPanePlaceholder"];
 	} else {
 		[toolbar setSelectedItemIdentifier:@"QSMainMenuPrefPane"];

--- a/Quicksilver/Code-App/QSSetupAssistant.m
+++ b/Quicksilver/Code-App/QSSetupAssistant.m
@@ -136,7 +136,7 @@
 }
 
 - (BOOL)windowShouldClose:(id)sender {
-	if (!defaultBool(@"QSAgreementAccepted") ) {
+	if (![[NSUserDefaults standardUserDefaults] boolForKey:@"QSAgreementAccepted"] ) {
         QSAlertResponse response = [NSAlert runAlertWithTitle:NSLocalizedString(@"Cancel Setup", @"Setup assistant - Cancel alert title")
                                                      message:NSLocalizedString(@"Would you like to stop setup and quit Quicksilver?", @"Setup assistant - Cancel alert message")
                                                      buttons:@[NSLocalizedString(@"Quit", nil), NSLocalizedString(@"Cancel", nil)]

--- a/Quicksilver/Code-QuickStepCore/QSCatalogEntry.m
+++ b/Quicksilver/Code-QuickStepCore/QSCatalogEntry.m
@@ -792,7 +792,7 @@ NSString *const QSCatalogEntryInvalidatedNotification = @"QSCatalogEntryInvalida
 
 
 // Backward-compatibility
-- (BOOL)deletable QS_DEPRECATED { return self.canBeDeleted; }
+- (BOOL)deletable __attribute__((deprecated)) { return self.canBeDeleted; }
 
 @end
 

--- a/Quicksilver/Code-QuickStepCore/QSCatalogEntry_Private.h
+++ b/Quicksilver/Code-QuickStepCore/QSCatalogEntry_Private.h
@@ -37,5 +37,5 @@
 @end
 
 @interface QSCatalogEntry (OldStyleSourceSupport)
-- (id)objectForKey:(NSString *)key QS_DEPRECATED_MSG("Sources now get QSCatalogEntry objects. Please use those");
+- (id)objectForKey:(NSString *)key __attribute__((deprecated("Sources now get QSCatalogEntry objects. Please use those")));
 @end

--- a/Quicksilver/Code-QuickStepCore/QSLibrarian.h
+++ b/Quicksilver/Code-QuickStepCore/QSLibrarian.h
@@ -85,7 +85,7 @@ extern QSLibrarian *QSLib; // Shared Instance
 - (void)startThreadedAndForcedScan;
 - (IBAction)forceScanCatalog:(id)sender;
 - (IBAction)scanCatalog:(id)sender;
-- (void)scanCatalogWithDelay:(id)sender QS_DEPRECATED;
+- (void)scanCatalogWithDelay:(id)sender __attribute__((deprecated));
 - (BOOL)itemIsOmitted:(QSBasicObject *)item;
 - (void)setItem:(QSBasicObject *)item isOmitted:(BOOL)omit;
 #ifdef DEBUG
@@ -93,7 +93,7 @@ extern QSLibrarian *QSLib; // Shared Instance
 - (NSMutableArray *)scoreTest:(id)sender;
 #endif
 - (NSMutableArray *)scoredArrayForString:(NSString *)string;
-- (NSMutableArray *)scoredArrayForString:(NSString *)string inNamedSet:(NSString *)setName QS_DEPRECATED;
+- (NSMutableArray *)scoredArrayForString:(NSString *)string inNamedSet:(NSString *)setName __attribute__((deprecated));
 - (NSMutableArray *)scoredArrayForString:(NSString *)searchString inSet:(id)set;
 - (NSMutableArray *)scoredArrayForString:(NSString *)searchString inSet:(NSArray *)set mnemonicsOnly:(BOOL)mnemonicsOnly;
 - (NSMutableArray *)shelfNamed:(NSString *)shelfName;

--- a/Quicksilver/Code-QuickStepCore/QSLibrarian.h
+++ b/Quicksilver/Code-QuickStepCore/QSLibrarian.h
@@ -1,5 +1,6 @@
 #import <Foundation/Foundation.h>
 #import "QSCatalogEntry.h"
+#import "QSThreadSafeMutableDictionary.h"
 
 #define kCustomCatalogID @"QSCatalogCustom"
 

--- a/Quicksilver/Code-QuickStepCore/QSObject.h
+++ b/Quicksilver/Code-QuickStepCore/QSObject.h
@@ -7,8 +7,6 @@
 
 extern NSSize QSMaxIconSize;
 
-#define itemForKey(k) [data objectForKey:k]
-
 // meta dictionary keys
 #define kQSObjectPrimaryName      @"QSObjectName"
 #define kQSObjectAlternateName    @"QSObjectLabel"

--- a/Quicksilver/Code-QuickStepCore/QSObject.h
+++ b/Quicksilver/Code-QuickStepCore/QSObject.h
@@ -2,6 +2,7 @@
 
 #import <QSCore/QSBasicObject.h>
 #import <QSCore/QSObjectHandler.h>
+#import "QSThreadSafeMutableDictionary.h"
 
 @class QSObject, QSBasicObject;
 

--- a/Quicksilver/Code-QuickStepCore/QSObject.h
+++ b/Quicksilver/Code-QuickStepCore/QSObject.h
@@ -73,7 +73,7 @@ typedef struct _QSObjectFlags {
 + (void)interfaceChanged;
 
 + (id)objectWithName:(NSString *)aName;
-+ (id)objectWithIdentifier:(NSString *)anIdentifier QS_DEPRECATED;
++ (id)objectWithIdentifier:(NSString *)anIdentifier __attribute__((deprecated));
 + (id)makeObjectWithIdentifier:(NSString *)anIdentifier;
 + (id)objectByMergingObjects:(NSArray *)objects;
 + (id)objectByMergingObjects:(NSArray *)objects withObject:(QSObject *)object;
@@ -119,7 +119,7 @@ typedef struct _QSObjectFlags {
 - (BOOL)unloadIcon;
 - (NSImage *)icon;
 - (void)setIcon:(NSImage *)newIcon;
-- (void)updateIcon:(NSImage *)newIcon QS_DEPRECATED_MSG("Use -setIcon:");
+- (void)updateIcon:(NSImage *)newIcon __attribute__((deprecated("Use -setIcon:")));
 @end
 
 @interface QSObject (Hierarchy)

--- a/Quicksilver/Code-QuickStepCore/QSObject.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject.m
@@ -3,6 +3,8 @@
 #import "QSDebug.h"
 #import "QSObjectHandler.h"
 
+#import <QSCore/QSCore-Swift.h>
+
 static NSMutableSet *iconLoadedSet;
 static NSMutableSet *childLoadedSet;
 
@@ -13,6 +15,9 @@ NSSize QSMaxIconSize;
 @implementation QSObject
 + (void)initialize {
 	if (!QSObjectInitialized) {
+		QSSwiftObj *swiftobj = [[QSSwiftObj alloc] init];
+		[swiftobj sayHello];
+
 		QSMaxIconSize = QSSizeMax;
 		NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
 		[nc addObserver:self selector:@selector(interfaceChanged) name:QSInterfaceChangedNotification object:nil];

--- a/Quicksilver/Code-QuickStepCore/QSObject.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject.m
@@ -15,9 +15,6 @@ NSSize QSMaxIconSize;
 @implementation QSObject
 + (void)initialize {
 	if (!QSObjectInitialized) {
-		QSSwiftObj *swiftobj = [[QSSwiftObj alloc] init];
-		[swiftobj sayHello];
-
 		QSMaxIconSize = QSSizeMax;
 		NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
 		[nc addObserver:self selector:@selector(interfaceChanged) name:QSInterfaceChangedNotification object:nil];

--- a/Quicksilver/Code-QuickStepCore/QSObject.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject.m
@@ -396,14 +396,14 @@ NSSize QSMaxIconSize;
         [self setObject:details forMeta:kQSObjectDetails];
     } else if ([self stringValue]) {
         details = [self stringValue];
-    } else if ([itemForKey([self primaryType]) isKindOfClass:[NSString class]]) {
-        details = itemForKey([self primaryType]);
+    } else if ([[data objectForKey:[self primaryType]] isKindOfClass:[NSString class]]) {
+        details = [data objectForKey:[self primaryType]];
     }
     
 	return details;
 }
 
-- (id)primaryObject {return itemForKey([self primaryType]);}
+- (id)primaryObject {return [data objectForKey:[self primaryType]];}
 	//- (id)objectForKey:(id)aKey {return [data objectForKey:aKey];}
 	//- (void)setObject:(id)object forKey:(id)aKey {[data setObject:object forKey:aKey];}
 

--- a/Quicksilver/Code-QuickStepCore/QSObject.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject.m
@@ -3,6 +3,8 @@
 #import "QSDebug.h"
 #import "QSObjectHandler.h"
 
+// Currently unused import, intentionally left here to ensure swift continues to compile
+// while pending more work.
 #import <QSCore/QSCore-Swift.h>
 
 static NSMutableSet *iconLoadedSet;

--- a/Quicksilver/Code-QuickStepCore/QSObjectHandler.h
+++ b/Quicksilver/Code-QuickStepCore/QSObjectHandler.h
@@ -38,7 +38,7 @@
 
 - (NSAppleEventDescriptor *)AEDescriptorForObject:(QSObject *)object;
 
-- (QSObject *)initFileObject:(QSObject *)object ofType:(NSString *)type QS_DEPRECATED NS_RETURNS_NOT_RETAINED;
+- (QSObject *)initFileObject:(QSObject *)object ofType:(NSString *)type __attribute__((deprecated)) NS_RETURNS_NOT_RETAINED;
 @end
 
 

--- a/Quicksilver/Code-QuickStepCore/QSObjectRanker.h
+++ b/Quicksilver/Code-QuickStepCore/QSObjectRanker.h
@@ -26,7 +26,7 @@ extern NSString *QSRankingIncludeOmitted;   // BOOL. Specifies whether the ranke
 - (NSString*)matchedStringForAbbreviation:(NSString*)anAbbreviation hitmask:(NSIndexSet **)hitmask inContext:(NSString *)context;
 
 @optional
-- (QSRankedObject *)rankedObject:(QSBasicObject *)object forAbbreviation:(NSString*)anAbbreviation inContext:(NSString *)context withMnemonics:(NSArray *)mnemonics mnemonicsOnly:(BOOL)mnemonicsOnly QS_DEPRECATED;
+- (QSRankedObject *)rankedObject:(QSBasicObject *)object forAbbreviation:(NSString*)anAbbreviation inContext:(NSString *)context withMnemonics:(NSArray *)mnemonics mnemonicsOnly:(BOOL)mnemonicsOnly __attribute__((deprecated));
 @end
 
 

--- a/Quicksilver/Code-QuickStepCore/QSObjectSource.h
+++ b/Quicksilver/Code-QuickStepCore/QSObjectSource.h
@@ -79,7 +79,7 @@
 	/* The following is deprecated because it duplicates -selection.
 	 * But it can't be removed because dyld will notice and plugins will fail to load
 	 */
-	NSMutableDictionary *currentEntry QS_DEPRECATED;
+	NSMutableDictionary *currentEntry __attribute__((deprecated));
 }
 
 - (void)invalidateSelf;
@@ -102,7 +102,7 @@
 // Please use -selectedEntry instead of those
 // The rational being that between -currentEntry, -selection and direct Ivar
 // everything can go wrong.
-@property (retain) NSMutableDictionary *currentEntry QS_DEPRECATED;
-@property (retain) QSCatalogEntry *selection QS_DEPRECATED;
+@property (retain) NSMutableDictionary *currentEntry __attribute__((deprecated));
+@property (retain) QSCatalogEntry *selection __attribute__((deprecated));
 
 @end

--- a/Quicksilver/Code-QuickStepCore/QSObject_Pasteboard.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject_Pasteboard.m
@@ -166,14 +166,14 @@ id objectForPasteboardType(NSPasteboard *pasteboard, NSString *type) {
 }
 
 - (void)guessName {
-	if (itemForKey(QSFilePathType) ) {
+	if ([data objectForKey:QSFilePathType]) {
 		[self setPrimaryType:QSFilePathType];
 		[self getNameFromFiles];
 	} else {
-        NSString *textString = itemForKey(QSTextType);
+		NSString *textString = [data objectForKey:QSTextType];
         // some objects (images from the web) don't have a text string but have a URL
         if (!textString) {
-            textString = itemForKey(NSURLPboardType);
+			textString = [data objectForKey:NSURLPboardType];
         }
         textString = [textString stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
         
@@ -206,7 +206,7 @@ id objectForPasteboardType(NSPasteboard *pasteboard, NSString *type) {
         }
 
         for (NSString *key in keys) {
-			if (itemForKey(key) ) {
+			if ([data objectForKey:key] ) {
                 if ([key isEqualToString:QSTextType]) {
                     [self setDetails:nil];
                 } else {

--- a/Quicksilver/Code-QuickStepCore/QSPlugIn.m
+++ b/Quicksilver/Code-QuickStepCore/QSPlugIn.m
@@ -727,20 +727,16 @@ NSMutableDictionary *plugInBundlePaths = nil;
 
 	BOOL loadNow = ![QSReg handleRegistration:bundle];
 
-	id value;
-	id handler;
-
-	id handlerClass = nil;
-	NSString *key = nil;
-	NSEnumerator *kEnum = [[QSReg tableNamed:kQSPlugInInfoHandlers] keyEnumerator];
-	while((key = [kEnum nextObject]) && (handlerClass = [[QSReg tableNamed:kQSPlugInInfoHandlers] objectForKey:key]) ) {
-		value = [bundle dictionaryForFileOrPlistKey:key];
-		if (!value) continue;
+	[[QSReg tableNamed:kQSPlugInInfoHandlers] enumerateKeysAndObjectsUsingBlock:^(NSString *key, id handlerClass, BOOL * _Nonnull stop) {
+		id value = [bundle dictionaryForFileOrPlistKey:key];
+		if (!value) {
+			return;
+		}
 		//NSLog(@"----> Registering %@ for %@", key, [self name]);
-		handler = [QSReg getClassInstance:handlerClass];
+		id handler = [QSReg getClassInstance:handlerClass];
 		if ([handler respondsToSelector:@selector(handleInfo:ofType:fromBundle:)])
 			[handler handleInfo:value ofType:key fromBundle:[self bundle]];
-	}
+	}];
 
 	loadNow |= [[bundle objectForInfoDictionaryKey:@"QSLoadImmediately"] boolValue];
 

--- a/Quicksilver/Code-QuickStepCore/QSPlugIn.m
+++ b/Quicksilver/Code-QuickStepCore/QSPlugIn.m
@@ -730,7 +730,10 @@ NSMutableDictionary *plugInBundlePaths = nil;
 	id value;
 	id handler;
 
-	foreachkey(key, handlerClass, [QSReg tableNamed:kQSPlugInInfoHandlers]) {
+	id handlerClass = nil;
+	NSString *key = nil;
+	NSEnumerator *kEnum = [[QSReg tableNamed:kQSPlugInInfoHandlers] keyEnumerator];
+	while((key = [kEnum nextObject]) && (handlerClass = [[QSReg tableNamed:kQSPlugInInfoHandlers] objectForKey:key]) ) {
 		value = [bundle dictionaryForFileOrPlistKey:key];
 		if (!value) continue;
 		//NSLog(@"----> Registering %@ for %@", key, [self name]);

--- a/Quicksilver/Code-QuickStepCore/QSProcessMonitor.h
+++ b/Quicksilver/Code-QuickStepCore/QSProcessMonitor.h
@@ -1,6 +1,7 @@
 
 
 #import <Foundation/Foundation.h>
+#import <Carbon/Carbon.h>
 
 #define kQSShowBackgroundProcesses @"QSShowBackgroundProcesses"
 

--- a/Quicksilver/Code-QuickStepCore/QSProcessMonitor.h
+++ b/Quicksilver/Code-QuickStepCore/QSProcessMonitor.h
@@ -24,8 +24,8 @@
 - (NSArray *)backgroundProcesses; /* QSObjects */
 
 /* Deprecated, equivalent to the above without KVO */
-- (NSArray *)getAllProcesses QS_DEPRECATED_MSG("Use -allProcesses");
-- (NSArray *)getVisibleProcesses QS_DEPRECATED_MSG("Use -visibleProcesses");
+- (NSArray *)getAllProcesses __attribute__((deprecated("Use -allProcesses")));
+- (NSArray *)getVisibleProcesses __attribute__((deprecated("Use -visibleProcesses")));
 
 - (QSObject *)imbuedFileProcessForDict:(NSDictionary *)dict;
 - (BOOL)handleProcessEvent:(NSEvent *)theEvent;

--- a/Quicksilver/Code-QuickStepCore/QSSwiftObj.swift
+++ b/Quicksilver/Code-QuickStepCore/QSSwiftObj.swift
@@ -1,0 +1,8 @@
+//
+//  QSSwiftObj.swift
+//  QuickStep Core
+//
+//  Created by Nathan Henrie on 2024-11-08.
+//
+
+// import Foundation

--- a/Quicksilver/Code-QuickStepCore/QSSwiftObj.swift
+++ b/Quicksilver/Code-QuickStepCore/QSSwiftObj.swift
@@ -6,3 +6,10 @@
 //
 
  import Foundation
+
+public class QSSwiftObj: NSObject {
+    @objc public func sayHello() {
+        print("Hello from Swift")
+    }
+}
+

--- a/Quicksilver/Code-QuickStepCore/QSSwiftObj.swift
+++ b/Quicksilver/Code-QuickStepCore/QSSwiftObj.swift
@@ -5,11 +5,4 @@
 //  Created by Nathan Henrie on 2024-11-08.
 //
 
- import Foundation
-
-public class QSSwiftObj: NSObject {
-    @objc public func sayHello() {
-        print("Hello from Swift")
-    }
-}
-
+import Foundation

--- a/Quicksilver/Code-QuickStepCore/QSSwiftObj.swift
+++ b/Quicksilver/Code-QuickStepCore/QSSwiftObj.swift
@@ -5,4 +5,4 @@
 //  Created by Nathan Henrie on 2024-11-08.
 //
 
-// import Foundation
+ import Foundation

--- a/Quicksilver/Code-QuickStepCore/QSTrigger.m
+++ b/Quicksilver/Code-QuickStepCore/QSTrigger.m
@@ -175,7 +175,8 @@
             [self setEnabled:NO];
         }
     };
-    if (defaultBool(kExecuteInThread) && [cmd canThread]) {
+//	defaultBool(x) [[NSUserDefaults standardUserDefaults] boolForKey:x]
+    if ([[NSUserDefaults standardUserDefaults] boolForKey:kExecuteInThread] && [cmd canThread]) {
         dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), block);
     } else {
         block();

--- a/Quicksilver/Code-QuickStepCore/QSTriggerCenter.m
+++ b/Quicksilver/Code-QuickStepCore/QSTriggerCenter.m
@@ -131,7 +131,10 @@
 
 - (NSArray *)triggersWithParentID:(NSString *)ident {
 	NSMutableArray *array = [NSMutableArray array];
-	foreachkey(key, trigger, triggersDict) {
+	id trigger = nil;
+	NSString *key = nil;
+	NSEnumerator *kEnum = [triggersDict keyEnumerator];
+	while((key = [kEnum nextObject]) && (trigger = [triggersDict objectForKey:key]) ) {
 		if ([[trigger parentID] isEqualToString:ident])
 			[array addObject:trigger];
 	}

--- a/Quicksilver/Code-QuickStepFoundation/NSString_BLTRExtensions.h
+++ b/Quicksilver/Code-QuickStepFoundation/NSString_BLTRExtensions.h
@@ -52,7 +52,7 @@ NSComparisonResult prefixCompare(NSString *aString, NSString *bString);
 
 @interface NSString (Replacement)
 - (NSArray *)lines;
-- (NSString *)stringByReplacing:(NSString *)search with:(NSString *)replacement QS_DEPRECATED;
+- (NSString *)stringByReplacing:(NSString *)search with:(NSString *)replacement __attribute__((deprecated));
 
 @end
 

--- a/Quicksilver/Code-QuickStepFoundation/NSWorkspace_BLTRExtensions.h
+++ b/Quicksilver/Code-QuickStepFoundation/NSWorkspace_BLTRExtensions.h
@@ -25,7 +25,7 @@
 - (void)reopenApplication:(NSDictionary *)theApp;
 - (void)quitApplication:(NSDictionary *)theApp;
 - (void)quitOtherApplications:(NSArray *)theApps;
-- (NSDictionary *)dictForApplicationIdentifier:(NSString *)ident QS_DEPRECATED;
+- (NSDictionary *)dictForApplicationIdentifier:(NSString *)ident __attribute__((deprecated));
 - (NSString *)commentForFile:(NSString *)path;
 - (BOOL)setComment:(NSString*)comment forFile:(NSString *)path;
 - (BOOL)openFileInBackground:(NSString *)fullPath;

--- a/Quicksilver/Code-QuickStepFoundation/QSGCD.h
+++ b/Quicksilver/Code-QuickStepFoundation/QSGCD.h
@@ -66,7 +66,7 @@ inline void QSGCDDelayed(NSTimeInterval delay, void (^block)(void))
 
 // Remove those when the plugins are call-free
 // Don't forget to remove definitions in .m file
-void runOnMainQueueSync(void (^block)(void)) QS_DEPRECATED_MSG("Use QSGCDMainSync");
-void runOnQueueSync(dispatch_queue_t queue, void (^block)(void)) QS_DEPRECATED_MSG("Use QSGCDQueueSync");
+void runOnMainQueueSync(void (^block)(void)) __attribute__((deprecated("Use QSGCDMainSync")));
+void runOnQueueSync(dispatch_queue_t queue, void (^block)(void)) __attribute__((deprecated("Use QSGCDQueueSync")));
 
 #endif // __QSGCD__

--- a/Quicksilver/Code-QuickStepInterface/QSDockingWindow.h
+++ b/Quicksilver/Code-QuickStepInterface/QSDockingWindow.h
@@ -45,10 +45,10 @@
  @result YES if window is hidden into the screen edge, otherwise NO
 */
 - (BOOL)isDocked;
-- (BOOL)canFade QS_DEPRECATED_MSG("Use -isDockedInstead");
+- (BOOL)canFade __attribute__((deprecated("Use -isDockedInstead")));
 
-- (NSString *)autosaveName QS_DEPRECATED_MSG("Use -NSWindow frameAutosaveName or -NSWindowController windowFrameAutosaveName");
-- (void)setAutosaveName:(NSString *)newAutosaveName QS_DEPRECATED_MSG("Use -NSWindow frameAutosaveName or -NSWindowController windowFrameAutosaveName");;
+- (NSString *)autosaveName __attribute__((deprecated("Use -NSWindow frameAutosaveName or -NSWindowController windowFrameAutosaveName")));
+- (void)setAutosaveName:(NSString *)newAutosaveName __attribute__((deprecated("Use -NSWindow frameAutosaveName or -NSWindowController windowFrameAutosaveName")));;
 - (void)resignKeyWindowNow;
 - (IBAction)orderFrontHidden:(id)sender;
 - (void)saveFrame;

--- a/Quicksilver/Code-QuickStepInterface/QSResizingInterfaceController.h
+++ b/Quicksilver/Code-QuickStepInterface/QSResizingInterfaceController.h
@@ -7,7 +7,7 @@
 	BOOL expanded;
 }
 - (void)firstResponderChanged:(NSResponder *)aResponder;
-- (void)resetAdjustTimer QS_DEPRECATED_MSG("Use -adjustWindow:");
+- (void)resetAdjustTimer __attribute__((deprecated("Use -adjustWindow:")));
 - (void)expandWindow:(id)sender;
 - (void)contractWindow:(id)sender;
 

--- a/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
+++ b/Quicksilver/Code-QuickStepInterface/QSSearchObjectView.m
@@ -1485,7 +1485,7 @@ NSMutableDictionary *bindingsDict = nil;
 #pragma mark NSResponder Key Bindings
 - (void)deleteBackward:(id)sender {
 	if ([[self partialString] length] > 0 || matchedString) {
-		if (defaultBool(kDoubleDeleteClearsObject)) {
+		if ([[NSUserDefaults standardUserDefaults] boolForKey:kDoubleDeleteClearsObject]) {
 			// option to have delete clear the entire search string
 			[self clearSearch];
 			[self clearTextView];

--- a/Quicksilver/Code-QuickStepInterface/QSTableView.h
+++ b/Quicksilver/Code-QuickStepInterface/QSTableView.h
@@ -9,14 +9,14 @@
 - (BOOL)tableView:(QSTableView *)aTableView shouldDrawRow:(NSInteger)rowIndex inClipRect:(NSRect)clipRect;
 - (BOOL)tableView:(QSTableView *)aTableView rowIsSeparator:(NSInteger)rowIndex;
 - (NSMenu *)tableView:(QSTableView*)tableView menuForTableColumn:(NSTableColumn *)column row:(NSInteger)row;
-- (void)tableView:(QSTableView *)tv dropEndedWithOperation:(NSDragOperation)operation QS_DEPRECATED_MSG("It has neved been called on the delegate");
+- (void)tableView:(QSTableView *)tv dropEndedWithOperation:(NSDragOperation)operation __attribute__((deprecated("It has neved been called on the delegate")));
 - (void)drawSeparatorForRow:(NSInteger)rowIndex clipRect:(NSRect)clipRect;
 @end
 
 @protocol QSTableViewDataSource <NSTableViewDataSource>
 
 @optional
-- (void)tableView:(QSTableView *)aTableView dropEndedWithOperation:(NSDragOperation)operation QS_DEPRECATED_MSG("Use -tableView:draggingSession:... and friends");
+- (void)tableView:(QSTableView *)aTableView dropEndedWithOperation:(NSDragOperation)operation __attribute__((deprecated("Use -tableView:draggingSession:... and friends")));
 @end
 
 @interface QSTableView : NSTableView {
@@ -30,8 +30,8 @@
 
 - (NSColor *)highlightColor;
 - (void)setHighlightColor:(NSColor *)aHighlightColor;
-- (id)draggingDelegate QS_DEPRECATED_MSG("Use -tableView:draggingSession:... and friends");
-- (void)setDraggingDelegate:(id)aDraggingDelegate QS_DEPRECATED_MSG("Use -tableView:draggingSession:... and friends");;
+- (id)draggingDelegate __attribute__((deprecated("Use -tableView:draggingSession:... and friends")));
+- (void)setDraggingDelegate:(id)aDraggingDelegate __attribute__((deprecated("Use -tableView:draggingSession:... and friends")));;
 - (void)setOpaque:(BOOL)flag;
 - (id <QSTableViewDelegate>)delegate;
 - (id <QSTableViewDataSource>)dataSource;

--- a/Quicksilver/PlugIns-Main/PrimerInterface/QSPrimerInterfaceController.m
+++ b/Quicksilver/PlugIns-Main/PrimerInterface/QSPrimerInterfaceController.m
@@ -78,7 +78,7 @@
 	frame = constrainRectToRect(frame, [[[self window] screen] frame]);
 	[[self window] setFrame:frame display:YES];
 
-	if (defaultBool(@"QSAlwaysCenterInterface") ) {
+    if ([[NSUserDefaults standardUserDefaults] boolForKey:@"QSAlwaysCenterInterface"] ) {
 		NSRect frame = [[self window] frame];
 		frame = centerRectInRect(frame, [[[self window] screen] frame]);
 		[[self window] setFrame:frame display:YES];

--- a/Quicksilver/Quicksilver.xcodeproj/project.pbxproj
+++ b/Quicksilver/Quicksilver.xcodeproj/project.pbxproj
@@ -6434,6 +6434,7 @@
 				INSTALL_PATH = "@executable_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.blacktree.QSCore;
 				PRODUCT_NAME = QSCore;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Testing;
 		};
@@ -6842,6 +6843,7 @@
 				INSTALL_PATH = "@executable_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.blacktree.QSCore;
 				PRODUCT_NAME = QSCore;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -6858,6 +6860,7 @@
 				INSTALL_PATH = "@executable_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.blacktree.QSCore;
 				PRODUCT_NAME = QSCore;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};

--- a/Quicksilver/Quicksilver.xcodeproj/project.pbxproj
+++ b/Quicksilver/Quicksilver.xcodeproj/project.pbxproj
@@ -6633,7 +6633,6 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				INFOPLIST_FILE = "Quicksilver Tests/Quicksilver Tests-Info.plist";
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.qsapp.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUNDLE_LOADER)";
@@ -7225,7 +7224,6 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				INFOPLIST_FILE = "Quicksilver Tests/Quicksilver Tests-Info.plist";
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.qsapp.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUNDLE_LOADER)";
@@ -7266,7 +7264,6 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				INFOPLIST_FILE = "Quicksilver Tests/Quicksilver Tests-Info.plist";
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.qsapp.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUNDLE_LOADER)";

--- a/Quicksilver/Quicksilver.xcodeproj/project.pbxproj
+++ b/Quicksilver/Quicksilver.xcodeproj/project.pbxproj
@@ -6340,7 +6340,7 @@
 				GCC_PREFIX_HEADER = "$(SRCROOT)/Configuration/Quicksilver.pch";
 				GCC_PREPROCESSOR_DEFINITIONS_NOT_USED_IN_PRECOMPS = TESTING;
 				ONLY_ACTIVE_ARCH = YES;
-				SWIFT_VERSION = 6.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Testing;
 		};
@@ -7058,7 +7058,7 @@
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_PREFIX_HEADER = "$(SRCROOT)/Configuration/Quicksilver.pch";
 				ONLY_ACTIVE_ARCH = YES;
-				SWIFT_VERSION = 6.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -7083,7 +7083,7 @@
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_PREFIX_HEADER = "$(SRCROOT)/Configuration/Quicksilver.pch";
-				SWIFT_VERSION = 6.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};

--- a/Quicksilver/Quicksilver.xcodeproj/project.pbxproj
+++ b/Quicksilver/Quicksilver.xcodeproj/project.pbxproj
@@ -6340,6 +6340,7 @@
 				GCC_PREFIX_HEADER = "$(SRCROOT)/Configuration/Quicksilver.pch";
 				GCC_PREPROCESSOR_DEFINITIONS_NOT_USED_IN_PRECOMPS = TESTING;
 				ONLY_ACTIVE_ARCH = YES;
+				SWIFT_VERSION = 6.0;
 			};
 			name = Testing;
 		};
@@ -7055,6 +7056,7 @@
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_PREFIX_HEADER = "$(SRCROOT)/Configuration/Quicksilver.pch";
 				ONLY_ACTIVE_ARCH = YES;
+				SWIFT_VERSION = 6.0;
 			};
 			name = Debug;
 		};
@@ -7079,6 +7081,7 @@
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_PREFIX_HEADER = "$(SRCROOT)/Configuration/Quicksilver.pch";
+				SWIFT_VERSION = 6.0;
 			};
 			name = Release;
 		};

--- a/Quicksilver/Quicksilver.xcodeproj/project.pbxproj
+++ b/Quicksilver/Quicksilver.xcodeproj/project.pbxproj
@@ -174,6 +174,7 @@
 		4DFE7DD40E08219C000B9AA3 /* AppKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 29B97324FDCFA39411CA2CEA /* AppKit.framework */; };
 		4DFE7DDA0E0821C0000B9AA3 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */; };
 		6008C51F2AAF433900512CB2 /* QSPathsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6008C51E2AAF433900512CB2 /* QSPathsTests.m */; };
+		604EAB052CDE5B1E005B3451 /* QSSwiftObj.swift in Sources */ = {isa = PBXBuildFile; fileRef = 604EAB042CDE5B1E005B3451 /* QSSwiftObj.swift */; };
 		60FCBED82844C9770091AB6B /* OSAKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 60FCBED02844C9770091AB6B /* OSAKit.framework */; };
 		6535A91A1086EF4D009D5C90 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 6535A9191086EF4D009D5C90 /* Localizable.strings */; };
 		6535A98A1086F627009D5C90 /* About.strings in Resources */ = {isa = PBXBuildFile; fileRef = 6535A9891086F627009D5C90 /* About.strings */; };
@@ -1231,6 +1232,7 @@
 		4DFE7DAD0E081BFD000B9AA3 /* QuickLook.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuickLook.framework; path = /System/Library/Frameworks/QuickLook.framework; sourceTree = "<absolute>"; };
 		6008C51E2AAF433900512CB2 /* QSPathsTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = QSPathsTests.m; sourceTree = "<group>"; };
 		600950BC2ABB76AF00F67DEB /* QSCorePlugIn-Info-Testing.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "QSCorePlugIn-Info-Testing.plist"; sourceTree = "<group>"; };
+		604EAB042CDE5B1E005B3451 /* QSSwiftObj.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QSSwiftObj.swift; sourceTree = "<group>"; };
 		60FCBED02844C9770091AB6B /* OSAKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OSAKit.framework; path = System/Library/Frameworks/OSAKit.framework; sourceTree = SDKROOT; };
 		6535A8DE1086EF23009D5C90 /* English */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = English; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		6535A91C1086EF5F009D5C90 /* German */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = German; path = de.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -3632,6 +3634,7 @@
 				E1E5FB9407B20DD20044D6EF /* QSObjCMessageSource.m */,
 				E1E5FB9507B20DD20044D6EF /* QSObject.h */,
 				E1E5FB9607B20DD20044D6EF /* QSObject.m */,
+				604EAB042CDE5B1E005B3451 /* QSSwiftObj.swift */,
 				7F24E8B507EDC67D00943D5A /* QSObject_AEConversion.h */,
 				7F24E8B607EDC67D00943D5A /* QSObject_AEConversion.m */,
 				E1E5FB9707B20DD20044D6EF /* QSObject_Drag.h */,
@@ -4399,6 +4402,9 @@
 					CD61BBB7192B18FA00040609 = {
 						TestTargetID = 8D1107260486CEB800E47090;
 					};
+					E103F15F0647200700447FE0 = {
+						LastSwiftMigration = 1610;
+					};
 				};
 			};
 			buildConfigurationList = 7F6B3E7C085CE68E000735A8 /* Build configuration list for PBXProject "Quicksilver" */;
@@ -5072,6 +5078,7 @@
 				E1E5FC3807B20DD20044D6EF /* QSTypes.m in Sources */,
 				7FB37EB5080997EF00A2B2B4 /* QSURLDownloadWrapper.m in Sources */,
 				E1E5FC3A07B20DD20044D6EF /* QSVoyeur.m in Sources */,
+				604EAB052CDE5B1E005B3451 /* QSSwiftObj.swift in Sources */,
 				D493990E1350078E00B908C6 /* QSDownloads.m in Sources */,
 				CD1B17D9158A573000E4A030 /* VDKQueue.m in Sources */,
 				D413173015DEE5D90021479B /* LaunchAtLoginController.m in Sources */,


### PR DESCRIPTION
- **macos-12 runner is deprecated**
- **Remove complex macros, which break compilation with Swift**
- **Remove complex macros, which are incompatible with Swift**
- **Add missing imports**
- **Add blank swift file**
- **Use Swift 6.0**
- **Fix minimum version message and https URL**
- **Remove outdated version target**
- **Add bare minimum to run swift from objc**
- **Swift 6.0 not avail in GHA runners at this point (xcode 15), stick to swift 5 for now**
- **Remove dummy Swift code**
