### PR TITLE
Only check for screenshot permissions on macos11+

### DIFF
--- a/Quicksilver/Code-App/QSController.m
+++ b/Quicksilver/Code-App/QSController.m
@@ -875,7 +875,7 @@ static QSController *defaultController = nil;
 		[closeAccessibilityWindowButton setEnabled:NO];
 		[accessibilityPermissionWindow setIsVisible:YES];
 		hasClickedScreenshotButton = NO;
-		if (@available(macOS 10.15, *)) {
+		if ([NSApplication isBigSur]) {
 				hasScreenshotPermissionOnStartup = CGPreflightScreenCaptureAccess();
 		} else {
 				// below 10.15, no need to give permissions
@@ -912,7 +912,7 @@ static QSController *defaultController = nil;
 				}];
 		} else if (sender == screenshotButton) {
 				hasClickedScreenshotButton = YES;
-				if (@available(macOS 10.15, *)) {
+				if ([NSApplication isBigSur]) {
 						CGRequestScreenCaptureAccess();
 				}
 		} else {


### PR DESCRIPTION
That's a strange one, since `CGPreflightScreenCaptureAccess` is explicitly listed as working on macos10.15+, but I've changed the implementation here slightly to use the `isXXX` methods, and then just use `isBigSur` instead of `isCatalina`.