### PR TITLE
Reload recent documents (children) every time

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSObject_FileHandling.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject_FileHandling.m
@@ -328,7 +328,14 @@ NSArray *QSGetRecentDocumentsForBundle(NSString *bundleIdentifier) {
 						return [handler objectHasValidChildren:object];
 					return NO;
 				}
-			}
+      } else {
+          // Check for recent documents
+          NSString *sflPath = QSGetRecentDocumentsPathForBundle(bundleIdentifier);
+          if ([[NSFileManager defaultManager] fileExistsAtPath:[sflPath stringByStandardizingPath] isDirectory:nil]) {
+              // reload recent documents every time
+              return NO;
+          }
+      }
 			return YES;
 		}
 


### PR DESCRIPTION
Makes sure that right arrowing into apps shows the latest 'recent documents' every time.

Fixes #3036 