### PR TITLE
Minor CI tweaks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,8 +91,8 @@ jobs:
           # https://docs.github.com/en/actions/deployment/deploying-xcode-applications/installing-an-apple-certificate-on-macos-runners-for-xcode-development
           KEYCHAIN_PATH=${RUNNER_TEMP}/app-signing.keychain-db
           CERTIFICATE_PATH=${RUNNER_TEMP}/build_certificate.p12
-          echo -n "${MACOS_CERTIFICATE}" | base64 --decode \
-            --output "${CERTIFICATE_PATH}"
+          base64 --decode --output "${CERTIFICATE_PATH}" <<<"${MACOS_CERTIFICATE}"
+          trap "rm -rf -- '${RUNNER_TEMP}'" EXIT
 
           security create-keychain -p "${KEYCHAIN_PASSWORD}" "${KEYCHAIN_PATH}"
           security default-keychain -s "${KEYCHAIN_PATH}"
@@ -103,6 +103,7 @@ jobs:
           security import "${CERTIFICATE_PATH}" \
             -P "${MACOS_CERTIFICATE_PASSWORD}" \
             -A -t cert -f pkcs12 -k "${KEYCHAIN_PATH}"
+          rm -- "${CERTIFICATE_PATH}"
           xcrun notarytool store-credentials "${KEYCHAIN_PROFILE}" \
             --apple-id "${NOTARIZING_ID}" \
             --team-id "${SIGNING_IDENTITY}" \
@@ -146,13 +147,14 @@ jobs:
           # Create ssh keyfile with locked down permissions and ensure its removal
           # Unfortunately process substitution won't work because ssh closes
           # all fd > 2
-          touch /tmp/key
-          chmod 0600 /tmp/key
-          trap 'rm -f /tmp/key' EXIT
-          echo "${SSH_KEY}" > /tmp/key
+          (
+            umask 077
+            echo "${SSH_KEY}" > /tmp/key
+          )
+          trap 'rm -f -- /tmp/key' EXIT
 
           ssh -T "${SERVER}" -p "${PORT}" -i /tmp/key \
             -o StrictHostKeyChecking=no \
             "${GITHUB_REPOSITORY}" \
             </tmp/ChangesBare.html
-          rm /tmp/key
+          rm -- /tmp/key

--- a/Quicksilver/Tools/qs-nuke
+++ b/Quicksilver/Tools/qs-nuke
@@ -61,7 +61,7 @@ if [ -e "${QS_APPSUPPORT_PATH}" ]; then
 			mv "${QS_APPSUPPORT_PATH}" "${QS_APPSUPPORT_PATH}-${BACKUP_SUFFIX}"
 		else
 			echo "Removing \"${QS_APPSUPPORT_PATH}\"..."
-			rm -R "${QS_APPSUPPORT_PATH}"
+			rm -R -- "${QS_APPSUPPORT_PATH}"
 		fi
 	else
 		echo "Unexpected file type at path \"${QS_APPSUPPORT_PATH}\", cancelling"
@@ -76,7 +76,7 @@ if [ -e "${QS_PREFERENCE_FILE}.plist" ]; then
 			mv "${QS_PREFERENCE_FILE}.plist" "${QS_PREFERENCE_FILE}.plist-${BACKUP_SUFFIX}"
 		else
 			echo "Removing \"${QS_PREFERENCE_FILE}\"..."
-			rm "${QS_PREFERENCE_FILE}.plist"
+			rm -- "${QS_PREFERENCE_FILE}.plist"
 		fi
 	else
 		echo "Unexpected file type at path \"${QS_PREFERENCE_FILE}.plist\", cancelling"
@@ -87,7 +87,7 @@ fi
 if [ -e "${QS_CACHES_PATH}" ]; then
 	if [ -d "${QS_CACHES_PATH}" ]; then
 		echo "Removing \"${QS_CACHES_PATH}\"..."
-		rm -R "${QS_CACHES_PATH}"
+		rm -R -- "${QS_CACHES_PATH}"
 	else
 		echo "Unexpected file type at path \"${QS_CACHES_PATH}.plist\", cancelling"
 		exit 1

--- a/Quicksilver/Tools/qsrelease
+++ b/Quicksilver/Tools/qsrelease
@@ -83,4 +83,4 @@ fi
 "${TOOLSDIR}"/qssign
 
 # Clean up settings if all went well
-rm -f "${SETTINGS}"
+rm -f -- "${SETTINGS}"

--- a/Quicksilver/Tools/qssign
+++ b/Quicksilver/Tools/qssign
@@ -55,7 +55,7 @@ codesign --deep --timestamp --options runtime --sign "${SIGNING_IDENTITY}" "${QS
 codesign --verify --deep --strict --verbose=1 "${QS_VERSIONED_DMG}"
 
 # Replace unsigned version of the app with the signed version; BSD cp won't overwrite
-rm -rf "${BUILT_PRODUCTS_DIR}/Quicksilver.app"
+rm -rf -- "${BUILT_PRODUCTS_DIR}/Quicksilver.app"
 cp -a \
   "${DMG_TEMP}"/Quicksilver.app \
   "${DMG_TEMP}"/Quicksilver.app/Contents/Info.plist \


### PR DESCRIPTION
- remove sensitive files ASAP
- add traps to also ensure their removal if script fails (belt and
  suspenders)
- add `--` to `rm` calls to avoid potential risks with hyphenated
  filenames
