### PR TITLE
Avoid QoS inversion when loading scripts

### DIFF
--- a/Quicksilver/PlugIns-Main/QSCorePlugIn/Code/QSAppleScriptActions.m
+++ b/Quicksilver/PlugIns-Main/QSCorePlugIn/Code/QSAppleScriptActions.m
@@ -414,9 +414,12 @@
         int pid = [[NSProcessInfo processInfo] processIdentifier];
         NSAppleEventDescriptor* targetAddress = [[NSAppleEventDescriptor alloc] initWithDescriptorType:typeKernelProcessID bytes:&pid length:sizeof(pid)];
         
-        NSDictionary *errorDict = nil;
-        NSAppleScript *script = [[NSAppleScript alloc] initWithContentsOfURL:[NSURL fileURLWithPath:scriptPath] error:&errorDict];
+        NSDictionary __block *errorDict = nil;
+        NSAppleScript __block *script;
         
+        QSGCDMainSync(^{
+            script = [[NSAppleScript alloc] initWithContentsOfURL:[NSURL fileURLWithPath:scriptPath] error:&errorDict];
+        });
 		event = [[NSAppleEventDescriptor alloc] initWithEventClass:kQSScriptSuite eventID:kQSGetArgumentCountCommand targetDescriptor:targetAddress returnID:kAutoGenerateReturnID transactionID:kAnyTransactionID];
         
         NSAppleEventDescriptor *result = [script executeAppleEvent:event error:&errorDict];


### PR DESCRIPTION
@pjrobertson @skurfer does this look like the right way to resolve this warning?

<img width="872" height="387" alt="Screenshot 2025-08-21 at 14 01 15" src="https://github.com/user-attachments/assets/46d14f9d-fda1-4d65-a487-df4b4c2d57e1" />
