### PR TITLE
Use isMainThread to check if we're on the main thread

### DIFF
--- a/Quicksilver/Code-QuickStepFoundation/QSGCD.h
+++ b/Quicksilver/Code-QuickStepFoundation/QSGCD.h
@@ -33,7 +33,11 @@ inline void QSGCDQueueDelayed(dispatch_queue_t queue, NSTimeInterval delay, void
 
 inline void QSGCDMainSync(void (^block)(void))
 {
-    QSGCDQueueSync(dispatch_get_main_queue(), block);
+    if ([NSThread isMainThread]) {
+        block();
+    } else {
+        dispatch_sync(dispatch_get_main_queue(), block);
+    }
 }
 
 inline void QSGCDMainAsync(void (^block)(void))


### PR DESCRIPTION
This is an alternative to using `dispatch_queue_get_label(queue) == dispatch_queue_get_label(DISPATCH_CURRENT_QUEUE_LABEL)` which is unreliable for the main thread. 

See here: https://stackoverflow.com/a/23957282/305324

Attached is the crash logs I've been seeing, FYI

[global-selection-crash.txt](https://github.com/user-attachments/files/21946881/global-selection-crash.txt)
