### PR TITLE
Silence unhelpful log when object not found for self

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSProcessMonitor.m
+++ b/Quicksilver/Code-QuickStepCore/QSProcessMonitor.m
@@ -322,7 +322,9 @@ OSStatus appTerminated(EventHandlerCallRef nextHandler, EventRef theEvent, void 
 		});
 	} else {
 #ifdef DEBUG
-		NSLog(@"No object found for process %u", (unsigned int)psn.highLongOfPSN);
+			if (psn.highLongOfPSN != 0) {
+					NSLog(@"No object found for process %u", (unsigned int)psn.highLongOfPSN);
+			}
 #endif
 	}
 }


### PR DESCRIPTION
During long-running debug sessions my log fills up with
`No object found for process 0`.

I'm fairly confident that GetEventParameter(... kEventParamProcessID)
returning PSN of 0 refers to the current process (though having trouble
finding this in official Apple documentation).

This silences this log spam when running in debug mode.

Alternatively could map `0` to the Quicksilver PID when scanning for running
processes, but that would add a little overhead every time processes were
scanned and might be problematic if someone had multiple QS processes running
(for whatever reason).
