### PR TITLE
Run text extraction from images serially

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSObject_FileHandling.m
+++ b/Quicksilver/Code-QuickStepCore/QSObject_FileHandling.m
@@ -696,45 +696,53 @@ NSArray *QSGetRecentDocumentsForBundle(NSString *bundleIdentifier) {
 
 #define MAX_IMAGE_SCAN_SIZE 50 * 1024 * 1024 // 50MB
 
+static dispatch_queue_t _textRecognitionQueue;
+static dispatch_once_t _textRecognitionQueueToken;
+
 - (void)loadAdditionalSearchContext {
   if ([[NSUserDefaults standardUserDefaults] boolForKey:kQSDisableExtractTextFromImages]) {
     return;
   }
 
   if (@available(macOS 10.15, *)) {
-    
+
     // For images, use text recognition to extract any text and store as searchable context
     NSString *path = [self validSingleFilePath];
     if (!path) {
       return;
     }
-    
+
     NSString *uti = [self fileUTI];
     // Check if this is an image file
     if (!QSTypeConformsTo(uti, (NSString *)kUTTypeImage)) {
       return;
     }
-    
+
     NSURL *fileURL = [NSURL fileURLWithPath:path];
-    
+
     if (!fileURL) {
       return;
     }
-    
-    // skip extracting text for images over 20MB
+
+    // skip extracting text for images over 50MB
     NSNumber *fileSize = nil;
     [fileURL getResourceValue:&fileSize forKey:NSURLFileSizeKey error:nil];
     if ([fileSize unsignedLongLongValue] > MAX_IMAGE_SCAN_SIZE) return;
-    
+
     __weak __typeof(self) weakSelf = self;
-    QSGCDAsync(^{
+    // Use a serial queue to avoid overwhelming the system with concurrent Vision requests
+    dispatch_once(&_textRecognitionQueueToken, ^{
+      _textRecognitionQueue = dispatch_queue_create("quicksilver.textrecognition", DISPATCH_QUEUE_SERIAL);
+      dispatch_set_target_queue(_textRecognitionQueue, dispatch_get_global_queue(QOS_CLASS_UTILITY, 0));
+    });
+    dispatch_async(_textRecognitionQueue, ^{
       // Create a text recognition request
       VNRecognizeTextRequest *request = [[VNRecognizeTextRequest alloc] initWithCompletionHandler:^(VNRequest *request, NSError *error) {
         if (error) {
           NSLog(@"Text recognition error: %@", error);
           return;
         }
-        
+
         NSMutableString *recognizedText = [NSMutableString string];
         for (VNRecognizedTextObservation *observation in request.results) {
           VNRecognizedText *text = [[observation topCandidates:1] firstObject];

--- a/Quicksilver/Configuration/Developer.xcconfig
+++ b/Quicksilver/Configuration/Developer.xcconfig
@@ -1,10 +1,10 @@
 // This file contains developer-specific information. You can provide temporary overrides to build settings here.
 
 // The bundle version displayed in the Finder's Get Info dialog and About Box
-QS_INFO_VERSION = 2.5.9
+QS_INFO_VERSION = 2.6.0
 
 // The current development version shown in About Box
-QS_BUNDLE_VERSION = 4053
+QS_BUNDLE_VERSION = 4054
 
 // A build of Quicksilver that breaks backwards compatibility for plugins. Setting a value here will mean that all future plugins built with `bltrversion` will have a minimum QS version requirement of this value
 QS_BACKWARDS_COMPATIBILITY_BREAK = 4001


### PR DESCRIPTION
Avoids overwhelming resources when many images are being scanned (previously, it would fire of an unlimited number of background threads equal to the number of images being scanned).

Changes:

> Replaced QSGCDAsync (global concurrent queue) with a dedicated DISPATCH_QUEUE_SERIAL queue at QOS_CLASS_UTILITY priority. This means image text recognition requests are processed one at a time on a low-priority background thread, instead of hundreds firing concurrently and starving the system.