### PR TITLE
Use APFS instead of HFS

### DIFF
--- a/Quicksilver/Tools/qssign
+++ b/Quicksilver/Tools/qssign
@@ -65,8 +65,6 @@ sign_and_notarize_qs() {
 
   cd ..
   hdiutil create \
-    -ov \
-    -fs HFS+ \
     -volname "Quicksilver" \
     -srcfolder "${DMG_TEMP}" \
     -format UDRW \
@@ -77,6 +75,7 @@ sign_and_notarize_qs() {
   SetFile -a C . "${MOUNT_DIR}"
 
   hdiutil detach "${MOUNT_DIR}"
+  # TODO: Once MRV >= 10.15 change to ULMO format for better compression ratio
   hdiutil convert \
     "${QS_VERSIONED_DMG}" \
     -format UDZO \


### PR DESCRIPTION
APFS is the modern standard and built-in since 10.13; QS currently requires 10.14 so this should be a harmless modernization.

Would be nice to use LZMA but that requires 10.15 so will drop a note reminding us to do that at some point.