### PR TITLE
Do not block startup on optional permissions

### DIFF
--- a/Quicksilver/Code-App/QSController.m
+++ b/Quicksilver/Code-App/QSController.m
@@ -822,8 +822,7 @@ static QSController *defaultController = nil;
 	return;
 #endif
 
-	MPAuthorizationStatus fullDisk = [MPPermissionsKit authorizationStatusForPermissionType:MPPermissionTypeFullDiskAccess];
-	if(![self hasAccessibilityPermission] || fullDisk != MPAuthorizationStatusAuthorized) {
+	if(![self hasAccessibilityPermission]) {
 		if (![accessibilityPermissionWindow isVisible]) {
 			[self showAccessibilityPrompt:nil];
 			return;
@@ -857,9 +856,9 @@ static QSController *defaultController = nil;
 		[calendarsButton setEnabled:!hasCalendars || !hasReminders];
 		[screenshotButton setEnabled:!hasScreenshot];
 
-		[closeAccessibilityWindowButton setEnabled:(hasAccessibility && hasFullDisk)];
+		[closeAccessibilityWindowButton setEnabled:hasAccessibility];
 		
-		if (hasAccessibility && hasFullDisk && hasCalendars && hasContacts && hasReminders && hasClickedScreenshotButton) {
+		if (hasAccessibility) {
 				[accessibilityPermissionWindow close];
 		} else if (!accessibilityChecker) {
 				accessibilityChecker = [NSTimer scheduledTimerWithTimeInterval:0.5 repeats:YES block:^(NSTimer * _Nonnull timer) {


### PR DESCRIPTION
This changes the startup permission gate so Quicksilver does not become unusable when optional permissions are unavailable or misreported by macOS.

On Tahoe/macOS 26, Quicksilver can repeatedly show the permissions window even after permissions appear granted in System Settings. In the current implementation, normal startup is blocked when either Accessibility or Full Disk Access is not authorised, and the permissions window only auto-closes when Accessibility, Full Disk Access, Contacts, Calendars, Reminders, and Screenshot state are all satisfied.

This patch keeps Accessibility as the essential launch-blocking permission, but avoids blocking startup on Full Disk Access and lets the permissions window close once Accessibility is available. Optional permissions can still be requested from the permissions UI or preferences, but they should not prevent the app from launching.

This does not attempt to fix the separate Primer/interface file-descriptor issue.
