### PR TITLE
Fix Bezel fallback after interface load failure

### DIFF
--- a/Quicksilver/Code-QuickStepCore/QSInterfaceMediator.m
+++ b/Quicksilver/Code-QuickStepCore/QSInterfaceMediator.m
@@ -23,7 +23,7 @@
 			[prefInstances setObject:mediator forKey:kQSCommandInterfaceControllers];
         } else {
             QSShowNotifierWithAttributes([NSDictionary dictionaryWithObjectsAndKeys:@"QSNotification", QSNotifierType, [QSResourceManager imageNamed:kQSBundleID], QSNotifierIcon, NSLocalizedString(@"Interface Changed", nil), QSNotifierTitle, NSLocalizedString(@"Interface could not be loaded. Switching to Bezel",nil),  QSNotifierText, nil]);
-            mediator = [self instanceForKey:@"QSBezelnterfaceController" inTable:kQSCommandInterfaceControllers];
+            mediator = [self instanceForKey:@"QSBezelInterfaceController" inTable:kQSCommandInterfaceControllers];
             [prefInstances setObject:mediator forKey:kQSCommandInterfaceControllers];
         }
 	}


### PR DESCRIPTION
Fixes a typo in the command-interface fallback path.

When the preferred command interface cannot be loaded, Quicksilver shows a notification saying it is switching to Bezel. The fallback code then asks the registry for `QSBezelnterfaceController`, which is missing the `I` in `Interface`.

That typo means the intended Bezel fallback can fail, leaving Quicksilver without a usable command interface after an interface/plugin load failure.

This changes the fallback key to `QSBezelInterfaceController`.

Context:
- This is relevant to recent macOS Tahoe reports where Quicksilver launches but has no usable interface, or shows “Interface could not be loaded. Switching to Bezel” and then remains crippled.
- This PR does not address file descriptor limits directly.
- This PR is separate from the optional-permissions startup gate PR.
